### PR TITLE
fix: civic variant aliases should be a list + pydantic warning

### DIFF
--- a/metakb/schemas/variation_statement.py
+++ b/metakb/schemas/variation_statement.py
@@ -125,7 +125,7 @@ class _VariantStudySummary(_VariantStatement):
     isReportedIn: List[Union[Document, core_models.IRI]] = Field(
         ...,
         description="A document in which the information content is expressed.",
-        min_items=1,
+        min_length=1,
     )
 
 

--- a/metakb/transform/civic.py
+++ b/metakb/transform/civic.py
@@ -362,7 +362,7 @@ class CivicTransform(Transform):
                 continue
 
             # Get aliases from MP and Variant record
-            aliases = (mp["aliases"] or []) + civic_variation_data["aliases"]
+            aliases = (mp["aliases"] or []) + (civic_variation_data["aliases"] or [])
 
             # Get molecular profile score data
             mp_score = mp["molecular_profile_score"]


### PR DESCRIPTION
* min_items -> min_length for pydantic v2