### PR TITLE
fix: key error in MoaHarvester _get_feature

### DIFF
--- a/metakb/harvesters/moa.py
+++ b/metakb/harvesters/moa.py
@@ -247,7 +247,7 @@ class MoaHarvester(Harvester):
         elif feature_type == "microsatellite_stability":
             feature = "{}".format(v.get("status"))
         elif feature_type == "mutational_signature":
-            csn = v["cosmic_signature_number"]
+            csn = v.get("cosmic_signature_number", "")
             feature = "COSMIC Signature {}".format(csn)
         elif feature_type == "mutational_burden":
             clss = v["classification"]


### PR DESCRIPTION
close #256

* Sometimes cosmic_signature_number does not exist for moa mutational_signature features