### PR TITLE
change: snp ids should not be in civic aliases during transform

### DIFF
--- a/metakb/transform/civic.py
+++ b/metakb/transform/civic.py
@@ -562,8 +562,8 @@ class CivicTransform(Transform):
                         ),
                         relation=core_models.Relation.RELATED_MATCH
                     ))
-
-                aliases.append(a)
+                else:
+                    aliases.append(a)
 
             if variant["coordinates"]:
                 coordinates = {

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -155,7 +155,7 @@ def civic_mpid33(civic_vid33):
                 }
             }
         ],
-        "aliases": ["LEU858ARG", "rs121434568"],
+        "aliases": ["LEU858ARG"],
         "mappings": [
             {
                 "coding": {

--- a/tests/unit/transform/test_civic_transform_therapeutic.py
+++ b/tests/unit/transform/test_civic_transform_therapeutic.py
@@ -101,8 +101,7 @@ def civic_mpid12(civic_vid12):
         "aliases": [
             "VAL600GLU",
             "V640E",
-            "VAL640GLU",
-            "rs113488022"
+            "VAL640GLU"
         ],
         "mappings": [
             {


### PR DESCRIPTION
close #254 

* This commit makes it so that snp ids are only in civic mappings