### PR TITLE
feat: add oncokb as a source (#170)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -137,3 +137,5 @@ dynamodb_local_latest/
 
 # Zip
 *.zip
+
+notebooks

--- a/README.md
+++ b/README.md
@@ -93,6 +93,20 @@ MetaKB relies on environment variables to set in order to work.
     export UTA_DB_URL=postgresql://uta_admin:password@localhost:5432/uta/uta_20210129
     ```
 
+  * `ONCOKB_API_TOKEN`
+    * Required to harvest OncoKB data. If you do not set this environment variable, you can set during the initialization of the OncoKBHarvester.
+    * Used to access OncoKB data via their REST API. See [here](https://www.oncokb.org/apiAccess) for more information on how to register an account and get an OncoKB API token.
+
+    Example for setting environment variable:
+    ```shell script
+    export ONCOKB_API_TOKEN={api_token}
+    ```
+
+    Example for setting during OncoKB Harvester initialization:
+    ```python
+    OncoKBHarvester(api_token={api_token})
+    ```
+
 * Required when using the `--load_normalizers_db` or `--force_load_normalizers_db` arguments in CLI commands
   * `RXNORM_API_KEY`
     * Used in Therapy Normalizer to retrieve RxNorm data
@@ -113,6 +127,20 @@ MetaKB relies on environment variables to set in order to work.
     ```shell script
     export DATAVERSE_API_KEY={dataverse_api_key}
     ```
+
+### Data files
+
+Some sources in MetaKB require user provided files to harvest data.
+
+* OncoKB
+  * In addition to setting the `ONCOKB_API_TOKEN` environment variable to harvest OncoKB data, you also need to provide a CSV file containing a header row with `hugo_symbol` and `protein_change`, associated rows containing protein variants you wish to harvest, and using a comma as the delimiter. The file will look something like:
+
+    ```csv
+    hugo_symbol,protein_change
+    BRAF,V600E
+    ...
+    ```
+  * This file will harvest OncoKB evidence based on the variants provided.
 
 ### Loading data
 

--- a/docs/cli/README.md
+++ b/docs/cli/README.md
@@ -27,4 +27,7 @@ More information on MetaKB CLI arguments
   * Load a source's transformed CDM file at specified path. This bypasses having to run the source harvest and transform steps. Exclusive with `--load_latest_cdms` and `--load_latest_s3_cdms`.
 
 * `--load_latest_s3_cdms`
-  * Deletes all nodes from the MetaKB Neo4j database, retrieves latest source transformed CDM files from public s3 bucket, and loads the Neo4j database with the retrieved data. This bypasses having to run the source harvest and transform steps Exclusive with `--load_latest_cdms` and `--load_target_cdms`.
+  * Deletes all nodes from the MetaKB Neo4j database, retrieves latest source transformed CDM files from public s3 bucket, and loads the Neo4j database with the retrieved data. This bypasses having to run the source harvest and transform steps. Exclusive with `--load_latest_cdms` and `--load_target_cdms`. Will not download OncoKB transformed data.
+
+* `--oncokb_variants_by_protein_change_path`
+  * Path to CSV file containing header row with `hugo_symbol` and `protein_change` and associated rows containing protein variants you wish to harvest using a comma as the delimiter. Not required if using `--load_latest_cdms`, `--load_target_cdm`, or `--load_latest_s3_cdms`"

--- a/metakb/cli.py
+++ b/metakb/cli.py
@@ -126,6 +126,7 @@ class CLI:
     )
     @click.option(
         "--oncokb_variants_by_protein_change_path",
+        "-k",
         required=False,
         type=click.Path(exists=True, dir_okay=False, readable=True, path_type=Path),
         help=("Path to CSV file containing header row with `hugo_symbol` and "

--- a/metakb/cli.py
+++ b/metakb/cli.py
@@ -28,8 +28,8 @@ from botocore.config import Config
 from metakb import APP_ROOT
 from metakb.database import Graph
 from metakb.schemas import SourceName
-from metakb.harvesters import Harvester, CIViCHarvester, MOAHarvester
-from metakb.transform import Transform, CIViCTransform, MOATransform
+from metakb.harvesters import Harvester, CIViCHarvester, MOAHarvester, OncoKBHarvester
+from metakb.transform import Transform, CIViCTransform, MOATransform, OncoKBTransform
 
 
 logger = logging.getLogger('metakb.cli')
@@ -112,7 +112,8 @@ class CLI:
         required=False,
         help=("Clear MetaKB database, retrieve most recent data available "
               "from VICC S3 bucket, and load the database with retrieved "
-              "data. Exclusive with --load_latest_cdms and load_target_cdm.")
+              "data. Will not download OncoKB transformed data. Exclusive with"
+              " --load_latest_cdms and load_target_cdm.")
     )
     @click.option(
         "--update_cached",
@@ -123,12 +124,21 @@ class CLI:
         help=("`True` if civicpy cache should be updated. Note this will take serveral"
               "minutes. `False` if local cache should be used")
     )
+    @click.option(
+        "--oncokb_variants_by_protein_change_path",
+        required=False,
+        type=click.Path(exists=True, dir_okay=False, readable=True, path_type=Path),
+        help=("Path to CSV file containing header row with `hugo_symbol` and "
+              "`protein_change` and associated rows containing protein variants you "
+              "wish to harvest using a comma as the delimiter. Not required if using "
+              "`--load_latest_cdms`, `--load_target_cdm`, or `--load_latest_s3_cdms`")
+    )
     async def update_metakb_db(
         db_url: str, db_username: str, db_password: str,
         load_normalizers_db: bool, force_load_normalizers_db: bool,
         normalizers_db_url: str, load_latest_cdms: bool,
         load_target_cdm: Optional[Path], load_latest_s3_cdms: bool,
-        update_cached: bool
+        update_cached: bool, oncokb_variants_by_protein_change_path: Optional[Path]
     ):
         """Execute data harvest and transformation from resources and upload
         to graph datastore.
@@ -151,7 +161,12 @@ class CLI:
             if load_normalizers_db or force_load_normalizers_db:
                 CLI()._load_normalizers_db(force_load_normalizers_db)
 
-            CLI()._harvest_sources(update_cached)
+            if not oncokb_variants_by_protein_change_path:
+                CLI()._help_msg(
+                    "Error: Must provide `--oncokb_variants_by_protein_change_path`")
+
+            CLI()._harvest_sources(update_cached,
+                                   oncokb_variants_by_protein_change_path)
             await CLI()._transform_sources()
 
         # Load neo4j database
@@ -178,6 +193,7 @@ class CLI:
                 except IndexError:
                     raise FileNotFoundError(f"No valid transform file found "
                                             f"matching pattern: {pattern}")
+                click.echo(f"\tLoading {src} CDM from path...: {path}")
                 g.load_from_json(path)
         g.close()
         end = timer()
@@ -235,23 +251,27 @@ class CLI:
         return newest_version
 
     @staticmethod
-    def _harvest_sources(update_cached) -> None:
+    def _harvest_sources(update_cached, oncokb_variants_by_protein_change_path) -> None:
         """Run harvesting procedure for all sources."""
         echo_info("Harvesting sources...")
         # TODO: Switch to using constant
         harvester_sources = {
-            'civic': CIViCHarvester,
-            'moa': MOAHarvester
+            SourceName.CIVIC.value: CIViCHarvester,
+            SourceName.MOA.value: MOAHarvester,
+            SourceName.ONCOKB.value: OncoKBHarvester
         }
         total_start = timer()
         for source_str, source_class in harvester_sources.items():
             echo_info(f"Harvesting {source_str}...")
             start = timer()
             source: Harvester = source_class()
-            if source_str == "civic" and update_cached:
+            if source_str == SourceName.CIVIC and update_cached:
                 # Use latest civic data
                 echo_info("(civicpy cache is also being updated)")
                 source_successful = source.harvest(update_cache=True)
+            elif source_str == SourceName.ONCOKB:
+                source_successful = source.harvest(
+                    oncokb_variants_by_protein_change_path)
             else:
                 source_successful = source.harvest()
             end = timer()
@@ -272,8 +292,9 @@ class CLI:
         echo_info("Transforming harvested data to CDM...")
         # TODO: Switch to using constant
         transform_sources = {
-            'civic': CIViCTransform,
-            'moa': MOATransform
+            SourceName.CIVIC.value: CIViCTransform,
+            SourceName.MOA.value: MOATransform,
+            SourceName.ONCOKB.value: OncoKBTransform
         }
         total_start = timer()
         for src_str, src_name in transform_sources.items():

--- a/metakb/harvesters/__init__.py
+++ b/metakb/harvesters/__init__.py
@@ -2,3 +2,4 @@
 from .base import Harvester
 from .civic import CIViCHarvester
 from .moa import MOAHarvester
+from .oncokb import OncoKBHarvester

--- a/metakb/harvesters/oncokb.py
+++ b/metakb/harvesters/oncokb.py
@@ -1,0 +1,173 @@
+"""Module for harvesting data from OncoKB"""
+import logging
+import csv
+from pathlib import Path
+from typing import Dict, List, Union, Optional
+from os import environ
+from enum import Enum
+
+import requests
+
+from metakb.harvesters.base import Harvester
+
+
+logger = logging.getLogger("metakb.harvesters.oncokb")
+logger.setLevel(logging.DEBUG)
+
+
+class OncoKBHarvesterException(Exception):
+    """OncoKB Harvester Exceptions"""
+
+    pass
+
+
+class OncoKBLevels(str, Enum):
+    """OncoKB levels of evidence names. https://www.oncokb.org/levels"""
+
+    PROGNOSTIC = "prognostic"
+    DIAGNOSTIC = "diagnostic"
+    RESISTANCE = "resistance"
+    SENSITIVE = "sensitive"
+
+
+class OncoKBHarvester(Harvester):
+    """Class for harvesting OncoKB data via REST API"""
+
+    api_url = "https://www.oncokb.org/api/v1"
+
+    def __init__(self, api_token: Optional[str] = None) -> None:
+        """Initialize the OncoKB Harvester class.
+
+        :param Optional[str] api_token: API Token to access OncoKB data via its REST
+            API. Can also set the api_token via environment variable `ONCOKB_API_TOKEN`.
+            See https://www.oncokb.org/apiAccess for more information
+        """
+        super().__init__()
+        self.api_token = api_token or environ.get("ONCOKB_API_TOKEN")
+        if not self.api_token:
+            raise OncoKBHarvesterException(
+                "Access to OncoKB data via REST API requires an api token. You can set "
+                "it during initialization (e.g., OncoKBHarvester(api_token={API_TOKEN})). "  # noqa: E501
+                "or by setting the `ONCOKB_API_TOKEN` environment variable. For getting"
+                " an API token, visit https://www.oncokb.org/apiAccess.")
+
+    def harvest(self, variants_by_protein_change_path: Path,
+                filename: Optional[str] = None) -> bool:
+        """Retrieve and store gene and variant and its associated evidence from
+        OncoKB in composite and individual JSON files.
+
+        :param Path variants_by_protein_change_path: Path to CSV file containing
+            header row with `hugo_symbol` and `protein_change` and associated rows
+            containing protein variants you wish to harvest using a comma as the
+            delimiter
+        :param Optional[str] filename: File name for composite JSON
+        :return: `True` if operation was successful, `False` otherwise.
+        :rtype: bool
+        """
+        harvest_successful = False
+        try:
+            self.fda_levels = {}
+            self.genes = self.harvest_genes()
+            self.variants = self.harvest_variants(variants_by_protein_change_path)
+            self.metadata = self.get_metadata()
+            self.diagnostic_levels = self._get_api_response(f"/levels/{OncoKBLevels.DIAGNOSTIC}")  # noqa: E501
+            self.prognostic_levels = self._get_api_response(f"/levels/{OncoKBLevels.PROGNOSTIC}")  # noqa: E501
+            self.resistance_levels = self._get_api_response(f"/levels/{OncoKBLevels.RESISTANCE}")  # noqa: E501
+            self.sensitive_levels = self._get_api_response(f"/levels/{OncoKBLevels.SENSITIVE}")  # noqa: E501
+
+            json_created = self.create_json(
+                {
+                    "genes": self.genes,
+                    "variants": self.variants,
+                    "levels": {
+                        "diagnostic": self.diagnostic_levels,
+                        "prognostic": self.prognostic_levels,
+                        "resistance": self.resistance_levels,
+                        "sensitive": self.sensitive_levels,
+                        "fda": self.fda_levels
+                    },
+                    "metadata": self.metadata
+                }, filename
+            )
+            if json_created:
+                harvest_successful = True
+            else:
+                logger.error("OncoKB Harvester was not successful")
+        except Exception as e:  # noqa: E722
+            logger.error(f"OncoKB Harvester was not successful: {e}")
+        return harvest_successful
+
+    def _get_api_response(self, endpoint: str) -> Optional[Union[Dict, List[Dict]]]:
+        """Get response from OncoKB endpoint
+
+        :param str endpoint: Endpoint you wish to query, containing query string
+            parameters if applicable.
+        :return: Response from querying OncoKB endpoint
+        """
+        resp = None
+        url = requests.utils.requote_uri(f"{self.api_url}{endpoint}")
+        r = requests.get(url, headers={"Authorization": f"Bearer {self.api_token}"})
+        if r.status_code == 200:
+            resp = r.json()
+        else:
+            logger.error(f"{url} returned status_code: {r.status_code}")
+        return resp
+
+    def get_metadata(self) -> Optional[Dict]:
+        """Get OncoKB metadata. Will update `fda_levels` instance variable.
+
+        :return: OncoKB API metadata if request is successful
+        """
+        metadata = self._get_api_response("/info") or None
+        if metadata:
+            for level in metadata["levels"]:
+                if "Fda" in level["levelOfEvidence"]:
+                    self.fda_levels[level["levelOfEvidence"]] = level["description"]
+            del metadata["levels"]
+        return metadata
+
+    def harvest_genes(self) -> List[Dict]:
+        """Harvest all curated genes in OncoKB
+
+        :return: Gene data from OncoKB if request is successful
+        """
+        return self._get_api_response("/utils/allCuratedGenes") or list()
+
+    def harvest_variants(self, variants_by_protein_change_path: Path) -> List[Dict]:
+        """Harvest variants and their associated evidence items from OncoKB. We
+        currently only pull from /annotate/mutations/byProteinChange endpoint.
+
+        :param Path variants_by_protein_change_path: Path to CSV file containing
+            header row with `hugo_symbol` and `protein_change` and associated rows
+            containing protein variants you wish to harvest using a comma as the
+            delimiter
+        :return: List of variants and their associated evidence items from OncoKB
+            if the request is successful
+        """
+        return self._harvest_protein_change_variants(variants_by_protein_change_path)
+
+    def _harvest_protein_change_variants(
+        self, variants_by_protein_change_path: Path
+    ) -> List[Dict]:
+        """Harvest protein change variants and their associated evidence items from
+        OncoKB.
+
+        :param Path variants_by_protein_change_path: Path to CSV file containing
+            header row with `hugo_symbol` and `protein_change` and associated rows
+            containing protein variants you wish to harvest using a comma as the
+            delimiter
+        :return: List of protein change variants and their associated evidence items
+            from OncoKB if the request is successful
+        """
+        variants = list()
+        with open(variants_by_protein_change_path, "r") as f:
+            reader = csv.reader(f)
+            next(reader)  # skip header
+            for row in reader:
+                symbol, p_change = row
+                endpoint = f"/annotate/mutations/byProteinChange?hugoSymbol={symbol}&"\
+                           f"alteration={p_change}&referenceGenome=GRCh38"
+                resp = self._get_api_response(endpoint)
+                if resp:
+                    variants.append(resp)
+        return variants

--- a/metakb/harvesters/oncokb.py
+++ b/metakb/harvesters/oncokb.py
@@ -163,8 +163,7 @@ class OncoKBHarvester(Harvester):
         with open(variants_by_protein_change_path, "r") as f:
             reader = csv.reader(f)
             next(reader)  # skip header
-            for row in reader:
-                symbol, p_change = row
+            for symbol, p_change in reader:
                 endpoint = f"/annotate/mutations/byProteinChange?hugoSymbol={symbol}&"\
                            f"alteration={p_change}&referenceGenome=GRCh38"
                 resp = self._get_api_response(endpoint)

--- a/metakb/schemas.py
+++ b/metakb/schemas.py
@@ -4,7 +4,7 @@ from typing import List, Optional, Union, Dict, Any, Type
 
 from ga4gh.vrsatile.pydantic.vrs_models import CURIE
 from ga4gh.vrsatile.pydantic.vrsatile_models import ValueObjectDescriptor, \
-    GeneDescriptor, VariationDescriptor
+    GeneDescriptor, VariationDescriptor, Extension
 from pydantic import BaseModel
 from pydantic.types import StrictBool
 
@@ -12,10 +12,11 @@ from metakb.version import __version__, LAST_UPDATED
 
 
 class SourceName(str, Enum):
-    """Resources we import directly."""
+    """Resources we import directly. Values are all lowercase."""
 
-    CIVIC = 'civic'
-    MOA = 'moa'
+    CIVIC = "civic"
+    MOA = "moa"
+    ONCOKB = "oncokb"
 
 
 class XrefSystem(str, Enum):
@@ -180,6 +181,7 @@ class MethodID(IntEnum):
     CIVIC_AID_AMP_ASCO_CAP = 2
     CIVIC_AID_ACMG = 3
     MOA_ASSERTION_BIORXIV = 4
+    ONCOKB_SOP = 5
 
 
 class Statement(BaseModel):
@@ -187,7 +189,7 @@ class Statement(BaseModel):
 
     id: CURIE
     type = 'Statement'
-    description: str
+    description: Optional[str]
     direction: Optional[Direction]
     evidence_level: CURIE
     proposition: CURIE
@@ -198,6 +200,7 @@ class Statement(BaseModel):
     method: CURIE
     supported_by: List[CURIE]
     # contribution: str  TODO: After metakb first pass
+    extensions: Optional[List[Extension]]
 
 
 class Document(BaseModel):
@@ -267,7 +270,7 @@ class StatementResponse(BaseModel):
 
     id: CURIE
     type = 'Statement'
-    description: str
+    description: Optional[str]
     direction: Optional[Direction]
     evidence_level: CURIE
     variation_origin: Optional[VariationOrigin]
@@ -277,6 +280,7 @@ class StatementResponse(BaseModel):
     disease_descriptor: CURIE
     method: CURIE
     supported_by: List[CURIE]
+    extensions: Optional[List[Extension]]
 
     class Config:
         """Configure examples."""
@@ -312,7 +316,7 @@ class NestedStatementResponse(BaseModel):
 
     id: CURIE
     type = 'Statement'
-    description: str
+    description: Optional[str]
     direction: Optional[Direction]
     evidence_level: CURIE
     variation_origin: Optional[VariationOrigin]
@@ -324,6 +328,7 @@ class NestedStatementResponse(BaseModel):
     disease_descriptor: ValueObjectDescriptor
     method: Method
     supported_by: List[Union[Document, CURIE]]
+    extensions: Optional[List[Extension]]
 
     class Config:
         """Configure examples."""

--- a/metakb/transform/__init__.py
+++ b/metakb/transform/__init__.py
@@ -2,3 +2,4 @@
 from .base import Transform  # noqa: F401
 from .civic import CIViCTransform  # noqa: F401
 from .moa import MOATransform  # noqa: F401
+from .oncokb import OncoKBTransform  # noqa: F401

--- a/metakb/transform/oncokb.py
+++ b/metakb/transform/oncokb.py
@@ -1,0 +1,484 @@
+"""A module for transforming OncoKB to common data model (CDM)"""
+from typing import Optional, Dict, List
+from pathlib import Path
+from urllib.parse import quote
+from copy import deepcopy
+import logging
+
+from ga4gh.vrsatile.pydantic.vrsatile_models import VariationDescriptor, \
+    Extension, GeneDescriptor, ValueObjectDescriptor
+
+from metakb import APP_ROOT
+from metakb.normalizers import VICCNormalizers
+from metakb.transform.base import Transform
+from metakb.schemas import Date, DiagnosticPredicate, Document, Method, MethodID, \
+    Predicate, PredictivePredicate, PropositionType, Statement
+
+
+logger = logging.getLogger("metakb.transform.oncokb")
+logger.setLevel(logging.DEBUG)
+
+
+# OncoKB gene fields (oncokb_label, ext_label)
+GENE_EXT_CONVERSIONS = [
+    ("grch37Isoform", "ensembl_transcript_GRCh37"),
+    ("grch37RefSeq", "refseq_transcript_GRCh37"),
+    ("grch38Isoform", "ensembl_transcript_GRCh38"),
+    ("grch38RefSeq", "refseq_transcript_GRCh38"),
+    ("oncogene", "oncogene"),
+    ("highestSensitiveLevel", "oncokb_highest_sensitive_level"),
+    ("highestResistanceLevel", "oncokb_highest_resistance_level"),
+    ("background", "oncokb_background"),
+    ("tsg", "tumor_suppressor_gene")
+]
+
+
+# OncoKB variation fields (oncokb_label, ext_label)
+VARIATION_EXT_CONVERSIONS = [
+    ("oncogenic", "oncogenic"),
+    ("mutationEffect", "mutation_effect"),
+    ("hotspot", "hotspot"),
+    ("vus", "vus"),
+    ("highestSensitiveLevel", "oncokb_highest_sensitive_level"),
+    ("highestResistanceLevel", "oncokb_highest_resistance_level"),
+    ("highestDiagnosticImplicationLevel", "oncokb_highest_diagnostic_implication_level"),  # noqa: E501
+    ("highestPrognosticImplicationLevel", "oncokb_highest_prognostic_implication_level"),  # noqa: E501
+    ("highestFdaLevel", "oncokb_highest_fda_level"),
+    ("alleleExist", "allele_exist")
+]
+
+
+# OncoKB disease fields (oncokb_label, ext_label)
+DISEASE_EXT_CONVERSIONS = [
+    ("mainType", "oncotree_main_type"),
+    ("tissue", "tissue"),
+    ("children", "children"),
+    ("parent", "parent"),
+    ("level", "level"),
+    ("tumorForm", "tumor_form")
+]
+
+
+class OncoKBTransform(Transform):
+    """A class for transforming OncoKB to the common data model."""
+
+    method = f"method:{MethodID.ONCOKB_SOP}"
+
+    def __init__(
+        self, data_dir: Path = APP_ROOT / "data", harvester_path: Optional[Path] = None,
+        normalizers: Optional[VICCNormalizers] = None
+    ) -> None:
+        """Initialize OncoKB Transform class.
+
+        :param Path data_dir: Path to source data directory
+        :param Optional[Path] harvester_path: Path to previously harvested data
+        :param VICCNormalizers normalizers: normalizer collection instance
+        """
+        super().__init__(data_dir, harvester_path, normalizers)
+        # Able to normalize these IDSs
+        self.valid_ids = {
+            "disease_descriptors": dict(),
+            "therapy_descriptors": dict()
+        }
+        # Unable to normalize these IDs
+        self.invalid_ids = {
+            "therapy_descriptors": set(),
+            "disease_descriptors": set()
+        }
+
+        self.methods = [
+            Method(id=f"method:{MethodID.ONCOKB_SOP}",
+                   label="OncoKB Curation Standard Operating Procedure",
+                   url="https://sop.oncokb.org/",
+                   version=Date(year=2021, month=11).dict(),
+                   authors="OncoKB").dict(exclude_none=True)
+        ]
+
+    async def transform(self) -> None:
+        """Transform OncoKB harvested JSON to common data model. Will update instance
+        variables (statements, propositions, variation_descriptors, gene_descriptors,
+        therapy_descriptors, disease_descriptors, documents) with transformed data from
+        OncoKB.
+        """
+        data = self.extract_harvester()
+        variants_data = data["variants"]
+        genes_data = data["genes"]
+        levels = data["levels"]
+
+        self.sensitive_levels = levels["sensitive"]
+        self.resistance_levels = levels["resistance"]
+        self.fda_levels = levels["fda"]
+
+        self._add_gene_descriptors(genes_data)
+        await self._transform_evidence(variants_data)
+
+    async def _transform_evidence(self, variants_data: List[Dict]) -> None:
+        """Transform OncoKB evidence to common data model. Will update instance
+        variables (statements, propositions, variation_descriptors, gene_descriptors,
+        therapy_descriptors, disease_descriptors, documents) with transformed data from
+        OncoKB.
+
+        :param List[Dict] variants_data: Variants data from OncoKB. Contains variant
+            and associated evidence data.
+        """
+        for data in variants_data:
+            # Exclude trying on variants we know we can't normalize
+            unable_to_normalize_variant = {
+                "fusion", "fusions", "mutation", "mutations", "tandem", "domain",
+                "splice", "deletion", "hypermethylation", "silencing", "overexpression",
+                "amplification"
+            }
+
+            alt = data["query"]["alteration"]
+            if set(alt.lower().split()) & unable_to_normalize_variant:
+                logger.debug(f"Variation Normalizer does not support: {alt}")
+                continue
+
+            variation_descriptor = await self._add_variation_descriptor(data)
+            if not variation_descriptor:
+                continue
+
+            # We skip prognostic evidence (prognosticImplications) since there is not
+            # enough information
+
+            for diagnostic_imp in data["diagnosticImplications"]:
+                # Diagnostic evidence is all inclusive
+                self._add_diagnostic_evidence(diagnostic_imp, variation_descriptor)
+
+            for treatment in data["treatments"]:
+                # Therapeutic evidence
+                # Only support where only one drug
+                if len(treatment["drugs"]) != 1:
+                    continue
+
+                self._add_therapeutic_evidence(treatment, variation_descriptor)
+
+    def _add_evidence(
+        self, evidence_data: Dict, proposition_type: PropositionType, level: str,
+        predicate: Predicate, disease_data: Dict, variation_descriptor: Dict,
+        extensions: Optional[List] = None, therapy_descriptor: Optional[Dict] = None
+    ) -> None:
+        """Add transformed oncokb evidence as statements
+        Will update instance variables (disease_descriptors, proposition, documents,
+        statements)
+
+        :param Dict evidence_data: OncoKB evidence data
+        :param PropositionType proposition_type: Proposition type of `evidence_data`
+        :param str level: OncoKB level of `evidence_data`
+        :param Predicate predicate: Predicate of `evidence_data`
+        :param Dict disease_data: Disease data for `evidence_data`
+        :param Dict variation_descriptor: Variation descriptor associated to
+            `evidence_data`
+        :param Optional[List] extensions: List of extensions for `evidence_data`
+        :param Optional[Dict] therapy_descriptor: Therapy descriptor associated to
+            `evidence_data`. Only for therapeutic evidence.
+        """
+        disease_descriptor = self._add_disease_descriptor(disease_data)
+        if not disease_descriptor:
+            return None
+
+        proposition = self._get_proposition(
+            proposition_type, predicate, variation_descriptor["variation_id"],
+            disease_descriptor["disease_id"],
+            therapy_descriptor["therapy_id"] if therapy_descriptor else None)
+        if proposition:
+            documents = self._get_documents(evidence_data["pmids"])
+            description = evidence_data["description"]
+
+            statement_params = {
+                "description": description if description else None,
+                "evidence_level": f"oncokb.evidence_level:{level}",
+                "proposition": proposition["id"],
+                "variation_descriptor": variation_descriptor["id"],
+                "disease_descriptor": disease_descriptor["id"],
+                "therapy_descriptor": therapy_descriptor["id"] if therapy_descriptor else None,  # noqa: E501
+                "method": self.methods[0]["id"],
+                "supported_by": [d["id"] for d in documents],
+                "extensions": extensions
+            }
+            digest = self._generate_digest(statement_params)
+            statement_params["id"] = f"oncokb.evidence:{digest}"
+            statement = Statement(
+                **statement_params).dict(by_alias=True, exclude_none=True)
+            self.statements.append(statement)
+
+    def _add_diagnostic_evidence(self, diagnostic_implication: Dict,
+                                 variation_descriptor: Dict) -> None:
+        """Transform OncoKB Diagnostic Evidence to common data model. Will update
+        instance variables (statements, propositions, variation_descriptors,
+        gene_descriptors, therapy_descriptors, disease_descriptors, documents) with
+        transformed data from OncoKB.
+
+        :param Dict diagnostic_implication: Diagnostic evidence
+        :param Dict variation_descriptor: Variation Descriptor associated to diagnostic
+            evidence
+        """
+        predicate = DiagnosticPredicate.POSITIVE
+        proposition_type = PropositionType.DIAGNOSTIC
+        level = diagnostic_implication["levelOfEvidence"]
+        disease_data = diagnostic_implication["tumorType"]
+        self._add_evidence(diagnostic_implication, proposition_type, level, predicate,
+                           disease_data, variation_descriptor)
+
+    def _add_therapeutic_evidence(self, treatment: Dict,
+                                  variation_descriptor: Dict) -> None:
+        """Transform OncoKB Therapeutic Evidence to common data model. Will update
+        instance variables (statements, propositions, variation_descriptors,
+        gene_descriptors, therapy_descriptors, disease_descriptors, documents) with
+        transformed data from OncoKB.
+
+        :param Dict treatment: Therapeutic evidence
+        :param Dict variation_descriptor: Variation Descriptor associated to therapeutic
+            evidence
+        """
+        level = treatment["level"]
+        proposition_type = PropositionType.PREDICTIVE
+        predicate = None
+        if level in self.sensitive_levels:
+            predicate = PredictivePredicate.SENSITIVITY
+        elif level in self.resistance_levels:
+            predicate = PredictivePredicate.RESISTANCE
+        else:
+            # This shouldn't happen, but adding a check just in case
+            logger.warning(f"Level {level} not in Sensitive or Resistance level")
+            return None
+
+        therapy_descriptor = self._add_therapy_descriptor(treatment["drugs"])
+        if not therapy_descriptor:
+            return None
+
+        disease_data = treatment["levelAssociatedCancerType"]
+
+        extensions = list()
+        fda_level = treatment["fdaLevel"]
+        if fda_level:
+            ext_value = {
+                "level": fda_level,
+                "description": self.fda_levels[fda_level]
+
+            }
+            extensions.append(Extension(name="onckb_fda_level", value=ext_value).dict())
+
+        self._add_evidence(treatment, proposition_type, level, predicate, disease_data,
+                           variation_descriptor, extensions, therapy_descriptor)
+
+    def _add_therapy_descriptor(self, drugs_data: List[Dict]) -> Optional[Dict]:
+        """Get therapy descriptor
+        The `therapy_descriptor` instance variable will be updated if therapy normalizer
+        was able to normalize the drug and if the drug does not already have a therapy
+        descriptor.
+
+        :param List[Dict] drugs_data: List of drugs. For now, `drugs_data` will always
+            have a length of one.
+        :return: Therapy descriptor represented as a dictionary if therapy normalizer
+            was able to normalize the drug
+        """
+        # Since we only support 1 therapeutic we can get the first element
+        drug = drugs_data[0]
+        uuid = drug["uuid"]
+        if uuid in self.valid_ids["therapy_descriptors"]:
+            therapy_descriptor = self.valid_ids["therapy_descriptors"][uuid]
+        else:
+            therapy_descriptor = None
+            if uuid not in self.invalid_ids["therapy_descriptors"]:
+                therapy_descriptor = self._get_therapy_descriptor(drugs_data)
+                if therapy_descriptor:
+                    self.valid_ids["therapy_descriptors"][uuid] = therapy_descriptor
+                    self.therapy_descriptors.append(therapy_descriptor)
+                else:
+                    self.invalid_ids["therapy_descriptors"].add(uuid)
+        return therapy_descriptor
+
+    def _get_therapy_descriptor(self, drugs_data: List[Dict]) -> Optional[Dict]:
+        """Get therapy descriptor for drug
+
+        :param List[Dict] drugs_data: List of drugs. For now, `drugs_data` will always
+            have a length of one.
+        :return: Therapy descriptor represented as a dictionary if therapy normalizer
+            was able to normalize the drug
+        """
+        # Since we only support 1 therapeutic we can get the first element
+        drug = drugs_data[0]
+        ncit_id = f"ncit:{drug['ncitCode']}"
+        label = drug["drugName"]
+
+        queries = [ncit_id, label]
+        therapy_norm_resp, normalized_therapy_id = \
+            self.vicc_normalizers.normalize_therapy(queries)
+        if not normalized_therapy_id:
+            logger.warning(f"Therapy Normalizer unable to normalize using queries: {queries}")  # noqa: E501
+            return None
+
+        regulatory_approval_extension = \
+            self.vicc_normalizers.get_regulatory_approval_extension(therapy_norm_resp)
+
+        return ValueObjectDescriptor(
+            type="TherapyDescriptor",
+            id=f"oncokb.normalize.therapy:{quote(label)}",
+            label=label,
+            therapy_id=normalized_therapy_id,
+            alternate_labels=drug["synonyms"] if drug["synonyms"] else None,
+            xrefs=[ncit_id],
+            extensions=[regulatory_approval_extension] if regulatory_approval_extension else None  # noqa: E501
+        ).dict(exclude_none=True)
+
+    def _add_disease_descriptor(self, disease_data: Dict) -> Optional[Dict]:
+        """Get disease descriptor
+        The `disease_descriptor` instance variable will be updated if disease normalizer
+        was able to normalize the disease and if the disease does not already have a
+        disease descriptor.
+
+        :param Dict disease_data: Disease data
+        :return: Disease descriptor represented as a dictionary if disease normalizer
+            was able to normalize the disease
+        """
+        disease_id = str(disease_data["id"])
+        if disease_id in self.valid_ids["disease_descriptors"]:
+            disease_descriptor = self.valid_ids["disease_descriptors"][disease_id]
+        else:
+            disease_descriptor = None
+            if disease_id not in self.invalid_ids["disease_descriptors"]:
+                disease_descriptor = self._get_disease_descriptor(disease_data)
+                if disease_descriptor:
+                    self.valid_ids["disease_descriptors"][disease_id] = \
+                        disease_descriptor
+                    self.disease_descriptors.append(disease_descriptor)
+                else:
+                    self.invalid_ids["disease_descriptors"].add(disease_id)
+        return disease_descriptor
+
+    def _get_disease_descriptor(self, disease_data: Dict) -> Optional[Dict]:
+        """Get disease descriptor for disease
+
+        :param Dict disease_data: Disease data
+        :return: Disease descriptor represented as a dictionary if disease normalizer
+            was able to normalize the disease
+        """
+        oncokb_disease_id = f"oncokb.disease:{disease_data['id']}"
+        oncotree_code = f"oncotree:{disease_data['code']}"
+        label = disease_data["name"]
+        queries = [oncotree_code, label]
+        _, normalized_disease_id = self.vicc_normalizers.normalize_disease(queries)
+        if not normalized_disease_id:
+            logger.warning(f"Disease Normalizer unable to normalize: "
+                           f"{oncokb_disease_id} using queries {queries}")
+            return None
+
+        extensions = list()
+        for key, ext_label in DISEASE_EXT_CONVERSIONS:
+            if disease_data[key] or disease_data[key] is False:
+                if key == "mainType":
+                    value = deepcopy(disease_data[key])
+                    value["tumor_form"] = value.pop("tumorForm")
+                else:
+                    value = disease_data[key]
+                extensions.append(Extension(name=ext_label, value=value))
+
+        disease_descriptor = ValueObjectDescriptor(
+            id=oncokb_disease_id,
+            type="DiseaseDescriptor",
+            label=label,
+            disease_id=normalized_disease_id,
+            xrefs=[oncotree_code],
+            extensions=extensions if extensions else None
+        ).dict(exclude_none=True)
+        return disease_descriptor
+
+    def _add_gene_descriptors(self, genes: List[Dict]) -> None:
+        """Add gene descriptors represented as a dict to the `gene_descriptors` instance
+            variable
+
+        :param List[Dict] genes: List of genes in OncoKB
+        """
+        for gene in genes:
+            gene_queries = list()
+            xrefs = list()
+
+            entrez_id = gene["entrezGeneId"]
+            if entrez_id:
+                entrez_id = f"ncbigene:{entrez_id}"
+                gene_queries.append(entrez_id)
+                xrefs.append(entrez_id)
+
+            symbol = gene["hugoSymbol"]
+            if symbol:
+                gene_queries.append(symbol)
+
+            _, normalized_gene_id = self.vicc_normalizers.normalize_gene(gene_queries)
+            if normalized_gene_id:
+                extensions = list()
+
+                for key, ext_label in GENE_EXT_CONVERSIONS:
+                    if gene[key] or gene[key] is False:
+                        extensions.append(Extension(name=ext_label, value=gene[key]))
+
+                gene_descriptor = GeneDescriptor(
+                    id=f"oncokb.normalize.gene:{symbol}",
+                    label=symbol,
+                    gene_id=normalized_gene_id,
+                    description=gene["summary"] if gene["summary"] else None,
+                    extensions=extensions if extensions else None,
+                    xrefs=xrefs if xrefs else None
+                ).dict(exclude_none=True)
+                self.gene_descriptors.append(gene_descriptor)
+            else:
+                logger.warning(f"Gene Normalizer unable to normalize: {gene_queries}")
+
+    async def _add_variation_descriptor(self, data: Dict) -> Optional[Dict]:
+        """Get variation descriptor
+        The `variation_descriptors` instance variable will be updated if variation
+        normalize was able to normalize the variant.
+
+        :param Dict data: OncoKB data
+        :return: Variation Descriptor represented as a dictionary if variation
+            normalizer was able to normalize the variant
+        """
+        query = data["query"]
+        gene = query["hugoSymbol"]
+        alteration = query["alteration"]
+        if not all((gene, alteration)):
+            return None
+
+        variant = f"{gene} {alteration}"
+        variation_descriptor = await self.vicc_normalizers.normalize_variation(
+            [variant])
+
+        if not variation_descriptor:
+            logger.warning(f"Variation Normalizer unable to normalize: {variant}")
+            return None
+
+        extensions = list()
+        for key, ext_label in VARIATION_EXT_CONVERSIONS:
+            if data[key] or data[key] is False:
+                extensions.append(Extension(name=ext_label, value=data[key]).dict())
+
+        vd = VariationDescriptor(
+            id=f"oncokb.variant:{quote(variant)}",
+            label=variant,
+            description=data["variantSummary"] if data["variantSummary"] else None,
+            variation_id=variation_descriptor.variation_id,
+            variation=variation_descriptor.variation,
+            gene_context=f"oncokb.normalize.gene:{query['hugoSymbol']}",
+            extensions=extensions if extensions else None
+        ).dict(by_alias=True, exclude_none=True)
+        self.variation_descriptors.append(vd)
+        return vd
+
+    def _get_documents(self, pmids: List[str]) -> List[dict]:
+        """Get documents from PMIDs.
+
+        :param List[str] pmids: List of PubMed IDs
+        :return: List of documents represented as dictionaries
+        """
+        documents = list()
+        for pmid in pmids:
+            document = Document(
+                id=f"pmid:{pmid}",
+                label=f"PubMed {pmid}"
+            ).dict(exclude_none=True)
+            documents.append(document)
+            if document not in self.documents:
+                self.documents.append(document)
+
+        # TODO: Do abstracts in issue-204
+        return documents

--- a/metakb/version.py
+++ b/metakb/version.py
@@ -1,4 +1,4 @@
 """MetaKB version"""
 # REQ: EACH TIME VERSION IS UPDATED, MUST ALSO UPDATE LAST_UPDATED
-__version__ = "1.1.0"
-LAST_UPDATED = "2022-11-08"
+__version__ = "1.1.1"
+LAST_UPDATED = "2022-12-12"

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -7,43 +7,47 @@ argcomplete==2.0.0 ; python_version >= '3.6'
 argh==0.26.2
 argon2-cffi==21.3.0 ; python_version >= '3.6'
 argon2-cffi-bindings==21.2.0 ; python_version >= '3.6'
-asttokens==2.1.0
+asttokens==2.2.1
 asyncclick==8.1.3.4
 asyncpg==0.27.0 ; python_full_version >= '3.7.0'
 attrs==22.1.0 ; python_version >= '3.5'
 babel==2.11.0 ; python_version >= '3.6'
 backcall==0.2.0
-backoff==2.1.2 ; python_version >= '3.7' and python_version < '4.0'
-backports-datetime-fromisoformat==1.0.0
+backoff==2.2.1 ; python_version >= '3.7' and python_version < '4.0'
+backports-datetime-fromisoformat==2.0.0
 beautifulsoup4==4.11.1 ; python_full_version >= '3.6.0'
 biocommons.seqrepo==0.6.5
-bioregistry[align]==0.6.8 ; python_version >= '3.7'
+bioregistry[align]==0.6.37 ; python_version >= '3.7'
 bioutils==0.5.7 ; python_version >= '3.6'
 bioversions==0.5.79
 bleach==5.0.1 ; python_version >= '3.7'
-boto3==1.26.4
-botocore==1.29.4
+boto3==1.26.26
+botocore==1.29.26
 bs4==0.0.1
-cachier==1.5.4
+cachetools==5.2.0 ; python_version ~= '3.7'
+cachier==2.0.0
 canonicaljson==1.6.4 ; python_version >= '3.7'
 cattrs==22.2.0 ; python_version >= '3.7'
-certifi==2022.9.24 ; python_version >= '3.6'
+certifi==2022.12.7 ; python_version >= '3.6'
 cffi==1.15.1
 cfgv==3.3.1 ; python_full_version >= '3.6.1'
+chardet==5.1.0 ; python_version >= '3.7'
 charset-normalizer==2.1.1 ; python_full_version >= '3.6.0'
-chembl-downloader==0.4.0
+chembl-downloader==0.4.2
 civicpy==2.0.0
 class-resolver==0.3.10
 click==8.1.3
 click-default-group==1.2.2
+colorama==0.4.6 ; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4, 3.5, 3.6'
 coloredlogs==15.0.1 ; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'
+comm==0.1.2 ; python_version >= '3.6'
 configparser==5.3.0 ; python_version >= '3.7'
 coverage==6.5.0
 coveralls==3.3.1
 cssselect==1.2.0 ; python_version >= '3.7'
 curies==0.4.0 ; python_version >= '3.7'
 dataclasses-json==0.5.7 ; python_version >= '3.6'
-debugpy==1.6.3 ; python_version >= '3.7'
+debugpy==1.6.4 ; python_version >= '3.7'
 decorator==5.1.1 ; python_version >= '3.5'
 defusedxml==0.7.1
 deprecation==2.1.0
@@ -51,79 +55,81 @@ disease-normalizer[dev]==0.2.15
 distlib==0.3.6
 docopt==0.6.2
 entrypoints==0.4 ; python_version >= '3.6'
-exceptiongroup==1.0.1 ; python_version < '3.11'
+exceptiongroup==1.0.4 ; python_version < '3.11'
 executing==1.2.0
-fake-useragent==0.1.14
-fastapi==0.86.0
+fake-useragent==1.1.1
+fastapi==0.88.0
 fastjsonschema==2.16.2
-filelock==3.8.0 ; python_version >= '3.7'
-flake8==5.0.4
+filelock==3.8.2 ; python_version >= '3.7'
+flake8==6.0.0
 flake8-annotations==2.9.1
 flake8-docstrings==1.6.0
-flake8-import-order==0.18.1
+flake8-import-order==0.18.2
 flake8-quotes==3.3.1
 ga4gh.vrs==0.8.0dev0
 ga4gh.vrsatile.pydantic==0.0.11
 gene-normalizer[dev]==0.1.30
 gffutils==0.11.1
 h11==0.14.0 ; python_version >= '3.7'
-hgvs==1.5.2
+hgvs==1.5.4
 humanfriendly==10.0 ; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'
-identify==2.5.8 ; python_version >= '3.7'
+identify==2.5.9 ; python_version >= '3.7'
 idna==3.4 ; python_version >= '3.5'
-importlib-metadata==5.0.0 ; python_version >= '3.7'
+importlib-metadata==5.1.0 ; python_version >= '3.7'
 inflection==0.5.1 ; python_version >= '3.5'
 iniconfig==1.1.1
-ipykernel==6.17.0
-ipython==8.6.0 ; python_version >= '3.8'
+ipykernel==6.19.2
+ipython==8.7.0 ; python_version >= '3.8'
 ipython-genutils==0.2.0
-ipywidgets==8.0.2 ; python_version >= '3.7'
+ipywidgets==8.0.3 ; python_version >= '3.7'
 isodate==0.6.1
-jedi==0.18.1 ; python_version >= '3.6'
+jedi==0.18.2 ; python_version >= '3.6'
 jinja2==3.1.2 ; python_version >= '3.7'
 jmespath==1.0.1 ; python_version >= '3.7'
 json5==0.9.10
 jsondiff==2.0.0
 jsonschema==3.2.0
 jupyter==1.0.0
-jupyter-client==7.4.4 ; python_version >= '3.7'
+jupyter-client==7.4.8 ; python_version >= '3.7'
 jupyter-console==6.4.4 ; python_version >= '3.7'
-jupyter-core==4.11.2 ; python_version >= '3.7'
-jupyter-server==1.23.0 ; python_version >= '3.7'
-jupyterlab==3.5.0
+jupyter-core==5.1.0 ; python_version >= '3.8'
+jupyter-events==0.4.0 ; python_version >= '3.7'
+jupyter-server==2.0.1 ; python_version >= '3.8'
+jupyter-server-terminals==0.4.2 ; python_version >= '3.8'
+jupyterlab==3.5.1
 jupyterlab-pygments==0.2.2 ; python_version >= '3.7'
-jupyterlab-server==2.16.2 ; python_version >= '3.7'
-jupyterlab-widgets==3.0.3 ; python_version >= '3.7'
+jupyterlab-server==2.16.5 ; python_version >= '3.7'
+jupyterlab-widgets==3.0.4 ; python_version >= '3.7'
 lxml==4.9.1 ; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'
 markdown==3.4.1 ; python_version >= '3.7'
 markupsafe==2.1.1 ; python_version >= '3.7'
-marshmallow==3.18.0 ; python_version >= '3.7'
+marshmallow==3.19.0 ; python_version >= '3.7'
 marshmallow-enum==1.5.1
 matplotlib-inline==0.1.6 ; python_version >= '3.5'
 mccabe==0.7.0 ; python_version >= '3.6'
 -e .
 mistune==2.0.4
 mock==4.0.3
-more-click==0.1.1 ; python_version >= '3.7'
+more-click==0.1.2 ; python_version >= '3.7'
 mwoauth==0.3.8
-mypy==0.990
+mypy==0.991
 mypy-extensions==0.4.3
 nbclassic==0.4.8 ; python_version >= '3.7'
-nbclient==0.7.0 ; python_full_version >= '3.7.0'
-nbconvert==7.2.3 ; python_version >= '3.7'
+nbclient==0.7.2 ; python_full_version >= '3.7.0'
+nbconvert==7.2.6 ; python_version >= '3.7'
 nbformat==5.7.0 ; python_version >= '3.7'
-neo4j==5.2.0
+neo4j==5.3.0
 nest-asyncio==1.5.6 ; python_version >= '3.5'
 networkx==2.8.8 ; python_version >= '3.8'
 nodeenv==1.7.0 ; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4, 3.5, 3.6'
 notebook==6.5.2 ; python_version >= '3.7'
 notebook-shim==0.2.2 ; python_version >= '3.7'
-numpy==1.23.4 ; python_version >= '3.8'
+numpy==1.23.5 ; python_version >= '3.8'
 oauthlib==3.2.2 ; python_version >= '3.6'
-obonet==0.3.0 ; python_version >= '3.5'
+obonet==0.3.1 ; python_version >= '3.7'
 owlready2==0.39
-packaging==21.3 ; python_version >= '3.6'
-pandas==1.5.1 ; python_version >= '3.8'
+packaging==22.0 ; python_version >= '3.7'
+pandas==1.5.2 ; python_version >= '3.8'
 pandocfilters==1.5.0 ; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'
 parse==1.19.0
 parsley==1.3
@@ -131,38 +137,39 @@ parso==0.8.3 ; python_version >= '3.6'
 pathtools==0.1.2
 pexpect==4.8.0 ; sys_platform != 'win32'
 pickleshare==0.7.5
-platformdirs==2.5.3 ; python_version >= '3.7'
+platformdirs==2.6.0 ; python_version >= '3.7'
 pluggy==1.0.0 ; python_version >= '3.6'
 portalocker==2.6.0 ; python_version >= '3.5'
 pre-commit==2.20.0
 prometheus-client==0.15.0 ; python_version >= '3.6'
-prompt-toolkit==3.0.32 ; python_full_version >= '3.6.2'
+prompt-toolkit==3.0.36 ; python_full_version >= '3.6.2'
 psutil==5.9.4 ; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'
 psycopg2==2.9.5 ; python_version >= '3.6'
 psycopg2-binary==2.9.5
 ptyprocess==0.7.0
 pure-eval==0.2.2
-py==1.11.0 ; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'
-pycodestyle==2.9.1 ; python_version >= '3.6'
+pycodestyle==2.10.0 ; python_version >= '3.6'
 pycparser==2.21
 pydantic==1.10.2
 pydocstyle==6.1.1 ; python_version >= '3.6'
 pyee==8.2.2
 pyfaidx==0.7.1
-pyflakes==2.5.0 ; python_version >= '3.6'
+pyflakes==3.0.1 ; python_version >= '3.6'
 pygments==2.13.0 ; python_version >= '3.6'
 pyjwt==2.6.0 ; python_version >= '3.7'
 pyliftover==0.4
 pyparsing==3.0.9 ; python_full_version >= '3.6.8'
 pyppeteer==1.0.2 ; python_version >= '3.7' and python_version < '4.0'
+pyproject-api==1.2.1 ; python_version >= '3.7'
 pyquery==1.4.3
 pyrsistent==0.19.2 ; python_version >= '3.7'
 pysam==0.20.0
 pystow==0.4.7 ; python_version >= '3.7'
 pytest==7.2.0
-pytest-asyncio==0.20.1
+pytest-asyncio==0.20.3
 pytest-cov==4.0.0
 python-dateutil==2.8.2 ; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2'
+python-json-logger==2.0.4 ; python_version >= '3.5'
 python-jsonschema-objects==0.4.1
 pytrie==0.4.0
 pytz==2022.6
@@ -178,46 +185,46 @@ requests-html==0.10.0 ; python_full_version >= '3.6.0'
 requests-oauthlib==1.3.1 ; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'
 s3transfer==0.6.0 ; python_version >= '3.7'
 send2trash==1.8.0
-setuptools==65.5.1 ; python_version >= '3.7'
-simplejson==3.17.6 ; python_version >= '2.5' and python_version not in '3.0, 3.1, 3.2'
+setuptools==65.6.3 ; python_version >= '3.7'
+simplejson==3.18.0 ; python_version >= '2.5' and python_version not in '3.0, 3.1, 3.2'
 six==1.16.0 ; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2'
 sniffio==1.3.0 ; python_version >= '3.7'
 snowballstemmer==2.2.0
 sortedcontainers==2.4.0
 soupsieve==2.3.2.post1 ; python_version >= '3.6'
 sqlparse==0.4.3 ; python_version >= '3.5'
-stack-data==0.6.0
-starlette==0.20.4 ; python_version >= '3.7'
+stack-data==0.6.2
+starlette==0.22.0 ; python_version >= '3.7'
 tabulate==0.9.0 ; python_version >= '3.7'
-terminado==0.17.0 ; python_version >= '3.7'
+terminado==0.17.1 ; python_version >= '3.7'
 thera-py[dev]==0.3.7
 tinycss2==1.2.1 ; python_version >= '3.7'
 toml==0.10.2 ; python_version >= '2.6' and python_version not in '3.0, 3.1, 3.2'
 tomli==2.0.1 ; python_version < '3.11'
 tornado==6.2 ; python_version >= '3.7'
-tox==3.27.0
+tox==4.0.3
 tqdm==4.64.1 ; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'
-traitlets==5.5.0 ; python_version >= '3.7'
-types-pyyaml==6.0.12.1
-types-requests==2.28.11.3
-types-urllib3==1.26.25.2
+traitlets==5.7.0 ; python_version >= '3.7'
+types-pyyaml==6.0.12.2
+types-requests==2.28.11.5
+types-urllib3==1.26.25.4
 typing-extensions==4.4.0 ; python_version >= '3.7'
 typing-inspect==0.8.0
-ujson==5.4.0 ; python_version >= '3.7'
+ujson==5.5.0 ; python_version >= '3.7'
 url-normalize==1.4.3 ; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4, 3.5'
-urllib3==1.26.12 ; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4, 3.5' and python_version < '4'
+urllib3==1.26.13 ; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4, 3.5'
 uta-tools==0.1.3 ; python_version >= '3.8'
-uvicorn==0.19.0
+uvicorn==0.20.0
 variation-normalizer==0.5.1
-vcfpy==0.13.5
-virtualenv==20.16.6 ; python_version >= '3.6'
-w3lib==2.0.1 ; python_version >= '3.6'
-watchdog==2.1.9 ; python_version >= '3.6'
+vcfpy==0.13.6
+virtualenv==20.17.1 ; python_version >= '3.6'
+w3lib==2.1.1 ; python_version >= '3.7'
+watchdog==2.2.0 ; python_version >= '3.6'
 wcwidth==0.2.5
 webencodings==0.5.1
 websocket-client==1.4.2 ; python_version >= '3.7'
 websockets==10.4 ; python_version >= '3.7'
-widgetsnbextension==4.0.3 ; python_version >= '3.7'
-wikibaseintegrator==0.12.1
+widgetsnbextension==4.0.4 ; python_version >= '3.7'
+wikibaseintegrator==0.12.2
 yoyo-migrations==8.1.0
-zipp==3.10.0 ; python_version >= '3.7'
+zipp==3.11.0 ; python_version >= '3.7'

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,122 +5,126 @@ appdirs==1.4.4
 appnope==0.1.3 ; platform_system == 'Darwin'
 argcomplete==2.0.0 ; python_version >= '3.6'
 argh==0.26.2
-asttokens==2.1.0
+asttokens==2.2.1
 asyncclick==8.1.3.4
 asyncpg==0.27.0 ; python_full_version >= '3.7.0'
 attrs==22.1.0 ; python_version >= '3.5'
 backcall==0.2.0
-backoff==2.1.2 ; python_version >= '3.7' and python_version < '4.0'
-backports-datetime-fromisoformat==1.0.0
+backoff==2.2.1 ; python_version >= '3.7' and python_version < '4.0'
+backports-datetime-fromisoformat==2.0.0
 beautifulsoup4==4.11.1 ; python_full_version >= '3.6.0'
 biocommons.seqrepo==0.6.5
-bioregistry[align]==0.6.8 ; python_version >= '3.7'
+bioregistry[align]==0.6.37 ; python_version >= '3.7'
 bioutils==0.5.7 ; python_version >= '3.6'
 bioversions==0.5.79
-boto3==1.26.4
-botocore==1.29.4
+boto3==1.26.26
+botocore==1.29.26
 bs4==0.0.1
-cachier==1.5.4
+cachetools==5.2.0 ; python_version ~= '3.7'
+cachier==2.0.0
 canonicaljson==1.6.4 ; python_version >= '3.7'
 cattrs==22.2.0 ; python_version >= '3.7'
-certifi==2022.9.24 ; python_version >= '3.6'
+certifi==2022.12.7 ; python_version >= '3.6'
 cfgv==3.3.1 ; python_full_version >= '3.6.1'
+chardet==5.1.0 ; python_version >= '3.7'
 charset-normalizer==2.1.1 ; python_full_version >= '3.6.0'
-chembl-downloader==0.4.0
+chembl-downloader==0.4.2
 civicpy==2.0.0
 class-resolver==0.3.10
 click==8.1.3
 click-default-group==1.2.2
+colorama==0.4.6 ; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4, 3.5, 3.6'
 coloredlogs==15.0.1 ; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'
+comm==0.1.2 ; python_version >= '3.6'
 configparser==5.3.0 ; python_version >= '3.7'
 cssselect==1.2.0 ; python_version >= '3.7'
 curies==0.4.0 ; python_version >= '3.7'
 dataclasses-json==0.5.7 ; python_version >= '3.6'
-debugpy==1.6.3 ; python_version >= '3.7'
+debugpy==1.6.4 ; python_version >= '3.7'
 decorator==5.1.1 ; python_version >= '3.5'
 defusedxml==0.7.1
 deprecation==2.1.0
 disease-normalizer[dev]==0.2.15
 distlib==0.3.6
 entrypoints==0.4 ; python_version >= '3.6'
-exceptiongroup==1.0.1 ; python_version < '3.11'
+exceptiongroup==1.0.4 ; python_version < '3.11'
 executing==1.2.0
-fake-useragent==0.1.14
-fastapi==0.86.0
-filelock==3.8.0 ; python_version >= '3.7'
-flake8==5.0.4
+fake-useragent==1.1.1
+fastapi==0.88.0
+filelock==3.8.2 ; python_version >= '3.7'
+flake8==6.0.0
 flake8-annotations==2.9.1
 flake8-docstrings==1.6.0
-flake8-import-order==0.18.1
+flake8-import-order==0.18.2
 flake8-quotes==3.3.1
 ga4gh.vrs==0.8.0dev0
 ga4gh.vrsatile.pydantic==0.0.11
 gene-normalizer[dev]==0.1.30
 gffutils==0.11.1
 h11==0.14.0 ; python_version >= '3.7'
-hgvs==1.5.2
+hgvs==1.5.4
 humanfriendly==10.0 ; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'
-identify==2.5.8 ; python_version >= '3.7'
+identify==2.5.9 ; python_version >= '3.7'
 idna==3.4 ; python_version >= '3.5'
-importlib-metadata==5.0.0 ; python_version >= '3.7'
+importlib-metadata==5.1.0 ; python_version >= '3.7'
 inflection==0.5.1 ; python_version >= '3.5'
-ipykernel==6.17.0
-ipython==8.6.0 ; python_version >= '3.8'
+ipykernel==6.19.2
+ipython==8.7.0 ; python_version >= '3.8'
 isodate==0.6.1
-jedi==0.18.1 ; python_version >= '3.6'
+jedi==0.18.2 ; python_version >= '3.6'
 jmespath==1.0.1 ; python_version >= '3.7'
 jsondiff==2.0.0
 jsonschema==3.2.0
-jupyter-client==7.4.4 ; python_version >= '3.7'
-jupyter-core==4.11.2 ; python_version >= '3.7'
+jupyter-client==7.4.8 ; python_version >= '3.7'
+jupyter-core==5.1.0 ; python_version >= '3.8'
 lxml==4.9.1 ; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'
 markdown==3.4.1 ; python_version >= '3.7'
-marshmallow==3.18.0 ; python_version >= '3.7'
+marshmallow==3.19.0 ; python_version >= '3.7'
 marshmallow-enum==1.5.1
 matplotlib-inline==0.1.6 ; python_version >= '3.5'
 mccabe==0.7.0 ; python_version >= '3.6'
-more-click==0.1.1 ; python_version >= '3.7'
+more-click==0.1.2 ; python_version >= '3.7'
 mwoauth==0.3.8
-mypy==0.990
+mypy==0.991
 mypy-extensions==0.4.3
-neo4j==5.2.0
+neo4j==5.3.0
 nest-asyncio==1.5.6 ; python_version >= '3.5'
 networkx==2.8.8 ; python_version >= '3.8'
 nodeenv==1.7.0 ; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4, 3.5, 3.6'
-numpy==1.23.4 ; python_version >= '3.8'
+numpy==1.23.5 ; python_version >= '3.8'
 oauthlib==3.2.2 ; python_version >= '3.6'
-obonet==0.3.0 ; python_version >= '3.5'
+obonet==0.3.1 ; python_version >= '3.7'
 owlready2==0.39
-packaging==21.3 ; python_version >= '3.6'
-pandas==1.5.1 ; python_version >= '3.8'
+packaging==22.0 ; python_version >= '3.7'
+pandas==1.5.2 ; python_version >= '3.8'
 parse==1.19.0
 parsley==1.3
 parso==0.8.3 ; python_version >= '3.6'
 pathtools==0.1.2
 pexpect==4.8.0 ; sys_platform != 'win32'
 pickleshare==0.7.5
-platformdirs==2.5.3 ; python_version >= '3.7'
+platformdirs==2.6.0 ; python_version >= '3.7'
 pluggy==1.0.0 ; python_version >= '3.6'
 portalocker==2.6.0 ; python_version >= '3.5'
 pre-commit==2.20.0
-prompt-toolkit==3.0.32 ; python_full_version >= '3.6.2'
+prompt-toolkit==3.0.36 ; python_full_version >= '3.6.2'
 psutil==5.9.4 ; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'
 psycopg2==2.9.5 ; python_version >= '3.6'
 psycopg2-binary==2.9.5
 ptyprocess==0.7.0
 pure-eval==0.2.2
-py==1.11.0 ; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'
-pycodestyle==2.9.1 ; python_version >= '3.6'
+pycodestyle==2.10.0 ; python_version >= '3.6'
 pydantic==1.10.2
 pydocstyle==6.1.1 ; python_version >= '3.6'
 pyee==8.2.2
 pyfaidx==0.7.1
-pyflakes==2.5.0 ; python_version >= '3.6'
+pyflakes==3.0.1 ; python_version >= '3.6'
 pygments==2.13.0 ; python_version >= '3.6'
 pyjwt==2.6.0 ; python_version >= '3.7'
 pyliftover==0.4
 pyparsing==3.0.9 ; python_full_version >= '3.6.8'
 pyppeteer==1.0.2 ; python_version >= '3.7' and python_version < '4.0'
+pyproject-api==1.2.1 ; python_version >= '3.7'
 pyquery==1.4.3
 pyrsistent==0.19.2 ; python_version >= '3.7'
 pysam==0.20.0
@@ -138,41 +142,41 @@ requests-ftp==0.3.1
 requests-html==0.10.0 ; python_full_version >= '3.6.0'
 requests-oauthlib==1.3.1 ; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'
 s3transfer==0.6.0 ; python_version >= '3.7'
-setuptools==65.5.1 ; python_version >= '3.7'
-simplejson==3.17.6 ; python_version >= '2.5' and python_version not in '3.0, 3.1, 3.2'
+setuptools==65.6.3 ; python_version >= '3.7'
+simplejson==3.18.0 ; python_version >= '2.5' and python_version not in '3.0, 3.1, 3.2'
 six==1.16.0 ; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2'
 sniffio==1.3.0 ; python_version >= '3.7'
 snowballstemmer==2.2.0
 sortedcontainers==2.4.0
 soupsieve==2.3.2.post1 ; python_version >= '3.6'
 sqlparse==0.4.3 ; python_version >= '3.5'
-stack-data==0.6.0
-starlette==0.20.4 ; python_version >= '3.7'
+stack-data==0.6.2
+starlette==0.22.0 ; python_version >= '3.7'
 tabulate==0.9.0 ; python_version >= '3.7'
 thera-py[dev]==0.3.7
 toml==0.10.2 ; python_version >= '2.6' and python_version not in '3.0, 3.1, 3.2'
 tomli==2.0.1 ; python_version < '3.11'
 tornado==6.2 ; python_version >= '3.7'
-tox==3.27.0
+tox==4.0.3
 tqdm==4.64.1 ; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'
-traitlets==5.5.0 ; python_version >= '3.7'
-types-pyyaml==6.0.12.1
-types-requests==2.28.11.3
-types-urllib3==1.26.25.2
+traitlets==5.7.0 ; python_version >= '3.7'
+types-pyyaml==6.0.12.2
+types-requests==2.28.11.5
+types-urllib3==1.26.25.4
 typing-extensions==4.4.0 ; python_version >= '3.7'
 typing-inspect==0.8.0
-ujson==5.4.0 ; python_version >= '3.7'
+ujson==5.5.0 ; python_version >= '3.7'
 url-normalize==1.4.3 ; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4, 3.5'
-urllib3==1.26.12 ; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4, 3.5' and python_version < '4'
+urllib3==1.26.13 ; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4, 3.5'
 uta-tools==0.1.3 ; python_version >= '3.8'
-uvicorn==0.19.0
+uvicorn==0.20.0
 variation-normalizer==0.5.1
-vcfpy==0.13.5
-virtualenv==20.16.6 ; python_version >= '3.6'
-w3lib==2.0.1 ; python_version >= '3.6'
-watchdog==2.1.9 ; python_version >= '3.6'
+vcfpy==0.13.6
+virtualenv==20.17.1 ; python_version >= '3.6'
+w3lib==2.1.1 ; python_version >= '3.7'
+watchdog==2.2.0 ; python_version >= '3.6'
 wcwidth==0.2.5
 websockets==10.4 ; python_version >= '3.7'
-wikibaseintegrator==0.12.1
+wikibaseintegrator==0.12.2
 yoyo-migrations==8.1.0
-zipp==3.10.0 ; python_version >= '3.7'
+zipp==3.11.0 ; python_version >= '3.7'

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -184,7 +184,7 @@ def civic_tid146():
                         {
                             "id": "hemonc:25316",
                             "type": "DiseaseDescriptor",
-                            "label": "Non-small cell lung cancer Squamous",
+                            "label": "Non-small cell lung cancer squamous",
                             "disease_id": None
                         },
                         {
@@ -1263,6 +1263,12 @@ def moa_imatinib():
                         "type": "DiseaseDescriptor",
                         "label": "Gastrointestinal stromal tumor",
                         "disease_id": "ncit:C3868"
+                    },
+                    {
+                        "id": "hemonc:33893",
+                        "type": "DiseaseDescriptor",
+                        "label": "Chronic myelogenous leukemia pediatric",
+                        "disease_id": None
                     }
                 ]
             }
@@ -1367,6 +1373,407 @@ def pmid_11423618():
 
 
 @pytest.fixture(scope="session")
+def oncokb_diagnostic_statement1():
+    """Create test fixture for OncoKB BRAF V600E diagnostic evidence"""
+    return {
+        "id": "oncokb.evidence:1Aj9eQzlxTuA5SU4pawmBSLhB1Z-XN88",
+        "type": "Statement",
+        "evidence_level": "oncokb.evidence_level:LEVEL_Dx3",
+        "proposition": "proposition:aLUHxB-FSxQp8hvWKw0JWTdmVZUgkF2f",
+        "variation_descriptor": "oncokb.variant:BRAF%20V600E",
+        "disease_descriptor": "oncokb.disease:611",
+        "method": "method:5",
+        "supported_by": ["pmid:25422482", "pmid:26637772"]
+    }
+
+
+@pytest.fixture(scope="session")
+def oncokb_diagnostic_proposition1():
+    """Create test fixture for OncoKB BRAF V600E diagnostic proposition"""
+    return {
+        "id": "proposition:aLUHxB-FSxQp8hvWKw0JWTdmVZUgkF2f",
+        "type": "diagnostic_proposition",
+        "predicate": "is_diagnostic_inclusion_criterion_for",
+        "subject": "ga4gh:VA.ZDdoQdURgO2Daj2NxLj4pcDnjiiAsfbO",
+        "object_qualifier": "ncit:C53972"
+    }
+
+
+@pytest.fixture(scope="session")
+def oncokb_therapeutic_statement1():
+    """Create test fixture for OncoKB BRAF V600E therapeutic evidence"""
+    return {
+        "id": "oncokb.evidence:EkQhm6lSDcynRuNQRL73HFod5sSmCx93",
+        "type": "Statement",
+        "evidence_level": "oncokb.evidence_level:LEVEL_1",
+        "proposition": "proposition:EOEfYXjsyQmgV2sNA-gfK5i0Cj8WGGuw",
+        "variation_descriptor": "oncokb.variant:BRAF%20V600E",
+        "disease_descriptor": "oncokb.disease:453",
+        "therapy_descriptor": "oncokb.normalize.therapy:Trametinib",
+        "method": "method:5",
+        "supported_by": ["pmid:29361468", "pmid:25399551", "pmid:22663011",
+                         "pmid:25265492"],
+        "extensions": [
+            {
+                "type": "Extension",
+                "name": "onckb_fda_level",
+                "value": {
+                    "level": "LEVEL_Fda2",
+                    "description": "Cancer Mutations with Evidence of Clinical Significance"  # noqa: E501
+                }
+            }
+        ]
+    }
+
+
+@pytest.fixture(scope="session")
+def oncokb_therapeutic_proposition1():
+    """Create test fixture for OncoKB BRAF V600E therapeutic proposition"""
+    return {
+        "id": "proposition:EOEfYXjsyQmgV2sNA-gfK5i0Cj8WGGuw",
+        "type": "therapeutic_response_proposition",
+        "predicate": "predicts_sensitivity_to",
+        "subject": "ga4gh:VA.ZDdoQdURgO2Daj2NxLj4pcDnjiiAsfbO",
+        "object_qualifier": "ncit:C3224",
+        "object": "rxcui:1425098"
+    }
+
+
+@pytest.fixture(scope="session")
+def oncokb_braf_v600e_vd():
+    """Create test fixture for BRAF V600E Variation Descriptor"""
+    return {
+        "type": "VariationDescriptor",
+        "id": "oncokb.variant:BRAF%20V600E",
+        "label": "BRAF V600E",
+        "description": "The BRAF V600E mutation is known to be oncogenic.",
+        "variation_id": "ga4gh:VA.ZDdoQdURgO2Daj2NxLj4pcDnjiiAsfbO",
+        "variation": {
+            "_id": "ga4gh:VA.ZDdoQdURgO2Daj2NxLj4pcDnjiiAsfbO",
+            "location": {
+                "_id": "ga4gh:VSL.2cHIgn7iLKk4x9z3zLkSTTFMV0e48DR4",
+                "interval": {
+                    "end": {"value": 600, "type": "Number"},
+                    "start": {"value": 599, "type": "Number"},
+                    "type": "SequenceInterval"
+                },
+                "sequence_id": "ga4gh:SQ.cQvw4UsHHRRlogxbWCB8W-mKD4AraM9y",
+                "type": "SequenceLocation"
+            },
+            "state": {
+                "sequence": "E",
+                "type": "LiteralSequenceExpression"
+            },
+            "type": "Allele"
+        },
+        "gene_context": "oncokb.normalize.gene:BRAF",
+        "extensions": [
+            {
+                "type": "Extension",
+                "name": "oncogenic",
+                "value": "Oncogenic"
+            },
+            {
+                "type": "Extension",
+                "name": "mutation_effect",
+                "value": {
+                    "knownEffect": "Gain-of-function",
+                    "description": "",
+                    "citations": {
+                        "pmids": [
+                            "25417114",
+                            "20179705",
+                            "23833300",
+                            "26091043",
+                            "26343582",
+                            "12068308",
+                            "30351999",
+                            "25079552",
+                            "28783719",
+                            "19251651",
+                            "15035987"
+                        ],
+                        "abstracts": []
+                    }
+                }
+            },
+            {
+                "type": "Extension",
+                "name": "hotspot",
+                "value": True
+            },
+            {
+                "type": "Extension",
+                "name": "vus",
+                "value": False
+            },
+            {
+                "type": "Extension",
+                "name": "oncokb_highest_sensitive_level",
+                "value": "LEVEL_1"
+            },
+            {
+                "type": "Extension",
+                "name": "oncokb_highest_diagnostic_implication_level",
+                "value": "LEVEL_Dx2"
+            },
+            {
+                "type": "Extension",
+                "name": "oncokb_highest_fda_level",
+                "value": "LEVEL_Fda2"
+            },
+            {
+                "type": "Extension",
+                "name": "allele_exist",
+                "value": True
+            }
+        ]
+    }
+
+
+@pytest.fixture(scope="session")
+def oncokb_braf_gene_descriptor():
+    """Create test fixture for BRAF gene descriptor"""
+    return {
+        "id": "oncokb.normalize.gene:BRAF",
+        "type": "GeneDescriptor",
+        "label": "BRAF",
+        "gene_id": "hgnc:1097",
+        "description": "BRAF, an intracellular kinase, is frequently mutated in melanoma, thyroid and lung cancers among others.",  # noqa: E501
+        "xrefs": ["ncbigene:673"],
+        "extensions": [
+            {
+                "type": "Extension",
+                "name": "ensembl_transcript_GRCh37",
+                "value": "ENST00000288602"
+            },
+            {
+                "type": "Extension",
+                "name": "refseq_transcript_GRCh37",
+                "value": "NM_004333.4"
+            },
+            {
+                "type": "Extension",
+                "name": "ensembl_transcript_GRCh38",
+                "value": "ENST00000646891"
+            },
+            {
+                "type": "Extension",
+                "name": "refseq_transcript_GRCh38",
+                "value": "NM_004333.4"
+            },
+            {
+                "type": "Extension",
+                "name": "oncogene",
+                "value": True
+            },
+            {
+                "type": "Extension",
+                "name": "oncokb_highest_sensitive_level",
+                "value": "1"
+            },
+            {
+                "type": "Extension",
+                "name": "oncokb_background",
+                "value": "BRAF is a serine/threonine kinase that plays a key role in the regulation of the mitogen-activated protein kinase (MAPK) cascade (PMID: 15520807), which under physiologic conditions regulates the expression of genes involved in cellular functions, including proliferation (PMID: 24202393). Genetic alterations in BRAF are found in a large percentage of melanomas, thyroid cancers and histiocytic neoplasms as well as a small fraction of lung and colorectal cancers. The most common BRAF point mutation is V600E, which deregulates the protein's kinase activity leading to constitutive BRAF activation, as BRAF V600E can signal as a monomer independently of RAS or upstream activation (PMID: 20179705). Other BRAF mutations have been found that affect the protein's propensity to dimerize (PMID: 16858395, 26343582, 12068308). The product of these alterations is a BRAF kinase that can activate MAPK signaling in an unregulated manner and, in some instances, is directly responsible for cancer growth (PMID: 15520807). Inhibitors of mutant BRAF, including vemurafenib and dabrafenib, are FDA-approved for the treatment of late-stage or unresectable melanoma.",  # noqa: E501
+            },
+            {
+                "type": "Extension",
+                "name": "tumor_suppressor_gene",
+                "value": False
+            }
+        ]
+    }
+
+
+@pytest.fixture(scope="session")
+def oncokb_trametinib_therapy_descriptor():
+    """Create OncoKB therapy descriptor for Trametinib"""
+    return {
+        "id": "oncokb.normalize.therapy:Trametinib",
+        "type": "TherapyDescriptor",
+        "label": "Trametinib",
+        "therapy_id": "rxcui:1425098",
+        "alternate_labels": [
+            "JTP-74057",
+            "MEK Inhibitor GSK1120212",
+            "N-(3-{3-cyclopropyl-5-[(2-fluoro-4-iodophenyl)amino]-6,8-dimethyl-2,4,7-trioxo-3,4,6,7-tetrahydropyrido[4,3-d]pyrimidin-1(2H)-yl}phenyl)acetamide",  # noqa: E501
+            "GSK1120212",
+            "TRAMETINIB",
+            "Trametinib"
+        ],
+        "xrefs": ["ncit:C77908"],
+        "extensions": [
+            {
+                "type": "Extension",
+                "name": "regulatory_approval",
+                "value": {
+                    "approval_rating": "ChEMBL",
+                    "has_indications": [
+                        {
+                            "id": "mesh:D009369",
+                            "type": "DiseaseDescriptor",
+                            "label": "Neoplasms",
+                            "disease_id": "ncit:C3262"
+                        }
+                    ]
+                }
+            }
+        ]
+    }
+
+
+@pytest.fixture(scope="session")
+def oncokb_ecd_disease_descriptor():
+    """Create OncoKB disease descriptor for ECD"""
+    return {
+        "type": "DiseaseDescriptor",
+        "id": "oncokb.disease:611",
+        "label": "Erdheim-Chester Disease",
+        "disease_id": "ncit:C53972",
+        "xrefs": ["oncotree:ECD"],
+        "extensions": [
+            {
+                "type": "Extension",
+                "name": "oncotree_main_type",
+                "value": {
+                    "id": None,
+                    "name": "Histiocytosis",
+                    "tumor_form": "LIQUID"
+                }
+            },
+            {
+                "type": "Extension",
+                "name": "tissue",
+                "value": "Myeloid"
+            },
+            {
+                "type": "Extension",
+                "name": "parent",
+                "value": "HDCN"
+            },
+            {
+                "type": "Extension",
+                "name": "level",
+                "value": 4
+            },
+            {
+                "type": "Extension",
+                "name": "tumor_form",
+                "value": "LIQUID"
+            }
+        ]
+    }
+
+
+@pytest.fixture(scope="session")
+def oncokb_mel_disease_descriptor():
+    """Create OncoKB disease descriptor for MEL"""
+    return {
+        "type": "DiseaseDescriptor",
+        "id": "oncokb.disease:453",
+        "label": "Melanoma",
+        "disease_id": "ncit:C3224",
+        "xrefs": ["oncotree:MEL"],
+        "extensions": [
+            {
+                "type": "Extension",
+                "name": "oncotree_main_type",
+                "value": {
+                    "id": None,
+                    "name": "Melanoma",
+                    "tumor_form": "SOLID"
+                }
+            },
+            {
+                "type": "Extension",
+                "name": "tissue",
+                "value": "Skin"
+            },
+            {
+                "type": "Extension",
+                "name": "parent",
+                "value": "SKIN"
+            },
+            {
+                "type": "Extension",
+                "name": "level",
+                "value": 2
+            },
+            {
+                "type": "Extension",
+                "name": "tumor_form",
+                "value": "SOLID"
+            }
+        ]
+    }
+
+
+@pytest.fixture(scope="session")
+def oncokb_diagnostic1_documents():
+    """Create test fixture for OncoKB diagnostic evidence 1 documents"""
+    return [
+        {
+            "id": "pmid:25422482",
+            "label": "PubMed 25422482",
+            "type": "Document"
+        },
+        {
+            "id": "pmid:26637772",
+            "label": "PubMed 26637772",
+            "type": "Document"
+        }
+    ]
+
+
+@pytest.fixture(scope="session")
+def oncokb_therapeutic1_documents_query():
+    """Create test fixture for OncoKB therapeutic evidence 1 documents during queries.
+    Since CIViC provided more information, we now have a description
+    and a more detailed label for pmid:22663011
+    """
+    return [
+        {
+            "id": "pmid:29361468",
+            "label": "PubMed 29361468",
+            "type": "Document"
+        },
+        {
+            "id": "pmid:25399551",
+            "label": "PubMed 25399551",
+            "type": "Document"
+        },
+        {
+            "id": "pmid:22663011",
+            "label": "Flaherty et al., 2012, N. Engl. J. Med.",
+            "description": "Improved survival with MEK inhibition in BRAF-mutated melanoma.",  # noqa: E501
+            "type": "Document"
+        },
+        {
+            "id": "pmid:25265492",
+            "label": "PubMed 25265492",
+            "type": "Document"
+        }
+    ]
+
+
+@pytest.fixture(scope="session")
+def oncokb_method():
+    """Create test fixture for OncoKB method"""
+    return {
+        "id": "method:5",
+        "label": "OncoKB Curation Standard Operating Procedure",
+        "url": "https://sop.oncokb.org/",
+        "version": {
+            "year": 2021,
+            "month": 11
+        },
+        "authors": "OncoKB",
+        "type": "Method"
+    }
+
+
+@pytest.fixture(scope="session")
 def sources_count() -> int:
     """Provide number of currently-implemented sources."""
     return len(SourceName.__members__)
@@ -1379,13 +1786,19 @@ def check_statement():
         """Check that statements are match."""
         assert actual.keys() == test.keys()
         assert actual["id"] == test["id"]
-        assert actual["description"] == test["description"]
+        if "description" in test:
+            assert actual["description"] == test["description"]
+        else:
+            assert "description" not in actual
         if "direction" in test.keys():
             # MOA doesn"t have direction?
             assert actual["direction"] == test["direction"]
         assert actual["evidence_level"] == test["evidence_level"]
         assert actual["proposition"].startswith("proposition:")
-        assert actual["variation_origin"] == test["variation_origin"]
+        if "variation_origin" in test:
+            assert actual["variation_origin"] == test["variation_origin"]
+        else:
+            assert "variation_origin" not in actual
         assert actual["variation_descriptor"] == test["variation_descriptor"]
         if "therapy_descriptor" not in test.keys():
             assert "therapy_descriptor" not in actual.keys()
@@ -1419,22 +1832,26 @@ def check_proposition():
 @pytest.fixture(scope="session")
 def check_variation_descriptor():
     """Create a test fixture to compare variation descriptors."""
-    def check_variation_descriptor(actual, test):
+    def check_variation_descriptor(actual, test, check_descriptor=None, nested=False):
         """Check that variation descriptors match."""
         actual_keys = actual.keys()
         test_keys = test.keys()
         assert actual_keys == test_keys
         for key in test_keys:
             if key in ["id", "type", "label", "description", "variation_id",
-                       "structural_type", "vrs_ref_allele_seq",
-                       "gene_context"]:
+                       "structural_type", "vrs_ref_allele_seq"]:
                 assert actual[key] == test[key]
+            elif key == "gene_context":
+                if nested:
+                    check_descriptor(actual["gene_context"], test["gene_context"])
+                else:
+                    assert actual[key] == test[key]
             elif key in ["xrefs", "alternate_labels"]:
                 assert set(actual[key]) == set(test[key])
             elif key == "variation":
                 assert actual["variation"] == test["variation"]
             elif key == "extensions":
-                assert len(actual) == len(test)
+                assert len(actual["extensions"]) == len(test["extensions"])
                 for test_extension in test["extensions"]:
                     for actual_extension in actual["extensions"]:
                         if test_extension["name"] == actual_extension["name"]:
@@ -1466,6 +1883,20 @@ def check_descriptor():
         for key in test_keys:
             if key in ["alternate_labels", "xrefs"]:
                 assert set(actual[key]) == set(test[key])
+            elif key == "extensions":
+                assert len(actual["extensions"]) == len(test["extensions"])
+                if test["type"] == "TherapyDescriptor":
+                    # Therapy only has regulatory approval extension
+                    assert len(actual["extensions"]) == 1
+                    actual_ext = actual["extensions"][0]
+                    test_ext = test["extensions"][0]
+                    assert actual_ext["value"]["approval_rating"] == test_ext["value"]["approval_rating"]  # noqa: E501
+                    assert len(actual_ext["value"]["has_indications"]) == len(test_ext["value"]["has_indications"])  # noqa: E501
+                    for x in test_ext["value"]["has_indications"]:
+                        assert x in actual_ext["value"]["has_indications"], x
+                else:
+                    for x in test[key]:
+                        assert x in actual[key], x
             else:
                 assert actual[key] == test[key]
     return check_descriptor

--- a/tests/data/harvesters/oncokb/variants_by_protein_change.csv
+++ b/tests/data/harvesters/oncokb/variants_by_protein_change.csv
@@ -1,0 +1,2 @@
+hugo_symbol,protein_change
+BRAF,V600E

--- a/tests/data/transform/oncokb_harvester.json
+++ b/tests/data/transform/oncokb_harvester.json
@@ -1,0 +1,216 @@
+{
+  "genes": [
+    {
+      "grch37Isoform": "ENST00000288602",
+      "grch37RefSeq": "NM_004333.4",
+      "grch38Isoform": "ENST00000646891",
+      "grch38RefSeq": "NM_004333.4",
+      "entrezGeneId": 673,
+      "hugoSymbol": "BRAF",
+      "oncogene": true,
+      "highestSensitiveLevel": "1",
+      "highestResistanceLevel": "",
+      "summary": "BRAF, an intracellular kinase, is frequently mutated in melanoma, thyroid and lung cancers among others.",
+      "background": "BRAF is a serine/threonine kinase that plays a key role in the regulation of the mitogen-activated protein kinase (MAPK) cascade (PMID: 15520807), which under physiologic conditions regulates the expression of genes involved in cellular functions, including proliferation (PMID: 24202393). Genetic alterations in BRAF are found in a large percentage of melanomas, thyroid cancers and histiocytic neoplasms as well as a small fraction of lung and colorectal cancers. The most common BRAF point mutation is V600E, which deregulates the protein's kinase activity leading to constitutive BRAF activation, as BRAF V600E can signal as a monomer independently of RAS or upstream activation (PMID: 20179705). Other BRAF mutations have been found that affect the protein's propensity to dimerize (PMID: 16858395, 26343582, 12068308). The product of these alterations is a BRAF kinase that can activate MAPK signaling in an unregulated manner and, in some instances, is directly responsible for cancer growth (PMID: 15520807). Inhibitors of mutant BRAF, including vemurafenib and dabrafenib, are FDA-approved for the treatment of late-stage or unresectable melanoma.",
+      "tsg": false,
+      "highestResistancLevel": ""
+    }
+  ],
+  "variants": [
+    {
+      "query": {
+        "id": null,
+        "referenceGenome": "GRCh38",
+        "hugoSymbol": "BRAF",
+        "entrezGeneId": 673,
+        "alteration": "V600E",
+        "alterationType": null,
+        "svType": null,
+        "tumorType": null,
+        "consequence": null,
+        "proteinStart": null,
+        "proteinEnd": null,
+        "hgvs": null
+      },
+      "geneExist": true,
+      "variantExist": true,
+      "alleleExist": true,
+      "oncogenic": "Oncogenic",
+      "mutationEffect": {
+        "knownEffect": "Gain-of-function",
+        "description": "",
+        "citations": {
+          "pmids": [
+            "25417114",
+            "20179705",
+            "23833300",
+            "26091043",
+            "26343582",
+            "12068308",
+            "30351999",
+            "25079552",
+            "28783719",
+            "19251651",
+            "15035987"
+          ],
+          "abstracts": []
+        }
+      },
+      "highestSensitiveLevel": "LEVEL_1",
+      "highestResistanceLevel": null,
+      "highestDiagnosticImplicationLevel": "LEVEL_Dx2",
+      "highestPrognosticImplicationLevel": null,
+      "highestFdaLevel": "LEVEL_Fda2",
+      "otherSignificantSensitiveLevels": [],
+      "otherSignificantResistanceLevels": [],
+      "hotspot": true,
+      "geneSummary": "BRAF, an intracellular kinase, is frequently mutated in melanoma, thyroid and lung cancers among others.",
+      "variantSummary": "The BRAF V600E mutation is known to be oncogenic.",
+      "tumorTypeSummary": "",
+      "prognosticSummary": "",
+      "diagnosticSummary": "",
+      "diagnosticImplications": [
+        {
+          "levelOfEvidence": "LEVEL_Dx3",
+          "alterations": [
+            "V600E"
+          ],
+          "tumorType": {
+            "id": 611,
+            "code": "ECD",
+            "color": "LightSalmon",
+            "name": "Erdheim-Chester Disease",
+            "mainType": {
+              "id": null,
+              "name": "Histiocytosis",
+              "tumorForm": "LIQUID"
+            },
+            "tissue": "Myeloid",
+            "children": {},
+            "parent": "HDCN",
+            "level": 4,
+            "tumorForm": "LIQUID"
+          },
+          "pmids": [
+            "25422482",
+            "26637772"
+          ],
+          "abstracts": [],
+          "description": ""
+        }
+      ],
+      "prognosticImplications": [],
+      "treatments": [
+        {
+          "alterations": [
+            "V600E",
+            "V600K"
+          ],
+          "drugs": [
+            {
+              "ncitCode": "C77908",
+              "drugName": "Trametinib",
+              "uuid": "fb2bb01c-c0ec-4641-abf7-87f486075022",
+              "synonyms": [
+                "JTP-74057",
+                "MEK Inhibitor GSK1120212",
+                "N-(3-{3-cyclopropyl-5-[(2-fluoro-4-iodophenyl)amino]-6,8-dimethyl-2,4,7-trioxo-3,4,6,7-tetrahydropyrido[4,3-d]pyrimidin-1(2H)-yl}phenyl)acetamide",
+                "GSK1120212",
+                "TRAMETINIB",
+                "Trametinib"
+              ]
+            }
+          ],
+          "approvedIndications": [
+            "Trametinib is FDA-approved for BRAF V600E or V600K mutant unresectable or metastatic melanoma"
+          ],
+          "level": "LEVEL_1",
+          "fdaLevel": "LEVEL_Fda2",
+          "levelAssociatedCancerType": {
+            "id": 453,
+            "code": "MEL",
+            "color": "Black",
+            "name": "Melanoma",
+            "mainType": {
+              "id": null,
+              "name": "Melanoma",
+              "tumorForm": "SOLID"
+            },
+            "tissue": "Skin",
+            "children": {},
+            "parent": "SKIN",
+            "level": 2,
+            "tumorForm": "SOLID"
+          },
+          "levelExcludedCancerTypes": [],
+          "pmids": [
+            "29361468",
+            "25399551",
+            "22663011",
+            "25265492"
+          ],
+          "abstracts": [],
+          "description": ""
+        }
+      ],
+      "dataVersion": "v3.18",
+      "lastUpdate": "10/17/2022",
+      "vus": false
+    }
+  ],
+  "levels": {
+    "diagnostic": {
+      "LEVEL_Dx1": "FDA and/or professional guideline-recognized biomarker required for diagnosis in this indication",
+      "LEVEL_Dx2": "FDA and/or professional guideline-recognized biomarker that supports diagnosis in this indication",
+      "LEVEL_Dx3": "Biomarker that may assist disease diagnosis in this indication based on clinical evidence"
+    },
+    "prognostic": {
+      "LEVEL_Px1": "FDA and/or professional guideline-recognized biomarker prognostic in this indication based on well-powered studie(s)",
+      "LEVEL_Px2": "FDA and/or professional guideline-recognized biomarker prognostic in this indication based on a single or multiple small studies",
+      "LEVEL_Px3": "Biomarker is prognostic in this indication based on clinical evidence in well-powered studies"
+    },
+    "resistance": {
+      "LEVEL_R1": "Standard care biomarker predictive of resistance to an FDA-approved drug in this indication",
+      "LEVEL_R2": "Compelling clinical evidence supports the biomarker as being predictive of resistance to a drug"
+    },
+    "sensitive": {
+      "LEVEL_3A": "Compelling clinical evidence supports the biomarker as being predictive of response to a drug in this indication",
+      "LEVEL_3B": "Standard care or investigational biomarker predictive of response to an FDA-approved or investigational drug in another indication",
+      "LEVEL_2": "Standard care biomarker recommended by the NCCN or other expert panels predictive of response to an FDA-approved drug in this indication",
+      "LEVEL_4": "Compelling biological evidence supports the biomarker as being predictive of response to a drug",
+      "LEVEL_1": "FDA-recognized biomarker predictive of response to an FDA-approved drug in this indication"
+    },
+    "fda": {
+      "LEVEL_Fda1": "Companion Diagnostics",
+      "LEVEL_Fda2": "Cancer Mutations with Evidence of Clinical Significance",
+      "LEVEL_Fda3": "Cancer Mutations with Potential of Clinical Significance"
+    }
+  },
+  "metadata": {
+    "oncoTreeVersion": "oncotree_2019_12_01",
+    "ncitVersion": "19.03d",
+    "dataVersion": {
+      "version": "v3.18",
+      "date": "11/30/2022"
+    },
+    "appVersion": {
+      "version": "v3.11.2-no-frontend",
+      "major": 3,
+      "minor": 11,
+      "patch": 2,
+      "suffixTokens": [
+        "no-frontend"
+      ],
+      "stable": false
+    },
+    "apiVersion": {
+      "version": "v1.4.0",
+      "major": 1,
+      "minor": 4,
+      "patch": 0,
+      "suffixTokens": [],
+      "stable": true
+    },
+    "publicInstance": false
+  }
+}

--- a/tests/unit/database/test_database.py
+++ b/tests/unit/database/test_database.py
@@ -263,18 +263,6 @@ def test_statement_rules(graph: Graph, check_unique_property,
     check_relation_count("Statement", "Proposition", "DEFINED_BY")
     check_relation_count("Statement", "Method", "USES_METHOD")
 
-    cite_query = """
-    MATCH (s:Statement)
-    OPTIONAL MATCH (s)-[:CITES]->(d:Document)
-    OPTIONAL MATCH (s)-[:CITES]->(e:Statement)
-    WITH s, COUNT(d) as d_count, COUNT(e) as e_count
-    WHERE (d_count + e_count) < 1
-    RETURN COUNT(s)
-    """
-    with graph.driver.session() as s:
-        record = s.run(cite_query).single()
-    assert record.values()[0] == 0
-
 
 def test_proposition_rules(graph, check_unique_property):
     """Verify property and relationship rules for Proposition nodes."""

--- a/tests/unit/deltas/test_civic_deltas.py
+++ b/tests/unit/deltas/test_civic_deltas.py
@@ -1,10 +1,15 @@
 """Test CIViC deltas."""
-import pytest
-from metakb import PROJECT_ROOT, APP_ROOT
-from metakb.delta import Delta
-from datetime import date
 import json
 import os
+from datetime import date
+
+import pytest
+from civicpy.__version__ import __version__ as civicpy_version
+
+from metakb import PROJECT_ROOT, APP_ROOT
+from metakb.delta import Delta
+from metakb.version import __version__
+
 
 MAIN_JSON = PROJECT_ROOT / 'tests' / 'data' / 'deltas' / 'main_civic.json'
 UPDATED_JSON = \
@@ -38,8 +43,8 @@ def diff():
     """Create a test fixture for CIViC deltas."""
     return {
         '_meta': {
-            'civicpy_version': '1.1.2',
-            'metakb_version': '1.0.1',
+            'civicpy_version': civicpy_version,
+            'metakb_version': __version__,
             'date_harvested': date.today().strftime('%Y%m%d')
         },
         'genes': {

--- a/tests/unit/deltas/test_moa_deltas.py
+++ b/tests/unit/deltas/test_moa_deltas.py
@@ -1,10 +1,14 @@
 """Test MOAlmanac deltas."""
-import pytest
-from metakb import PROJECT_ROOT, APP_ROOT
-from metakb.delta import Delta
 from datetime import date
 import json
 import os
+
+import pytest
+
+from metakb import PROJECT_ROOT, APP_ROOT
+from metakb.delta import Delta
+from metakb.version import __version__
+
 
 MAIN_JSON = PROJECT_ROOT / 'tests' / 'data' / 'deltas' / 'main_moa.json'
 UPDATED_JSON = \
@@ -38,7 +42,7 @@ def diff():
     """Create a test fixture for MOAlmanac deltas."""
     return {
         '_meta': {
-            'metakb_version': '1.0.1',
+            'metakb_version': __version__,
             'date_harvested': date.today().strftime('%Y%m%d'),
             'moa_api_version': '0.2'
         },

--- a/tests/unit/harvesters/oncokb/test_oncokb_harvest.py
+++ b/tests/unit/harvesters/oncokb/test_oncokb_harvest.py
@@ -1,0 +1,23 @@
+"""Test OncoKB Harvester"""
+import os
+
+from metakb.harvesters import OncoKBHarvester
+from metakb import APP_ROOT, PROJECT_ROOT
+
+
+def test_harvest():
+    """Test OncoKB harvest method"""
+    ONCOKB_API_TOKEN = os.environ.get("ONCOKB_API_TOKEN")
+    o = OncoKBHarvester(api_token=ONCOKB_API_TOKEN)
+    assert not o.harvest("")
+    fn = "test_oncokb_harvester.json"
+    variants_by_protein_change_path = PROJECT_ROOT / "tests" / "data" / "harvesters" / \
+        "oncokb" / "variants_by_protein_change.csv"
+    assert o.harvest(variants_by_protein_change_path, fn)
+    for var in [o.genes, o.variants, o.metadata, o.diagnostic_levels,
+                o.prognostic_levels, o.sensitive_levels, o.sensitive_levels]:
+        assert var
+    file_path = APP_ROOT / "data" / "oncokb" / "harvester" / fn
+    assert file_path.exists()
+    os.remove(file_path)
+    assert not file_path.exists()

--- a/tests/unit/transform/test_oncokb_transform.py
+++ b/tests/unit/transform/test_oncokb_transform.py
@@ -1,0 +1,123 @@
+"""Test OncoKB Transformation to common data model
+
+Test data uses public OncoKB API: https://demo.oncokb.org/api
+"""
+import json
+
+import pytest
+import pytest_asyncio
+
+from metakb.transform.oncokb import OncoKBTransform
+from metakb import PROJECT_ROOT
+
+
+DATA_DIR = PROJECT_ROOT / "tests" / "data" / "transform"
+FILENAME = "oncokb_cdm.json"
+
+
+@pytest_asyncio.fixture(scope="module")
+@pytest.mark.asyncio
+async def data(normalizers):
+    """Create a OncoKB Transform test fixture."""
+    harvester_path = DATA_DIR / "oncokb_harvester.json"
+    o = OncoKBTransform(data_dir=DATA_DIR, harvester_path=harvester_path,
+                        normalizers=normalizers)
+    await o.transform()
+    o.create_json(transform_dir=DATA_DIR, filename=FILENAME)
+    with open(DATA_DIR / FILENAME, "r") as f:
+        data = json.load(f)
+    return data
+
+
+@pytest.fixture(scope="module")
+def oncokb_statements(oncokb_diagnostic_statement1, oncokb_therapeutic_statement1):
+    """Create OncoKB statements test fixture"""
+    return [oncokb_diagnostic_statement1, oncokb_therapeutic_statement1]
+
+
+@pytest.fixture(scope="module")
+def oncokb_propositions(oncokb_diagnostic_proposition1,
+                        oncokb_therapeutic_proposition1):
+    """Create OncoKB propositions test fixture"""
+    return [oncokb_diagnostic_proposition1, oncokb_therapeutic_proposition1]
+
+
+@pytest.fixture(scope="module")
+def oncokb_therapy_descriptors(oncokb_trametinib_therapy_descriptor):
+    """Create OncoKB therapy descriptors test fixture"""
+    return [oncokb_trametinib_therapy_descriptor]
+
+
+@pytest.fixture(scope="module")
+def oncokb_gene_descriptors(oncokb_braf_gene_descriptor):
+    """Create OncoKB gene descriptors test fixture"""
+    return [oncokb_braf_gene_descriptor]
+
+
+@pytest.fixture(scope="module")
+def oncokb_variation_descriptors(oncokb_braf_v600e_vd):
+    """Create OncoKB variation descriptors test fixture"""
+    return [oncokb_braf_v600e_vd]
+
+
+@pytest.fixture(scope="module")
+def oncokb_disease_descriptors(oncokb_ecd_disease_descriptor,
+                               oncokb_mel_disease_descriptor):
+    """Create OncoKB disease descriptors test fixture"""
+    return [oncokb_ecd_disease_descriptor, oncokb_mel_disease_descriptor]
+
+
+@pytest.fixture(scope="module")
+def oncokb_methods(oncokb_method):
+    """Create OncoKB methods test fixture"""
+    return [oncokb_method]
+
+
+@pytest.fixture(scope="module")
+def oncokb_therapeutic1_documents():
+    """Create test fixture for OncoKB therapeutic evidence 1 documents"""
+    return [
+        {
+            "id": "pmid:29361468",
+            "label": "PubMed 29361468",
+            "type": "Document"
+        },
+        {
+            "id": "pmid:25399551",
+            "label": "PubMed 25399551",
+            "type": "Document"
+        },
+        {
+            "id": "pmid:22663011",
+            "label": "PubMed 22663011",
+            "type": "Document"
+        },
+        {
+            "id": "pmid:25265492",
+            "label": "PubMed 25265492",
+            "type": "Document"
+        }
+    ]
+
+
+@pytest.fixture(scope="module")
+def oncokb_documents(oncokb_diagnostic1_documents, oncokb_therapeutic1_documents):
+    """Create OncoKB Documents test fixture"""
+    return oncokb_diagnostic1_documents + oncokb_therapeutic1_documents
+
+
+def test_oncokb_transform(
+    data, oncokb_statements, oncokb_propositions, oncokb_variation_descriptors,
+    oncokb_gene_descriptors, oncokb_disease_descriptors, oncokb_therapy_descriptors,
+    oncokb_methods, oncokb_documents, check_statement, check_proposition,
+    check_variation_descriptor, check_descriptor, check_document, check_method,
+    check_transformed_cdm
+):
+    """Test that OncoKB transform works correctly"""
+    check_transformed_cdm(
+        data, oncokb_statements, oncokb_propositions, oncokb_variation_descriptors,
+        oncokb_gene_descriptors, oncokb_disease_descriptors, oncokb_therapy_descriptors,
+        oncokb_methods, oncokb_documents, check_statement, check_proposition,
+        check_variation_descriptor, check_descriptor, check_document, check_method,
+        DATA_DIR / FILENAME
+    )


### PR DESCRIPTION
Close #170 

Notes:
- I've been looking at this code for so long, I'm sure there's places for improvement. Any feedback is appreciated! This is also a huge PR, so I may have forgotten some important notes. Let me know if there are any questions. 
- Wagner Lab team: 
    - DM me on slack about accessing the OncoKB API token if you do not know how to access.
    - I've uploaded harvester/cdm files in our private s3 bucket. I messaged in the slack with the prefix. DM me if you have any troubles accessing this. The last upload (20221212) was ran using the following aws ddb instances: gene: prod; therapy: nonprod (@jsstevenson ran this weekend and will promote it to prod some time this week. So that's why I used nonprod); disease:prod. I will also be using these environments for tests, since this is what prod will point to.
- OncoKB test data used public endpoint: https://demo.oncokb.org/api
- OncoKB does not have a "get all evidence" or "get all variants" endpoint. Instead, they have an endpoint which allows you to get all evidence associated to a variant. They also do not provide a list of variants that have been curated (`variants_by_protein_change_path` inside `harvest` method). It takes ~30 minutes to harvest. 
- OncoKB is not consistent with returning internal IDs in the response. They do provide internal ids for drugs (`uuid`) and diseases (`id`). In the cases where they do provide some kind of internal ID, I prefix the descriptor with `oncokb.{descriptor_type}`. In cases where they don't, I prefix the descriptor with `oncokb.normalize.{descriptor_type}`. The exception is with `Statements`. In this case, I created digests for the Statement parameters (similar to vrs-python) and prefixed with `oncokb.evidence`. 
- OncoKB does not provide enough information for prognostic evidence, so we skip this
- Until we switch to metaschema updates, we still only allow 1 therapy/drug for a Therapeutic evidence item
- Saving abstract documents for #204
- Made some small changes to deltas, but I think this entire class should be updated in a separate issue. We don't really compute / use deltas in our current pipeline. 
- Made some changes to the `Statement` model. @ahwagner approved adding an `extensions` field to store the fda level data. However, he did not approve me making `Statement.description` optional. Let me know if this is an issue. 
- Analysis + using other variant endpoints will be done in separate issues since this is already a massive PR.