### PR TITLE
Issue 54 refactor

### DIFF
--- a/analysis/civic/examples/transform/civic_cdm.json
+++ b/analysis/civic/examples/transform/civic_cdm.json
@@ -1,0 +1,346 @@
+{
+    "statements": [
+        {
+            "id": "civic:eid879",
+            "description": "A phase III clinical trial (NCT00949650) found that median progression free survival among patients with exon 19 deletions or L858R EGFR mutations (n = 308) was 13.6 months for afatinib and 6.9 months for chemotherapy (HR, 0.47; 95% CI, 0.34 to 0.65; P = 0.001).",
+            "direction": "supports",
+            "evidence_level": "civic.evidence_level:B",
+            "proposition": "proposition:103",
+            "variation_origin": "somatic",
+            "variation_descriptor": "civic:vid33",
+            "therapy_descriptor": "civic:tid146",
+            "disease_descriptor": "civic:did30",
+            "method": "method:001",
+            "supported_by": [
+                "pmid:23816960"
+            ],
+            "type": "Statement"
+        },
+        {
+            "id": "civic:eid883",
+            "description": "In a phase 2 study of patients with lung adenocarcinoma (stage IIIb with pleural effusion or stage IV) and EGFR mutations, treated with afatinib were assessed by objective response. 129 patients were treated with afatinib. 66% of the 106 patients with two common activating EGFR mutations (deletion 19 or L858R) had an objective response compared to 39% of 23 patients with less common mutations.",
+            "direction": "supports",
+            "evidence_level": "civic.evidence_level:B",
+            "proposition": "proposition:103",
+            "variation_origin": "somatic",
+            "variation_descriptor": "civic:vid33",
+            "therapy_descriptor": "civic:tid146",
+            "disease_descriptor": "civic:did30",
+            "method": "method:001",
+            "supported_by": [
+                "pmid:22452895"
+            ],
+            "type": "Statement"
+        },
+        {
+            "id": "civic:eid968",
+            "description": "Cells harboring L858R were sensitive to afatinib. This study performed drug response assays using five human NSCLC cell lines with various combinations of EGFR mutations. In order to directly compare the sensitivity of multiple EGFR mutations to EGFR-TKIs the authors also generated multiple EGFR transduced Ba/F3 stable cell lines and evaluated sensitivity to EGFR-TKIs by MTS assay.",
+            "direction": "supports",
+            "evidence_level": "civic.evidence_level:D",
+            "proposition": "proposition:109",
+            "variation_origin": "somatic",
+            "variation_descriptor": "civic:vid33",
+            "therapy_descriptor": "civic:tid146",
+            "disease_descriptor": "civic:did8",
+            "method": "method:001",
+            "supported_by": [
+                "pmid:26515464"
+            ],
+            "type": "Statement"
+        },
+        {
+            "id": "civic:eid982",
+            "description": "Afatinib is an irreversible covalent inhibitor of EGFR (second generation). This Phase III clinical trial (LUX-Lung 6; NCT01121393) was performed in Asian patients with EGFR mutant advanced NSCLC. 364 eligible patients with EGFR mutations were assigned to afatinib (n=242) or gemcitabine and cisplatin (n=122) treatment. The trial observed significantly longer median progression-free survival with afatinib vs. gemcitabine and cisplatin treatment (11.0 vs. 5.6 months). Afatinib/Chemotherapy group compositions: 51.2/50.8 % del 19; 38/37.7 % Leu858Arg; 10.8/11.5 % Uncommon.",
+            "direction": "supports",
+            "evidence_level": "civic.evidence_level:B",
+            "proposition": "proposition:103",
+            "variation_origin": "somatic",
+            "variation_descriptor": "civic:vid33",
+            "therapy_descriptor": "civic:tid146",
+            "disease_descriptor": "civic:did30",
+            "method": "method:001",
+            "supported_by": [
+                "pmid:24439929"
+            ],
+            "type": "Statement"
+        },
+        {
+            "id": "civic:eid2629",
+            "description": "In an in vitro study using NCI-H1666 cells (wildtype EGFR) and NCI-H3255 cells (EGFR-L858R), inhibition of cell growth was used as an assay to determine sensitivity to irreversible tyrosine kinase inhibitor (TKI) drugs. Cells with an EGFR L858R mutation demonstrated an improved response to afatinib (IC50: 0.7nM vs. 60nM) compared to wildtype EGFR cells.",
+            "direction": "supports",
+            "evidence_level": "civic.evidence_level:D",
+            "proposition": "proposition:109",
+            "variation_origin": "somatic",
+            "variation_descriptor": "civic:vid33",
+            "therapy_descriptor": "civic:tid146",
+            "disease_descriptor": "civic:did8",
+            "method": "method:001",
+            "supported_by": [
+                "pmid:18408761"
+            ],
+            "type": "Statement"
+        },
+        {
+            "id": "civic:eid2997",
+            "description": "Afatinib, an irreversible inhibitor of the ErbB family of tyrosine kinases has been approved in the US for the first-line treatment of patients with metastatic non-small-cell lung cancer (NSCLC) who have tumours with EGFR exon 19 deletions or exon 21 (L858R) substitution mutations as detected by a US FDA-approved test",
+            "direction": "supports",
+            "evidence_level": "civic.evidence_level:A",
+            "proposition": "proposition:109",
+            "variation_origin": "somatic",
+            "variation_descriptor": "civic:vid33",
+            "therapy_descriptor": "civic:tid146",
+            "disease_descriptor": "civic:did8",
+            "method": "method:001",
+            "supported_by": [
+                "pmid:23982599"
+            ],
+            "type": "Statement"
+        },
+        {
+            "id": "civic:aid6",
+            "description": "L858R is among the most common sensitizing EGFR mutations in NSCLC, and is assessed via DNA mutational analysis, including Sanger sequencing and next generation sequencing methods. Tyrosine kinase inhibitor afatinib is FDA approved, and is recommended (category 1) by NCCN guidelines along with erlotinib, gefitinib and osimertinib as first line systemic therapy in NSCLC with sensitizing EGFR mutation.",
+            "direction": "supports",
+            "evidence_level": "amp_asco_cap_2017_level:1A",
+            "proposition": "proposition:109",
+            "variation_origin": "somatic",
+            "variation_descriptor": "civic:vid33",
+            "therapy_descriptor": "civic:tid146",
+            "disease_descriptor": "civic:did8",
+            "method": "method:002",
+            "supported_by": [
+                "document:001",
+                "civic:eid2997",
+                "civic:eid2629",
+                "civic:eid982",
+                "civic:eid968",
+                "civic:eid883",
+                "civic:eid879"
+            ],
+            "type": "Statement"
+        }
+    ],
+    "propositions": [
+        {
+            "id": "proposition:103",
+            "predicate": "predicts_sensitivity_to",
+            "subject": "ga4gh:VA.WyOqFMhc8aOnMFgdY0uM7nSLNqxVPAiR",
+            "object_qualifier": "ncit:C3512",
+            "object": "rxcui:1430438",
+            "type": "therapeutic_response_proposition"
+        },
+        {
+            "id": "proposition:109",
+            "predicate": "predicts_sensitivity_to",
+            "subject": "ga4gh:VA.WyOqFMhc8aOnMFgdY0uM7nSLNqxVPAiR",
+            "object_qualifier": "ncit:C2926",
+            "object": "rxcui:1430438",
+            "type": "therapeutic_response_proposition"
+        }
+    ],
+    "variation_descriptors": [
+        {
+            "id": "civic:vid33",
+            "type": "VariationDescriptor",
+            "label": "L858R",
+            "description": "EGFR L858R has long been recognized as a functionally significant mutation in cancer, and is one of the most prevalent single mutations in lung cancer. Best described in non-small cell lung cancer (NSCLC), the mutation seems to confer sensitivity to first and second generation TKI's like gefitinib and neratinib. NSCLC patients with this mutation treated with TKI's show increased overall and progression-free survival, as compared to chemotherapy alone. Third generation TKI's are currently in clinical trials that specifically focus on mutant forms of EGFR, a few of which have shown efficacy in treating patients that failed to respond to earlier generation TKI therapies.",
+            "value_id": "ga4gh:VA.WyOqFMhc8aOnMFgdY0uM7nSLNqxVPAiR",
+            "value": {
+                "location": {
+                    "interval": {
+                        "end": 858,
+                        "start": 857,
+                        "type": "SimpleInterval"
+                    },
+                    "sequence_id": "ga4gh:SQ.vyo55F6mA6n2LgN4cagcdRzOuh38V4mE",
+                    "type": "SequenceLocation"
+                },
+                "state": {
+                    "sequence": "R",
+                    "type": "SequenceState"
+                },
+                "type": "Allele"
+            },
+            "xrefs": [
+                "clinvar:376280",
+                "clinvar:16609",
+                "clinvar:376282",
+                "caid:CA126713",
+                "dbsnp:121434568"
+            ],
+            "alternate_labels": [
+                "LEU858ARG"
+            ],
+            "extensions": [
+                {
+                    "name": "civic_representative_coordinate",
+                    "value": {
+                        "chromosome": "7",
+                        "start": 55259515,
+                        "stop": 55259515,
+                        "reference_bases": "T",
+                        "variant_bases": "G",
+                        "representative_transcript": "ENST00000275493.2",
+                        "ensembl_version": 75,
+                        "reference_build": "GRCh37"
+                    },
+                    "type": "Extension"
+                },
+                {
+                    "name": "civic_actionability_score",
+                    "value": "375",
+                    "type": "Extension"
+                }
+            ],
+            "molecule_context": "protein",
+            "structural_type": "SO:0001060",
+            "expressions": [
+                {
+                    "syntax": "hgvs:genomic",
+                    "value": "NC_000007.13:g.55259515T>G",
+                    "type": "Expression"
+                },
+                {
+                    "syntax": "hgvs:transcript",
+                    "value": "NM_005228.4:c.2573T>G",
+                    "type": "Expression"
+                },
+                {
+                    "syntax": "hgvs:transcript",
+                    "value": "ENST00000275493.2:c.2573T>G",
+                    "type": "Expression"
+                },
+                {
+                    "syntax": "hgvs:protein",
+                    "value": "NP_005219.2:p.Leu858Arg",
+                    "type": "Expression"
+                }
+            ],
+            "ref_allele_seq": "L",
+            "gene_context": "civic:gid19"
+        }
+    ],
+    "gene_descriptors": [
+        {
+            "id": "civic:gid19",
+            "type": "GeneDescriptor",
+            "label": "EGFR",
+            "description": "EGFR is widely recognized for its importance in cancer. Amplification and mutations have been shown to be driving events in many cancer types. Its role in non-small cell lung cancer, glioblastoma and basal-like breast cancers has spurred many research and drug development efforts. Tyrosine kinase inhibitors have shown efficacy in EGFR amplfied tumors, most notably gefitinib and erlotinib. Mutations in EGFR have been shown to confer resistance to these drugs, particularly the variant T790M, which has been functionally characterized as a resistance marker for both of these drugs. The later generation TKI's have seen some success in treating these resistant cases, and targeted sequencing of the EGFR locus has become a common practice in treatment of non-small cell lung cancer. \nOverproduction of ligands is another possible mechanism of activation of EGFR. ERBB ligands include EGF, TGF-a, AREG, EPG, BTC, HB-EGF, EPR and NRG1-4 (for detailed information please refer to the respective ligand section).",
+            "value": {
+                "id": "hgnc:3236",
+                "type": "Gene"
+            },
+            "alternate_labels": [
+                "ERRP",
+                "EGFR",
+                "mENA",
+                "PIG61",
+                "NISBD2",
+                "HER1",
+                "ERBB1",
+                "ERBB"
+            ]
+        }
+    ],
+    "therapy_descriptors": [
+        {
+            "id": "civic:tid146",
+            "type": "TherapyDescriptor",
+            "label": "Afatinib",
+            "value": {
+                "id": "rxcui:1430438",
+                "type": "Drug"
+            },
+            "alternate_labels": [
+                "BIBW2992",
+                "BIBW 2992",
+                "(2e)-N-(4-(3-Chloro-4-Fluoroanilino)-7-(((3s)-Oxolan-3-yl)Oxy)Quinoxazolin-6-yl)-4-(Dimethylamino)But-2-Enamide"
+            ]
+        }
+    ],
+    "disease_descriptors": [
+        {
+            "id": "civic:did8",
+            "type": "DiseaseDescriptor",
+            "label": "Lung Non-small Cell Carcinoma",
+            "value": {
+                "id": "ncit:C2926",
+                "type": "Disease"
+            }
+        },
+        {
+            "id": "civic:did30",
+            "type": "DiseaseDescriptor",
+            "label": "Lung Adenocarcinoma",
+            "value": {
+                "id": "ncit:C3512",
+                "type": "Disease"
+            }
+        }
+    ],
+    "methods": [
+        {
+            "id": "method:001",
+            "label": "Standard operating procedure for curation and clinical interpretation of variants in cancer",
+            "url": "https://genomemedicine.biomedcentral.com/articles/10.1186/s13073-019-0687-x",
+            "version": {
+                "year": 2019,
+                "month": 11,
+                "day": 29
+            },
+            "authors": "Danos, A.M., Krysiak, K., Barnell, E.K. et al."
+        },
+        {
+            "id": "method:002",
+            "label": "Standards and Guidelines for the Interpretation and Reporting of Sequence Variants in Cancer: A Joint Consensus Recommendation of the Association for Molecular Pathology, American Society of Clinical Oncology, and College of American Pathologists",
+            "url": "https://pubmed.ncbi.nlm.nih.gov/27993330/",
+            "version": {
+                "year": 2017,
+                "month": 1
+            },
+            "authors": "Li MM, Datto M, Duncavage EJ, et al."
+        }
+    ],
+    "documents": [
+        {
+            "id": "pmid:23816960",
+            "label": "Sequist et al., 2013, J. Clin. Oncol.",
+            "description": "Phase III study of afatinib or cisplatin plus pemetrexed in patients with metastatic lung adenocarcinoma with EGFR mutations."
+        },
+        {
+            "id": "pmid:22452895",
+            "label": "Yang et al., 2012, Lancet Oncol.",
+            "description": "Afatinib for patients with lung adenocarcinoma and epidermal growth factor receptor mutations (LUX-Lung 2): a phase 2 trial."
+        },
+        {
+            "id": "pmid:26515464",
+            "label": "Hirano et al., 2015, Oncotarget",
+            "description": "In vitro modeling to determine mutation specificity of EGFR tyrosine kinase inhibitors against clinically relevant EGFR mutants in non-small-cell lung cancer.",
+            "xrefs": [
+                "pmc:PMC4770737"
+            ]
+        },
+        {
+            "id": "pmid:24439929",
+            "label": "Wu et al., 2014, Lancet Oncol.",
+            "description": "Afatinib versus cisplatin plus gemcitabine for first-line treatment of Asian patients with advanced non-small-cell lung cancer harbouring EGFR mutations (LUX-Lung 6): an open-label, randomised phase 3 trial."
+        },
+        {
+            "id": "pmid:18408761",
+            "label": "Li et al., 2008, Oncogene",
+            "description": "BIBW2992, an irreversible EGFR/HER2 inhibitor highly effective in preclinical lung cancer models.",
+            "xrefs": [
+                "pmc:PMC2748240"
+            ]
+        },
+        {
+            "id": "pmid:23982599",
+            "label": "Dungo et al., 2013, Drugs",
+            "description": "Afatinib: first global approval."
+        },
+        {
+            "id": "document:001",
+            "document_id": "https://www.nccn.org/professionals/physician_gls/default.aspx",
+            "label": "NCCN Guidelines: Non-Small Cell Lung Cancer version 3.2018"
+        }
+    ]
+}

--- a/analysis/civic/examples/transform/civic_transform_example.py
+++ b/analysis/civic/examples/transform/civic_transform_example.py
@@ -16,44 +16,59 @@ def create_civic_example(civic_data):
         'methods': [],
         'documents': []
     }
-    supported_by_statement_ids = list()
+    supported_by_statement_ids = set()
     for s in civic_data['statements']:
         if s['id'] == 'civic:aid6':
             supported_by_statement_ids = \
-                [s for s in s['supported_by'] if s.startswith('civic:eid')]
-            supported_by_statement_ids += s['id']
+                {s for s in s['supported_by'] if s.startswith('civic:eid')}
+            supported_by_statement_ids.add(s['id'])
             break
 
+    proposition_ids = set()
+    vids = set()
+    tids = set()
+    dids = set()
+    gids = set()
+    methods = set()
+    documents = set()
     for s in civic_data['statements']:
         if s['id'] in supported_by_statement_ids:
             ex['statements'].append(s)
+            proposition_ids.add(s['proposition'])
+            vids.add(s['variation_descriptor'])
+            tids.add(s['therapy_descriptor'])
+            dids.add(s['disease_descriptor'])
+            methods.add(s['method'])
+            documents.update({d for d in s['supported_by'] if
+                             not d.startswith('civic:eid')})
 
     for p in civic_data['propositions']:
-        if p['subject'] == 'ga4gh:VA.WyOqFMhc8aOnMFgdY0uM7nSLNqxVPAiR' and p['object_qualifier'] == 'ncit:C2926' and p['object'] == 'ncit:C66940':  # noqa: E501
+        if p['id'] in proposition_ids:
             ex['propositions'].append(p)
-            break
 
     for v in civic_data['variation_descriptors']:
-        if v['id'] == 'civic:vid33':
+        if v['id'] in vids:
             ex['variation_descriptors'].append(v)
-            break
+            gids.add(v['gene_context'])
 
     for t in civic_data['therapy_descriptors']:
-        if t['id'] == 'civic:tid146':
+        if t['id'] in tids:
             ex['therapy_descriptors'].append(t)
-            break
+
+    for d in civic_data['disease_descriptors']:
+        if d['id'] in dids:
+            ex['disease_descriptors'].append(d)
 
     for g in civic_data['gene_descriptors']:
-        if g['id'] == 'civic:gid19':
+        if g['id'] in gids:
             ex['gene_descriptors'].append(g)
-            break
 
     for m in civic_data['methods']:
-        if m['id'] in ['method:001', 'method:002']:
+        if m['id'] in methods:
             ex['methods'].append(m)
 
     for d in civic_data['documents']:
-        if d['id'] in ['pmid:23982599', 'document:001']:
+        if d['id'] in documents:
             ex['documents'].append(d)
 
     with open(f"{PROJECT_ROOT}/analysis/civic/examples/transform/"

--- a/analysis/civic/examples/transform/civic_transform_example.py
+++ b/analysis/civic/examples/transform/civic_transform_example.py
@@ -6,25 +6,65 @@ from metakb import PROJECT_ROOT
 
 def create_civic_example(civic_data):
     """Create CIViC transform examples from list of evidence items."""
-    evidence_items = ['civic:eid2997', 'civic:eid32']
-    assertions = ['civic:aid6']
-    for response in civic_data:
-        statements = response['statements']
-        for s in statements:
-            if s['id'] in evidence_items and len(statements) == 1:
-                with open(f"{PROJECT_ROOT}/analysis/civic/examples/transform/"
-                          f"{s['id']}.json", 'w+') as f1:
-                    json.dump(response, f1)
-            if s['id'] in assertions:
-                with open(f"{PROJECT_ROOT}/analysis/civic/examples/transform/"
-                          f"{s['id']}.json", 'w+') as f2:  # noqa: E501
-                    json.dump(response, f2)
+    ex = {
+        'statements': [],
+        'propositions': [],
+        'variation_descriptors': [],
+        'gene_descriptors': [],
+        'therapy_descriptors': [],
+        'disease_descriptors': [],
+        'methods': [],
+        'documents': []
+    }
+    supported_by_statement_ids = list()
+    for s in civic_data['statements']:
+        if s['id'] == 'civic:aid6':
+            supported_by_statement_ids = \
+                [s for s in s['supported_by'] if s.startswith('civic:eid')]
+            supported_by_statement_ids += s['id']
+            break
+
+    for s in civic_data['statements']:
+        if s['id'] in supported_by_statement_ids:
+            ex['statements'].append(s)
+
+    for p in civic_data['propositions']:
+        if p['subject'] == 'ga4gh:VA.WyOqFMhc8aOnMFgdY0uM7nSLNqxVPAiR' and p['object_qualifier'] == 'ncit:C2926' and p['object'] == 'ncit:C66940':  # noqa: E501
+            ex['propositions'].append(p)
+            break
+
+    for v in civic_data['variation_descriptors']:
+        if v['id'] == 'civic:vid33':
+            ex['variation_descriptors'].append(v)
+            break
+
+    for t in civic_data['therapy_descriptors']:
+        if t['id'] == 'civic:tid146':
+            ex['therapy_descriptors'].append(t)
+            break
+
+    for g in civic_data['gene_descriptors']:
+        if g['id'] == 'civic:gid19':
+            ex['gene_descriptors'].append(g)
+            break
+
+    for m in civic_data['methods']:
+        if m['id'] in ['method:001', 'method:002']:
+            ex['methods'].append(m)
+
+    for d in civic_data['documents']:
+        if d['id'] in ['pmid:23982599', 'document:001']:
+            ex['documents'].append(d)
+
+    with open(f"{PROJECT_ROOT}/analysis/civic/examples/transform/"
+              f"civic_cdm.json", 'w+') as f2:
+        json.dump(ex, f2)
 
 
 if __name__ == '__main__':
     civic = CIViCTransform()
-    transformation = civic.transform()
-    civic._create_json(transformation)
+    civic.transform()
+    civic._create_json()
     with open(f"{PROJECT_ROOT}/data/civic/transform/civic_cdm.json", 'r') as f:
         civic_data = json.load(f)
     create_civic_example(civic_data)

--- a/analysis/moa/examples/transform/moa:aid69.json
+++ b/analysis/moa/examples/transform/moa:aid69.json
@@ -8,7 +8,7 @@
             "variation_origin": "somatic",
             "variation_descriptor": "moa:vid69",
             "therapy_descriptor": "moa.normalize.therapy:Imatinib",
-            "disease_descriptor": "moa.normalize.disease:CML",
+            "disease_descriptor": "moa.normalize.disease:Chronic%20Myelogenous%20Leukemia",
             "method": "method:004",
             "supported_by": [
                 "pmid:11423618"
@@ -22,7 +22,7 @@
             "predicate": "predicts_resistance_to",
             "subject": "ga4gh:VA.wVNOLHSUDotkavwqtSiPW1aWxJln3VMG",
             "object_qualifier": "ncit:C3174",
-            "object": "ncit:C62035",
+            "object": "rxcui:282388",
             "type": "therapeutic_response_proposition"
         }
     ],
@@ -67,12 +67,12 @@
             "molecule_context": "protein",
             "structural_type": "SO:0001606",
             "ref_allele_seq": "T",
-            "gene_context": "gene.normalize.moa:ABL1"
+            "gene_context": "moa.normalize.gene:ABL1"
         }
     ],
     "gene_descriptors": [
         {
-            "id": "gene.normalize.moa:ABL1",
+            "id": "moa.normalize.gene:ABL1",
             "type": "GeneDescriptor",
             "label": "ABL1",
             "value": {
@@ -87,14 +87,14 @@
             "type": "TherapyDescriptor",
             "label": "Imatinib",
             "value": {
-                "id": "ncit:C62035",
+                "id": "rxcui:282388",
                 "type": "Drug"
             }
         }
     ],
     "disease_descriptors": [
         {
-            "id": "moa.normalize.disease:CML",
+            "id": "moa.normalize.disease:Chronic%20Myelogenous%20Leukemia",
             "type": "DiseaseDescriptor",
             "label": "Chronic Myelogenous Leukemia",
             "value": {

--- a/analysis/moa/examples/transform/moa_transform_example.py
+++ b/analysis/moa/examples/transform/moa_transform_example.py
@@ -6,18 +6,64 @@ from metakb import PROJECT_ROOT
 
 def create_moa_example(moa_data):
     """Create MOA transform examples from list of evidence items."""
-    evidence_items = 'moa:69'
-    for response in moa_data:
-        if response['statements'][0]['id'] == evidence_items:
-            with open(f"{PROJECT_ROOT}/analysis/moa/examples/transform/"
-                      f"{response['statements'][0]['id']}.json", 'w+') as f:
-                json.dump(response, f)
+    assertion_id = 'moa:aid69'
+    ex = {}
+    proposition = None
+    var_des = None
+    t_des = None
+    d_des = None
+    g_des = None
+    method = None
+    doc = None
+
+    for statement in moa_data['statements']:
+        if statement['id'] == assertion_id:
+            ex['statements'] = [statement]
+            proposition = statement['proposition']
+            var_des = statement['variation_descriptor']
+            t_des = statement['therapy_descriptor']
+            d_des = statement['disease_descriptor']
+            method = statement['method']
+            doc = statement['supported_by'][0]
+
+    for p in moa_data['propositions']:
+        if p['id'] == proposition:
+            ex['propositions'] = [p]
+
+    for v in moa_data['variation_descriptors']:
+        if v['id'] == var_des:
+            ex['variation_descriptors'] = [v]
+            g_des = v['gene_context']
+
+    for g in moa_data['gene_descriptors']:
+        if g['id'] == g_des:
+            ex['gene_descriptors'] = [g]
+
+    for t in moa_data['therapy_descriptors']:
+        if t['id'] == t_des:
+            ex['therapy_descriptors'] = [t]
+
+    for d in moa_data['disease_descriptors']:
+        if d['id'] == d_des:
+            ex['disease_descriptors'] = [d]
+
+    for m in moa_data['methods']:
+        if m['id'] == method:
+            ex['methods'] = [m]
+
+    for d in moa_data['documents']:
+        if d['id'] == doc:
+            ex['documents'] = [d]
+
+    with open(f"{PROJECT_ROOT}/analysis/moa/examples/transform/"
+              f"{ex['statements'][0]['id']}.json", 'w+') as f:
+        json.dump(ex, f)
 
 
 if __name__ == '__main__':
     moa = MOATransform()
-    transformation = moa.transform()
-    moa._create_json(transformation)
+    moa.transform()
+    moa._create_json()
     with open(f"{PROJECT_ROOT}/data/moa/transform/moa_cdm.json", 'r') as f:
         moa_data = json.load(f)
     create_moa_example(moa_data)

--- a/metakb/transform/moa.py
+++ b/metakb/transform/moa.py
@@ -54,7 +54,6 @@ class MOATransform:
         :param path moa_dir: The moa transform data directory
         :param str fn: The file name for the transformed data
         """
-        print(moa_dir)
         moa_dir.mkdir(exist_ok=True, parents=True)
 
         composite_dict = {

--- a/tests/unit/transform/test_civic_transform.py
+++ b/tests/unit/transform/test_civic_transform.py
@@ -11,422 +11,259 @@ def data():
     """Create a CIViC Transform test fixture."""
     c = CIViCTransform(file_path=f"{PROJECT_ROOT}/tests/data/"
                                  f"transform/civic_harvester.json")
-    transformations = c.transform()
-
-    fn = f"{PROJECT_ROOT}/tests/data/transform/civic_cdm.json"
-
-    with open(fn, 'w+') as f:
-        json.dump(transformations, f)
-
-    with open(fn, 'r') as f:
+    c.transform()
+    c._create_json(civic_dir=PROJECT_ROOT / 'tests' / 'data' / 'transform')
+    with open(f"{PROJECT_ROOT}/tests/data/transform/civic_cdm.json", 'r') as f:
         data = json.load(f)
     return data
 
 
 @pytest.fixture(scope='module')
-def eid2997():
-    """Create EID2997 test fixture."""
-    return {
-        "statements": [
-            {
-                "id": "civic:eid2997",
-                "description": "Afatinib, an irreversible inhibitor of the ErbB family of tyrosine kinases has been approved in the US for the first-line treatment of patients with metastatic non-small-cell lung cancer (NSCLC) who have tumours with EGFR exon 19 deletions or exon 21 (L858R) substitution mutations as detected by a US FDA-approved test",  # noqa: E501
-                "direction": "supports",
-                "evidence_level": "civic.evidence_level:A",
-                "proposition": "proposition:001",
-                "variation_origin": "somatic",
-                "variation_descriptor": "civic:vid33",
-                "therapy_descriptor": "civic:tid146",
-                "disease_descriptor": "civic:did8",
-                "method": "method:001",
-                "supported_by": ["pmid:23982599"],
-                "type": "Statement"
-            }
-        ],
-        "propositions": [
-            {
-                "id": "proposition:001",
-                "predicate": "predicts_sensitivity_to",
-                "subject": "ga4gh:VA.WyOqFMhc8aOnMFgdY0uM7nSLNqxVPAiR",
-                "object_qualifier": "ncit:C2926",
-                "object": "ncit:C66940",
-                "type": "therapeutic_response_proposition"
-            }
-        ],
-        "variation_descriptors": [
-            {
-                "id": "civic:vid33",
-                "type": "VariationDescriptor",
-                "label": "L858R",
-                "description": "EGFR L858R has long been recognized as a functionally significant mutation in cancer, and is one of the most prevalent single mutations in lung cancer. Best described in non-small cell lung cancer (NSCLC), the mutation seems to confer sensitivity to first and second generation TKI's like gefitinib and neratinib. NSCLC patients with this mutation treated with TKI's show increased overall and progression-free survival, as compared to chemotherapy alone. Third generation TKI's are currently in clinical trials that specifically focus on mutant forms of EGFR, a few of which have shown efficacy in treating patients that failed to respond to earlier generation TKI therapies.",  # noqa: E501
-                "value_id": "ga4gh:VA.WyOqFMhc8aOnMFgdY0uM7nSLNqxVPAiR",
-                "value": {
-                    "location": {
-                        "interval": {
-                            "end": 858,
-                            "start": 857,
-                            "type": "SimpleInterval"
-                        },
-                        "sequence_id": "ga4gh:SQ.vyo55F6mA6n2LgN4cagcdRzOuh38V4mE",  # noqa: E501
-                        "type": "SequenceLocation"
-                    },
-                    "state": {
-                        "sequence": "R",
-                        "type": "SequenceState"
-                    },
-                    "type": "Allele"
-                },
-                "xrefs": [
-                    "clinvar:376280",
-                    "clinvar:376282",
-                    "clinvar:16609",
-                    "caid:CA126713",
-                    "dbsnp:121434568"
-                ],
-                "alternate_labels": [
-                    "LEU858ARG"
-                ],
-                "extensions": [
-                    {
-                        "name": "civic_representative_coordinate",
-                        "value": {
-                            "chromosome": "7",
-                            "start": 55259515,
-                            "stop": 55259515,
-                            "reference_bases": "T",
-                            "variant_bases": "G",
-                            "representative_transcript": "ENST00000275493.2",
-                            "ensembl_version": 75,
-                            "reference_build": "GRCh37"
-                        },
-                        "type": "Extension"
-                    },
-                    {
-                        "name": "civic_actionability_score",
-                        "value": "352.5",
-                        "type": "Extension"
-                    }
-                ],
-                "molecule_context": "protein",
-                "structural_type": "SO:0001060",
-                "expressions": [
-                    {
-                        "syntax": "hgvs:protein",
-                        "value": "NP_005219.2:p.Leu858Arg",
-                        "type": "Expression"
-                    },
-                    {
-                        "syntax": "hgvs:transcript",
-                        "value": "ENST00000275493.2:c.2573T>G",
-                        "type": "Expression"
-                    },
-                    {
-                        "syntax": "hgvs:transcript",
-                        "value": "NM_005228.4:c.2573T>G",
-                        "type": "Expression"
-                    },
-                    {
-                        "syntax": "hgvs:genomic",
-                        "value": "NC_000007.13:g.55259515T>G",
-                        "type": "Expression"
-                    }
-                ],
-                "ref_allele_seq": "L",
-                "gene_context": "civic:gid19"
-            }
-        ],
-        "therapy_descriptors": [
-            {
-                "id": "civic:tid146",
-                "type": "TherapyDescriptor",
-                "label": "Afatinib",
-                "value": {
-                    "id": "ncit:C66940",
-                    "type": "Drug"
-                },
-                "alternate_labels": [
-                    "BIBW2992",
-                    "BIBW 2992",
-                    "(2e)-N-(4-(3-Chloro-4-Fluoroanilino)-7-(((3s)-Oxolan-3-yl)Oxy)Quinoxazolin-6-yl)-4-(Dimethylamino)But-2-Enamide"  # noqa: E501
-                ]
-            }
-        ],
-        "disease_descriptors": [
-            {
-                "id": "civic:did8",
-                "type": "DiseaseDescriptor",
-                "label": "Lung Non-small Cell Carcinoma",
-                "value": {
-                    "id": "ncit:C2926",
-                    "type": "Disease"
-                }
-            }
-        ],
-        "gene_descriptors": [
-            {
-                "id": "civic:gid19",
-                "type": "GeneDescriptor",
-                "label": "EGFR",
-                "description": "EGFR is widely recognized for its importance in cancer. Amplification and mutations have been shown to be driving events in many cancer types. Its role in non-small cell lung cancer, glioblastoma and basal-like breast cancers has spurred many research and drug development efforts. Tyrosine kinase inhibitors have shown efficacy in EGFR amplfied tumors, most notably gefitinib and erlotinib. Mutations in EGFR have been shown to confer resistance to these drugs, particularly the variant T790M, which has been functionally characterized as a resistance marker for both of these drugs. The later generation TKI's have seen some success in treating these resistant cases, and targeted sequencing of the EGFR locus has become a common practice in treatment of non-small cell lung cancer. \n"  # noqa:E501
-                               "Overproduction of ligands is another possible mechanism of activation of EGFR. ERBB ligands include EGF, TGF-a, AREG, EPG, BTC, HB-EGF, EPR and NRG1-4 (for detailed information please refer to the respective ligand section).",  # noqa: E501
-                "value": {
-                    "type": "Gene",
-                    "id": "hgnc:3236"
-                },
-                "alternate_labels": [
-                    "EGFR",
-                    "mENA",
-                    "PIG61",
-                    "ERBB1",
-                    "ERBB",
-                    "NISBD2",
-                    "HER1"
-                ]
-            }
-        ],
-        "methods": [
-            {
-                "id": "method:001",
-                "label": "Standard operating procedure for curation and clinical interpretation of variants in cancer",  # noqa: E501
-                "url": "https://genomemedicine.biomedcentral.com/articles/10.1186/s13073-019-0687-x",  # noqa: E501
-                "version": {
-                    "year": 2019,
-                    "month": 11,
-                    "day": 29
-                },
-                "authors": "Danos, A.M., Krysiak, K., Barnell, E.K. et al."
-            }
-        ],
-        "documents": [
-            {
-                "id": "pmid:23982599",
-                "label": "Dungo et al., 2013, Drugs",
-                "description": "Afatinib: first global approval."
-            }
-        ]
-    }
+def statements():
+    """Create test fixture for statements."""
+    return [
+        {
+            "id": "civic:eid2997",
+            "description": "Afatinib, an irreversible inhibitor of the ErbB family of tyrosine kinases has been approved in the US for the first-line treatment of patients with metastatic non-small-cell lung cancer (NSCLC) who have tumours with EGFR exon 19 deletions or exon 21 (L858R) substitution mutations as detected by a US FDA-approved test",  # noqa: E501
+            "direction": "supports",
+            "evidence_level": "civic.evidence_level:A",
+            "proposition": "proposition:001",
+            "variation_origin": "somatic",
+            "variation_descriptor": "civic:vid33",
+            "therapy_descriptor": "civic:tid146",
+            "disease_descriptor": "civic:did8",
+            "method": "method:001",
+            "supported_by": ["pmid:23982599"],
+            "type": "Statement"
+        },
+        {
+            "id": "civic:aid6",
+            "description": "L858R is among the most common sensitizing EGFR mutations in NSCLC, and is assessed via DNA mutational analysis, including Sanger sequencing and next generation sequencing methods. Tyrosine kinase inhibitor afatinib is FDA approved, and is recommended (category 1) by NCCN guidelines along with erlotinib, gefitinib and osimertinib as first line systemic therapy in NSCLC with sensitizing EGFR mutation.",  # noqa: E501
+            "direction": "supports",
+            "evidence_level": "amp_asco_cap_2017_level:1A",
+            "proposition": "proposition:001",
+            "variation_origin": "somatic",
+            "variation_descriptor": "civic:vid33",
+            "therapy_descriptor": "civic:tid146",
+            "disease_descriptor": "civic:did8",
+            "method": "method:002",
+            "supported_by": ["document:001", "civic:eid2997"],
+            "type": "Statement"
+        }
+    ]
 
 
 @pytest.fixture(scope='module')
-def aid6():
-    """Create AID6 test fixture."""
-    return {
-        "statements": [
-            {
-                "id": "civic:aid6",
-                "description": "L858R is among the most common sensitizing EGFR mutations in NSCLC, and is assessed via DNA mutational analysis, including Sanger sequencing and next generation sequencing methods. Tyrosine kinase inhibitor afatinib is FDA approved, and is recommended (category 1) by NCCN guidelines along with erlotinib, gefitinib and osimertinib as first line systemic therapy in NSCLC with sensitizing EGFR mutation.",  # noqa: E501
-                "direction": "supports",
-                "evidence_level": "amp_asco_cap_2017_level:1A",
-                "proposition": "proposition:001",
-                "variation_origin": "somatic",
-                "variation_descriptor": "civic:vid33",
-                "therapy_descriptor": "civic:tid146",
-                "disease_descriptor": "civic:did8",
-                "method": "method:002",
-                "supported_by": ["document:001", "civic:eid2997"],
-                "type": "Statement"
+def propositions():
+    """Create test fixture for proposition."""
+    return [
+        {
+            "id": "proposition:001",
+            "predicate": "predicts_sensitivity_to",
+            "subject": "ga4gh:VA.WyOqFMhc8aOnMFgdY0uM7nSLNqxVPAiR",
+            "object_qualifier": "ncit:C2926",
+            "object": "ncit:C66940",
+            "type": "therapeutic_response_proposition"
+        }
+    ]
+
+
+@pytest.fixture(scope='module')
+def variation_descriptors():
+    """Create test fixture for variants."""
+    return [
+        {
+            "id": "civic:vid33",
+            "type": "VariationDescriptor",
+            "label": "L858R",
+            "description": "EGFR L858R has long been recognized as a functionally significant mutation in cancer, and is one of the most prevalent single mutations in lung cancer. Best described in non-small cell lung cancer (NSCLC), the mutation seems to confer sensitivity to first and second generation TKI's like gefitinib and neratinib. NSCLC patients with this mutation treated with TKI's show increased overall and progression-free survival, as compared to chemotherapy alone. Third generation TKI's are currently in clinical trials that specifically focus on mutant forms of EGFR, a few of which have shown efficacy in treating patients that failed to respond to earlier generation TKI therapies.",  # noqa: E501
+            "value_id": "ga4gh:VA.WyOqFMhc8aOnMFgdY0uM7nSLNqxVPAiR",
+            "value": {
+                "location": {
+                    "interval": {
+                        "end": 858,
+                        "start": 857,
+                        "type": "SimpleInterval"
+                    },
+                    "sequence_id": "ga4gh:SQ.vyo55F6mA6n2LgN4cagcdRzOuh38V4mE",  # noqa: E501
+                    "type": "SequenceLocation"
+                },
+                "state": {
+                    "sequence": "R",
+                    "type": "SequenceState"
+                },
+                "type": "Allele"
             },
-            {
-                "id": "civic:eid2997",
-                "description": "Afatinib, an irreversible inhibitor of the ErbB family of tyrosine kinases has been approved in the US for the first-line treatment of patients with metastatic non-small-cell lung cancer (NSCLC) who have tumours with EGFR exon 19 deletions or exon 21 (L858R) substitution mutations as detected by a US FDA-approved test",  # noqa: E501
-                "direction": "supports",
-                "evidence_level": "civic.evidence_level:A",
-                "proposition": "proposition:001",
-                "variation_origin": "somatic",
-                "variation_descriptor": "civic:vid33",
-                "therapy_descriptor": "civic:tid146",
-                "disease_descriptor": "civic:did8",
-                "method": "method:001",
-                "supported_by": ["pmid:23982599"],
-                "type": "Statement"
-            }
-        ],
-        "propositions": [
-            {
-                "id": "proposition:001",
-                "predicate": "predicts_sensitivity_to",
-                "subject": "ga4gh:VA.WyOqFMhc8aOnMFgdY0uM7nSLNqxVPAiR",  # noqa: E501
-                "object_qualifier": "ncit:C2926",
-                "object": "ncit:C66940",
-                "type": "therapeutic_response_proposition"
-            }
-        ],
-        "variation_descriptors": [
-            {
-                "id": "civic:vid33",
-                "type": "VariationDescriptor",
-                "label": "L858R",
-                "description": "EGFR L858R has long been recognized as a functionally significant mutation in cancer, and is one of the most prevalent single mutations in lung cancer. Best described in non-small cell lung cancer (NSCLC), the mutation seems to confer sensitivity to first and second generation TKI's like gefitinib and neratinib. NSCLC patients with this mutation treated with TKI's show increased overall and progression-free survival, as compared to chemotherapy alone. Third generation TKI's are currently in clinical trials that specifically focus on mutant forms of EGFR, a few of which have shown efficacy in treating patients that failed to respond to earlier generation TKI therapies.",  # noqa: E501
-                "value_id": "ga4gh:VA.WyOqFMhc8aOnMFgdY0uM7nSLNqxVPAiR",
-                "value": {
-                    "location": {
-                        "interval": {
-                            "end": 858,
-                            "start": 857,
-                            "type": "SimpleInterval"
-                        },
-                        "sequence_id": "ga4gh:SQ.vyo55F6mA6n2LgN4cagcdRzOuh38V4mE",  # noqa: E501
-                        "type": "SequenceLocation"
+            "xrefs": [
+                "clinvar:376280",
+                "clinvar:376282",
+                "clinvar:16609",
+                "caid:CA126713",
+                "dbsnp:121434568"
+            ],
+            "alternate_labels": [
+                "LEU858ARG"
+            ],
+            "extensions": [
+                {
+                    "name": "civic_representative_coordinate",
+                    "value": {
+                        "chromosome": "7",
+                        "start": 55259515,
+                        "stop": 55259515,
+                        "reference_bases": "T",
+                        "variant_bases": "G",
+                        "representative_transcript": "ENST00000275493.2",
+                        "ensembl_version": 75,
+                        "reference_build": "GRCh37"
                     },
-                    "state": {
-                        "sequence": "R",
-                        "type": "SequenceState"
-                    },
-                    "type": "Allele"
+                    "type": "Extension"
                 },
-                "xrefs": [
-                    "clinvar:376280",
-                    "clinvar:376282",
-                    "clinvar:16609",
-                    "caid:CA126713",
-                    "dbsnp:121434568"
-                ],
-                "alternate_labels": [
-                    "LEU858ARG"
-                ],
-                "extensions": [
-                    {
-                        "name": "civic_representative_coordinate",
-                        "value": {
-                            "chromosome": "7",
-                            "start": 55259515,
-                            "stop": 55259515,
-                            "reference_bases": "T",
-                            "variant_bases": "G",
-                            "representative_transcript": "ENST00000275493.2",
-                            "ensembl_version": 75,
-                            "reference_build": "GRCh37"
-                        },
-                        "type": "Extension"
-                    },
-                    {
-                        "name": "civic_actionability_score",
-                        "value": "352.5",
-                        "type": "Extension"
-                    }
-                ],
-                "molecule_context": "protein",
-                "structural_type": "SO:0001060",
-                "expressions": [
-                    {
-                        "syntax": "hgvs:protein",
-                        "value": "NP_005219.2:p.Leu858Arg",
-                        "type": "Expression"
-                    },
-                    {
-                        "syntax": "hgvs:transcript",
-                        "value": "ENST00000275493.2:c.2573T>G",
-                        "type": "Expression"
-                    },
-                    {
-                        "syntax": "hgvs:transcript",
-                        "value": "NM_005228.4:c.2573T>G",
-                        "type": "Expression"
-                    },
-                    {
-                        "syntax": "hgvs:genomic",
-                        "value": "NC_000007.13:g.55259515T>G",
-                        "type": "Expression"
-                    }
-                ],
-                "ref_allele_seq": "L",
-                "gene_context": "civic:gid19"
-            }
-        ],
-        "therapy_descriptors": [
-            {
-                "id": "civic:tid146",
-                "type": "TherapyDescriptor",
-                "label": "Afatinib",
-                "value": {
-                    "id": "ncit:C66940",
-                    "type": "Drug"
-                },
-                "alternate_labels": [
-                    "BIBW2992",
-                    "BIBW 2992",
-                    "(2e)-N-(4-(3-Chloro-4-Fluoroanilino)-7-(((3s)-Oxolan-3-yl)Oxy)Quinoxazolin-6-yl)-4-(Dimethylamino)But-2-Enamide"  # noqa: E501
-                ]
-            }
-        ],
-        "disease_descriptors": [
-            {
-                "id": "civic:did8",
-                "type": "DiseaseDescriptor",
-                "label": "Lung Non-small Cell Carcinoma",
-                "value": {
-                    "id": "ncit:C2926",
-                    "type": "Disease"
+                {
+                    "name": "civic_actionability_score",
+                    "value": "352.5",
+                    "type": "Extension"
                 }
-            }
-        ],
-        "gene_descriptors": [
-            {
-                "id": "civic:gid19",
-                "type": "GeneDescriptor",
-                "label": "EGFR",
-                "description": "EGFR is widely recognized for its importance in cancer. Amplification and mutations have been shown to be driving events in many cancer types. Its role in non-small cell lung cancer, glioblastoma and basal-like breast cancers has spurred many research and drug development efforts. Tyrosine kinase inhibitors have shown efficacy in EGFR amplfied tumors, most notably gefitinib and erlotinib. Mutations in EGFR have been shown to confer resistance to these drugs, particularly the variant T790M, which has been functionally characterized as a resistance marker for both of these drugs. The later generation TKI's have seen some success in treating these resistant cases, and targeted sequencing of the EGFR locus has become a common practice in treatment of non-small cell lung cancer. \n"  # noqa:E501
-                               "Overproduction of ligands is another possible mechanism of activation of EGFR. ERBB ligands include EGF, TGF-a, AREG, EPG, BTC, HB-EGF, EPR and NRG1-4 (for detailed information please refer to the respective ligand section).",  # noqa: E501
-                "value": {
-                    "type": "Gene",
-                    "id": "hgnc:3236"
+            ],
+            "molecule_context": "protein",
+            "structural_type": "SO:0001060",
+            "expressions": [
+                {
+                    "syntax": "hgvs:protein",
+                    "value": "NP_005219.2:p.Leu858Arg",
+                    "type": "Expression"
                 },
-                "alternate_labels": [
-                    "EGFR",
-                    "mENA",
-                    "PIG61",
-                    "ERBB1",
-                    "ERBB",
-                    "NISBD2",
-                    "HER1"
-                ]
-            }
-        ],
-        "methods": [
-            {
-                "id": "method:001",
-                "label": "Standard operating procedure for curation and clinical interpretation of variants in cancer",  # noqa: E501
-                "url": "https://genomemedicine.biomedcentral.com/articles/10.1186/s13073-019-0687-x",  # noqa: E501
-                "version": {
-                    "year": 2019,
-                    "month": 11,
-                    "day": 29
+                {
+                    "syntax": "hgvs:transcript",
+                    "value": "ENST00000275493.2:c.2573T>G",
+                    "type": "Expression"
                 },
-                "authors": "Danos, A.M., Krysiak, K., Barnell, E.K. et al."
-            },
-            {
-                "id": "method:002",
-                "label": "Standards and Guidelines for the Interpretation and Reporting of Sequence Variants in Cancer: A Joint Consensus Recommendation of the Association for Molecular Pathology, American Society of Clinical Oncology, and College of American Pathologists",  # noqa: E501
-                "url": "https://pubmed.ncbi.nlm.nih.gov/27993330/",
-                "version": {
-                    "year": 2017,
-                    "month": 1
+                {
+                    "syntax": "hgvs:transcript",
+                    "value": "NM_005228.4:c.2573T>G",
+                    "type": "Expression"
                 },
-                "authors": "Li MM, Datto M, Duncavage EJ, et al."
-            }
-        ],
-        "documents": [
-            {
-                "id": "document:001",
-                "document_id": "https://www.nccn.org/professionals/"
-                               "physician_gls/default.aspx",
-                "label": "NCCN Guidelines: Non-Small Cell "
-                         "Lung Cancer version 3.2018"
-            },
-            {
-                "id": "pmid:23982599",
-                "label": "Dungo et al., 2013, Drugs",
-                "description": "Afatinib: first global approval."
-            }
-        ]
-    }
+                {
+                    "syntax": "hgvs:genomic",
+                    "value": "NC_000007.13:g.55259515T>G",
+                    "type": "Expression"
+                }
+            ],
+            "ref_allele_seq": "L",
+            "gene_context": "civic:gid19"
+        }
+    ]
 
 
-def assert_same_keys_list_items(actual, test):
-    """Assert that keys in a dict are same or items in list are same."""
-    assert len(list(test)) == len(list(actual))
-    for item in list(actual):
-        assert item in test
+@pytest.fixture(scope='module')
+def therapy_descriptors():
+    """Create test fixture for therapy descriptors."""
+    return [
+        {
+            "id": "civic:tid146",
+            "type": "TherapyDescriptor",
+            "label": "Afatinib",
+            "value": {
+                "id": "ncit:C66940",
+                "type": "Drug"
+            },
+            "alternate_labels": [
+                "BIBW2992",
+                "BIBW 2992",
+                "(2e)-N-(4-(3-Chloro-4-Fluoroanilino)-7-(((3s)-Oxolan-3-yl)Oxy)Quinoxazolin-6-yl)-4-(Dimethylamino)But-2-Enamide"  # noqa: E501
+            ]
+        }
+    ]
+
+
+@pytest.fixture(scope='module')
+def disease_descriptors():
+    """Create test fixture for disease descriptors."""
+    return [
+        {
+            "id": "civic:did8",
+            "type": "DiseaseDescriptor",
+            "label": "Lung Non-small Cell Carcinoma",
+            "value": {
+                "id": "ncit:C2926",
+                "type": "Disease"
+            }
+        }
+    ]
+
+
+@pytest.fixture(scope='module')
+def gene_descriptors():
+    """Create test fixture for gene descriptors."""
+    return [
+        {
+            "id": "civic:gid19",
+            "type": "GeneDescriptor",
+            "label": "EGFR",
+            "description": "EGFR is widely recognized for its importance in cancer. Amplification and mutations have been shown to be driving events in many cancer types. Its role in non-small cell lung cancer, glioblastoma and basal-like breast cancers has spurred many research and drug development efforts. Tyrosine kinase inhibitors have shown efficacy in EGFR amplfied tumors, most notably gefitinib and erlotinib. Mutations in EGFR have been shown to confer resistance to these drugs, particularly the variant T790M, which has been functionally characterized as a resistance marker for both of these drugs. The later generation TKI's have seen some success in treating these resistant cases, and targeted sequencing of the EGFR locus has become a common practice in treatment of non-small cell lung cancer. \n"  # noqa:E501
+                           "Overproduction of ligands is another possible mechanism of activation of EGFR. ERBB ligands include EGF, TGF-a, AREG, EPG, BTC, HB-EGF, EPR and NRG1-4 (for detailed information please refer to the respective ligand section).",  # noqa: E501
+            "value": {
+                "id": "hgnc:3236",
+                "type": "Gene"
+            },
+            "alternate_labels": [
+                "EGFR",
+                "mENA",
+                "PIG61",
+                "NISBD2",
+                "HER1",
+                "ERBB1",
+                "ERBB"
+            ]
+        }
+    ]
+
+
+@pytest.fixture(scope='module')
+def methods():
+    """Create test fixture for methods."""
+    return [
+        {
+            "id": "method:001",
+            "label": "Standard operating procedure for curation and clinical interpretation of variants in cancer",  # noqa: E501
+            "url": "https://genomemedicine.biomedcentral.com/articles/10.1186/s13073-019-0687-x",  # noqa: E501
+            "version": {
+                "year": 2019,
+                "month": 11,
+                "day": 29
+            },
+            "authors": "Danos, A.M., Krysiak, K., Barnell, E.K. et al."
+        },
+        {
+            "id": "method:002",
+            "label": "Standards and Guidelines for the Interpretation and Reporting of Sequence Variants in Cancer: A Joint Consensus Recommendation of the Association for Molecular Pathology, American Society of Clinical Oncology, and College of American Pathologists",  # noqa: E501
+            "url": "https://pubmed.ncbi.nlm.nih.gov/27993330/",
+            "version": {
+                "year": 2017,
+                "month": 1
+            },
+            "authors": "Li MM, Datto M, Duncavage EJ, et al."
+        }
+    ]
+
+
+@pytest.fixture(scope='module')
+def documents():
+    """Create test fixture for documents."""
+    return [
+        {
+            "id": "pmid:23982599",
+            "label": "Dungo et al., 2013, Drugs",
+            "description": "Afatinib: first global approval."
+        },
+        {
+            "id": "document:001",
+            "document_id": "https://www.nccn.org/professionals/"
+                           "physician_gls/default.aspx",
+            "label": "NCCN Guidelines: Non-Small Cell "
+                     "Lung Cancer version 3.2018"
+        }
+    ]
 
 
 def assert_non_lists(actual, test):
@@ -440,7 +277,6 @@ def assert_non_lists(actual, test):
 def assertions(test_data, actual_data):
     """Assert that test and actual data are the same."""
     if isinstance(actual_data, dict):
-        assert_same_keys_list_items(actual_data.keys(), test_data.keys())
         for key in actual_data.keys():
             if isinstance(actual_data[key], list):
                 try:
@@ -450,7 +286,6 @@ def assertions(test_data, actual_data):
             else:
                 assert_non_lists(actual_data[key], test_data[key])
     elif isinstance(actual_data, list):
-        assert_same_keys_list_items(actual_data, test_data)
         for item in actual_data:
             if isinstance(item, list):
                 assert set(test_data) == set(actual_data)
@@ -458,38 +293,17 @@ def assertions(test_data, actual_data):
                 assert_non_lists(actual_data, test_data)
 
 
-def test_eid2997(data, eid2997):
-    """Test that transform is correct for EID2997."""
-    eid2997_data = None
-    for item in data:
-        if item['statements'][0]['id'] == 'civic:eid2997':
-            eid2997_data = item
-            break
-
-    eid2997_data_keys = eid2997_data.keys()
-
-    for key in eid2997.keys():
-        assert key in eid2997_data_keys
-        assert len(eid2997_data[key]) == len(eid2997[key])
-        assertions(eid2997_data[key][0], eid2997[key][0])
-
-
-def test_aid6(data, aid6):
-    """Test that transform is correct for AID6."""
-    aid6_data = None
-    for item in data:
-        if item['statements'][0]['id'] == 'civic:aid6':
-            aid6_data = item
-            break
-
-    aid_data_keys = aid6_data.keys()
-
-    for key in aid6.keys():
-        assert key in aid_data_keys
-        assert len(aid6_data[key]) == len(aid6[key])
-        if key in ['statements', 'methods', 'documents']:
-            assert_same_keys_list_items(aid6[key], aid6_data[key])
-        else:
-            assertions(aid6_data[key][0], aid6[key][0])
+def test_civic_cdm(data, statements, propositions, variation_descriptors,
+                   gene_descriptors, therapy_descriptors, disease_descriptors,
+                   methods, documents):
+    """Test that civic transform works correctly."""
+    assertions(statements, data['statements'])
+    assertions(propositions, data['propositions'])
+    assertions(variation_descriptors, data['variation_descriptors'])
+    assertions(gene_descriptors, data['gene_descriptors'])
+    assertions(therapy_descriptors, data['therapy_descriptors'])
+    assertions(disease_descriptors, data['disease_descriptors'])
+    assertions(methods, data['methods'])
+    assertions(documents, data['documents'])
 
     os.remove(f"{PROJECT_ROOT}/tests/data/transform/civic_cdm.json")

--- a/tests/unit/transform/test_civic_transform.py
+++ b/tests/unit/transform/test_civic_transform.py
@@ -62,7 +62,7 @@ def propositions():
             "predicate": "predicts_sensitivity_to",
             "subject": "ga4gh:VA.WyOqFMhc8aOnMFgdY0uM7nSLNqxVPAiR",
             "object_qualifier": "ncit:C2926",
-            "object": "ncit:C66940",
+            "object": "rxcui:1430438",
             "type": "therapeutic_response_proposition"
         }
     ]
@@ -164,7 +164,7 @@ def therapy_descriptors():
             "type": "TherapyDescriptor",
             "label": "Afatinib",
             "value": {
-                "id": "ncit:C66940",
+                "id": "rxcui:1430438",
                 "type": "Drug"
             },
             "alternate_labels": [

--- a/tests/unit/transform/test_moa_transform.py
+++ b/tests/unit/transform/test_moa_transform.py
@@ -11,156 +11,182 @@ def data():
     """Create a MOA Transform test fixture."""
     moa = MOATransform(file_path=f"{PROJECT_ROOT}/tests/data/"
                                  f"transform/moa_harvester.json")
-    transformations = moa.transform()
-
-    fn = f"{PROJECT_ROOT}/tests/data/transform/moa_cdm.json"
-
-    with open(fn, 'w+') as f:
-        json.dump(transformations, f)
-
-    with open(fn, 'r') as f:
+    moa.transform()
+    moa._create_json(moa_dir=PROJECT_ROOT / 'tests' / 'data' / 'transform')
+    with open(f"{PROJECT_ROOT}/tests/data/transform/moa_cdm.json", 'r') as f:
         data = json.load(f)
     return data
 
 
 @pytest.fixture(scope='module')
-def asst69():
-    """Create assertion69 test fixture."""
-    return {
-        "statements": [
-            {
-                "id": "moa:69",
-                "description": "T315I mutant ABL1 in p210 BCR-ABL cells resulted in retained high levels of phosphotyrosine at increasing concentrations of inhibitor STI-571, whereas wildtype appropriately received inhibition.",  # noqa: E501
-                "evidence_level": "moa.evidence_level:Preclinical",
-                "proposition": "proposition:001",
-                "variation_origin": "somatic",
-                "variation_descriptor": "moa:vid69",
-                "therapy_descriptor": "moa.normalize.therapy:Imatinib",
-                "disease_descriptor": "moa.normalize.disease:CML",
-                "method": "method:004",
-                "supported_by": [
-                    "pmid:11423618"
-                ],
-                "type": "Statement"
-            }
-        ],
-        "propositions": [
-            {
-                "id": "proposition:001",
-                "predicate": "predicts_resistance_to",
-                "subject": "ga4gh:VA.wVNOLHSUDotkavwqtSiPW1aWxJln3VMG",
-                "object_qualifier": "ncit:C3174",
-                "object": "ncit:C62035",
-                "type": "therapeutic_response_proposition"
-            }
-        ],
-        "variation_descriptors": [
-            {
-                "id": "moa:vid69",
-                "type": "VariationDescriptor",
-                "label": "ABL1 p.T315I (Missense)",
-                "value_id": "ga4gh:VA.wVNOLHSUDotkavwqtSiPW1aWxJln3VMG",
-                "value": {
-                    "location": {
-                        "interval": {
-                            "end": 315,
-                            "start": 314,
-                            "type": "SimpleInterval"
-                        },
-                        "sequence_id": "ga4gh:SQ.dmFigTG-0fY6I54swb7PoDuxCeT6O3Wg",  # noqa: E501
-                        "type": "SequenceLocation"
-                    },
-                    "state": {
-                        "sequence": "I",
-                        "type": "SequenceState"
-                    },
-                    "type": "Allele"
-                },
-                "extensions": [
-                    {
-                        "name": "moa_representative_coordinate",
-                        "value": {
-                            "chromosome": "9",
-                            "start_position": "133747580.0",
-                            "end_position": "133747580.0",
-                            "reference_allele": "C",
-                            "alternate_allele": "T",
-                            "cdna_change": "c.944C>T",
-                            "protein_change": "p.T315I",
-                            "exon": "5.0"
-                        },
-                        "type": "Extension"
-                    }
-                ],
-                "molecule_context": "protein",
-                "structural_type": "SO:0001606",
-                "ref_allele_seq": "T",
-                "gene_context": "gene.normalize.moa:ABL1"
-            }
-        ],
-        "gene_descriptors": [
-            {
-                "id": "gene.normalize.moa:ABL1",
-                "type": "GeneDescriptor",
-                "label": "ABL1",
-                "value": {
-                    "id": "hgnc:76",
-                    "type": "Gene"
-                }
-            }
-        ],
-        "therapy_descriptors": [
-            {
-                "id": "moa.normalize.therapy:Imatinib",
-                "type": "TherapyDescriptor",
-                "label": "Imatinib",
-                "value": {
-                    "id": "ncit:C62035",
-                    "type": "Drug"
-                }
-            }
-        ],
-        "disease_descriptors": [
-            {
-                "id": "moa.normalize.disease:CML",
-                "type": "DiseaseDescriptor",
-                "label": "Chronic Myelogenous Leukemia",
-                "value": {
-                    "id": "ncit:C3174",
-                    "type": "Disease"
-                }
-            }
-        ],
-        "methods": [
-            {
-                "id": "method:004",
-                "label": "Clinical interpretation of integrative molecular profiles to guide precision cancer medicine",  # noqa: E501
-                "url": "https://www.biorxiv.org/content/10.1101/2020.09.22.308833v1",  # noqa: E501
-                "version": {
-                    "year": 2020,
-                    "month": 9,
-                    "day": 22
-                },
-                "authors": "Reardon, B., Moore, N.D., Moore, N. et al."
-            }
-        ],
-        "documents": [
-            {
-                "id": "pmid:11423618",
-                "label": "Gorre, Mercedes E., et al. \"Clinical resistance to STI-571 cancer therapy caused by BCR-ABL gene mutation or amplification.\" Science 293.5531 (2001): 876-880.",  # noqa: E501
-                "xrefs": [
-                    "doi:10.1126/science.1062538"
-                ]
-            }
-        ]
-    }
+def asst69_statements():
+    """Create assertion69 statements test fixture."""
+    return [
+        {
+            "id": "moa:aid69",
+            "description": "T315I mutant ABL1 in p210 BCR-ABL cells "
+                           "resulted in retained high levels of "
+                           "phosphotyrosine at increasing concentrations "
+                           "of inhibitor STI-571, whereas wildtype "
+                           "appropriately received inhibition.",
+            "evidence_level": "moa.evidence_level:Preclinical",
+            "proposition": "proposition:001",
+            "variation_origin": "somatic",
+            "variation_descriptor": "moa:vid69",
+            "therapy_descriptor": "moa.normalize.therapy:Imatinib",
+            "disease_descriptor": "moa.normalize.disease:Chronic%20Myelogenous%20Leukemia",  # noqa: E501
+            "method": "method:004",
+            "supported_by": [
+                "pmid:11423618"
+            ],
+            "type": "Statement"
+        }
+    ]
 
 
-def assert_same_keys_list_items(actual, test):
-    """Assert that keys in a dict are same or items in list are same."""
-    assert len(list(test)) == len(list(actual))
-    for item in list(actual):
-        assert item in test
+@pytest.fixture(scope='module')
+def asst69_propositions():
+    """Create assertion69 propositions test fixture."""
+    return [
+        {
+            "id": "proposition:001",
+            "predicate": "predicts_resistance_to",
+            "subject": "ga4gh:VA.wVNOLHSUDotkavwqtSiPW1aWxJln3VMG",
+            "object_qualifier": "ncit:C3174",
+            "object": "rxcui:282388",
+            "type": "therapeutic_response_proposition"
+        }
+    ]
+
+
+@pytest.fixture(scope='module')
+def asst69_variation_descriptors():
+    """Create assertion69 variation_descriptors test fixture."""
+    return [
+        {
+            "id": "moa:vid69",
+            "type": "VariationDescriptor",
+            "label": "ABL1 p.T315I (Missense)",
+            "value_id": "ga4gh:VA.wVNOLHSUDotkavwqtSiPW1aWxJln3VMG",
+            "value": {
+                "location": {
+                    "interval": {
+                        "end": 315,
+                        "start": 314,
+                        "type": "SimpleInterval"
+                    },
+                    "sequence_id": "ga4gh:SQ.dmFigTG-0fY6I54swb7PoDuxCeT6O3Wg",
+                    "type": "SequenceLocation"
+                },
+                "state": {
+                    "sequence": "I",
+                    "type": "SequenceState"
+                },
+                "type": "Allele"
+            },
+            "extensions": [
+                {
+                    "name": "moa_representative_coordinate",
+                    "value": {
+                        "chromosome": "9",
+                        "start_position": "133747580.0",
+                        "end_position": "133747580.0",
+                        "reference_allele": "C",
+                        "alternate_allele": "T",
+                        "cdna_change": "c.944C>T",
+                        "protein_change": "p.T315I",
+                        "exon": "5.0"
+                    },
+                    "type": "Extension"
+                }
+            ],
+            "molecule_context": "protein",
+            "structural_type": "SO:0001606",
+            "ref_allele_seq": "T",
+            "gene_context": "moa.normalize.gene:ABL1"
+        }
+    ]
+
+
+@pytest.fixture(scope='module')
+def asst69_gene_descriptors():
+    """Create assertion69 gene_descriptors test fixture."""
+    return [
+        {
+            "id": "moa.normalize.gene:ABL1",
+            "type": "GeneDescriptor",
+            "label": "ABL1",
+            "value": {
+                "id": "hgnc:76",
+                "type": "Gene"
+            }
+        }
+    ]
+
+
+@pytest.fixture(scope='module')
+def asst69_therapy_descriptors():
+    """Create assertion69 therapy_descriptors test fixture."""
+    return [
+        {
+            "id": "moa.normalize.therapy:Imatinib",
+            "type": "TherapyDescriptor",
+            "label": "Imatinib",
+            "value": {
+                "id": "rxcui:282388",
+                "type": "Drug"
+            }
+        }
+    ]
+
+
+@pytest.fixture(scope='module')
+def asst69_disease_descriptors():
+    """Create assertion69 disease_descriptors test fixture."""
+    return [
+        {
+            "id": "moa.normalize.disease:Chronic%20Myelogenous%20Leukemia",
+            "type": "DiseaseDescriptor",
+            "label": "Chronic Myelogenous Leukemia",
+            "value": {
+                "id": "ncit:C3174",
+                "type": "Disease"
+            }
+        }
+    ]
+
+
+@pytest.fixture(scope='module')
+def asst69_methods():
+    """Create assertion69 methods test fixture."""
+    return[
+        {
+            "id": "method:004",
+            "label": "Clinical interpretation of integrative molecular "
+                     "profiles to guide precision cancer medicine",
+            "url": "https://www.biorxiv.org/content/10.1101/2020.09.22.308833v1",  # noqa: E501
+            "version": {
+                "year": 2020,
+                "month": 9,
+                "day": 22
+            },
+            "authors": "Reardon, B., Moore, N.D., Moore, N. et al."
+        }
+    ]
+
+
+@pytest.fixture(scope='module')
+def asst69_documents():
+    """Create assertion69 documents test fixture."""
+    return[
+        {
+            "id": "pmid:11423618",
+            "label": "Gorre, Mercedes E., et al. \"Clinical resistance to STI-571 cancer therapy caused by BCR-ABL gene mutation or amplification.\" Science 293.5531 (2001): 876-880.",  # noqa: E501
+            "xrefs": [
+                "doi:10.1126/science.1062538"
+            ]
+        }
+    ]
 
 
 def assert_non_lists(actual, test):
@@ -174,7 +200,6 @@ def assert_non_lists(actual, test):
 def assertions(test_data, actual_data):
     """Assert that test and actual data are the same."""
     if isinstance(actual_data, dict):
-        assert_same_keys_list_items(test_data.keys(), actual_data.keys())
         for key in actual_data.keys():
             if isinstance(actual_data[key], list):
                 try:
@@ -183,22 +208,26 @@ def assertions(test_data, actual_data):
                     assertions(test_data[key], actual_data[key])
             else:
                 assert_non_lists(actual_data[key], test_data[key])
+    elif isinstance(actual_data, list):
+        for item in actual_data:
+            if isinstance(item, list):
+                assert set(test_data) == set(actual_data)
+            else:
+                assert_non_lists(actual_data, test_data)
 
 
-def test_asst69(data, asst69):
-    """Test that transform is correct for assertion69."""
-    asst69_data = None
-    for item in data:
-        if item['statements'][0]['id'] == "moa:69":
-            asst69_data = item
-            break
-
-    asst69_data_keys = asst69_data.keys()
-
-    for key in asst69.keys():
-        assert key in asst69_data_keys
-        assert len(asst69_data[key]) == len(asst69[key])
-        print(asst69_data[key][0], asst69[key][0])
-        assertions(asst69_data[key][0], asst69[key][0])
+def test_moa_cdm(data, asst69_statements, asst69_propositions,
+                 asst69_variation_descriptors, asst69_gene_descriptors,
+                 asst69_therapy_descriptors, asst69_disease_descriptors,
+                 asst69_methods, asst69_documents):
+    """Test that moa transform works correctly."""
+    assertions(asst69_statements, data['statements'])
+    assertions(asst69_propositions, data['propositions'])
+    assertions(asst69_variation_descriptors, data['variation_descriptors'])
+    assertions(asst69_gene_descriptors, data['gene_descriptors'])
+    assertions(asst69_therapy_descriptors, data['therapy_descriptors'])
+    assertions(asst69_disease_descriptors, data['disease_descriptors'])
+    assertions(asst69_methods, data['methods'])
+    assertions(asst69_documents, data['documents'])
 
     os.remove(f"{PROJECT_ROOT}/tests/data/transform/moa_cdm.json")


### PR DESCRIPTION
Changed the format to be similar as harvester, and changed the id selection from normalizer. Renamed some variable names to be consistent with what civic.py uses. 

Only disease_Descriptor used the highest_match checking method since that's the only case it has multiple queries to try. 
I'm updating the MOA API responses in issue-54