### PR TITLE
change:  snp ids should not be in civic mp aliases during transform

### DIFF
--- a/metakb/transform/civic.py
+++ b/metakb/transform/civic.py
@@ -362,7 +362,10 @@ class CivicTransform(Transform):
                 continue
 
             # Get aliases from MP and Variant record
-            aliases = (mp["aliases"] or []) + (civic_variation_data["aliases"] or [])
+            aliases = civic_variation_data["aliases"] or []
+            for a in (mp["aliases"] or []):
+                if not SNP_RE.match(a):
+                    aliases.append(a)
 
             # Get molecular profile score data
             mp_score = mp["molecular_profile_score"]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -215,7 +215,7 @@ def civic_mpid33(civic_vid33):
             },
             {
                 "name": "CIViC Molecular Profile Score",
-                "value": 378.0,
+                "value": 379.0,
                 "type": "Extension"
             },
             {

--- a/tests/data/transform/therapeutic/civic_harvester.json
+++ b/tests/data/transform/therapeutic/civic_harvester.json
@@ -548,14 +548,14 @@
       "type": "molecular_profile",
       "id": 33,
       "variant_ids": [
-          33
+        33
       ],
       "name": "EGFR L858R",
       "molecular_profile_score": 379.0,
       "description": "EGFR L858R has long been recognized as a functionally significant mutation in cancer, and is one of the most prevalent single mutations in lung cancer. Best described in non-small cell lung cancer (NSCLC), the mutation seems to confer sensitivity to first and second generation TKI's like gefitinib and neratinib. NSCLC patients with this mutation treated with TKI's show increased overall and progression-free survival, as compared to chemotherapy alone. Third generation TKI's are currently in clinical trials that specifically focus on mutant forms of EGFR, a few of which have shown efficacy in treating patients that failed to respond to earlier generation TKI therapies.",
       "aliases": [
-          "LEU858ARG",
-          "RS121434568"
+        "LEU858ARG",
+        "RS121434568"
       ],
       "sources": []
     },
@@ -563,16 +563,16 @@
       "type": "molecular_profile",
       "id": 12,
       "variant_ids": [
-          12
+        12
       ],
       "name": "BRAF V600E",
       "molecular_profile_score": 1353.5,
       "description": "BRAF V600E has been shown to be recurrent in many cancer types. It is one of the most widely studied variants in cancer. This variant is correlated with poor prognosis in certain cancer types, including colorectal cancer and papillary thyroid cancer. The targeted therapeutic dabrafenib has been shown to be effective in clinical trials with an array of BRAF mutations and cancer types. Dabrafenib has also shown to be effective when combined with the MEK inhibitor trametinib in colorectal cancer and melanoma. However, in patients with TP53, CDKN2A and KRAS mutations, dabrafenib resistance has been reported. Ipilimumab, regorafenib, vemurafenib, and a number of combination therapies have been successful in treating V600E mutations. However, cetuximab and panitumumab have been largely shown to be ineffective without supplementary treatment.",
       "aliases": [
-          "RS113488022",
-          "VAL600GLU",
-          "V640E",
-          "VAL640GLU"
+        "RS113488022",
+        "VAL600GLU",
+        "V640E",
+        "VAL640GLU"
       ],
       "sources": []
     }

--- a/tests/data/transform/therapeutic/civic_harvester.json
+++ b/tests/data/transform/therapeutic/civic_harvester.json
@@ -548,25 +548,33 @@
       "type": "molecular_profile",
       "id": 33,
       "variant_ids": [
-        33
+          33
       ],
       "name": "EGFR L858R",
-      "molecular_profile_score": 378.0,
+      "molecular_profile_score": 379.0,
       "description": "EGFR L858R has long been recognized as a functionally significant mutation in cancer, and is one of the most prevalent single mutations in lung cancer. Best described in non-small cell lung cancer (NSCLC), the mutation seems to confer sensitivity to first and second generation TKI's like gefitinib and neratinib. NSCLC patients with this mutation treated with TKI's show increased overall and progression-free survival, as compared to chemotherapy alone. Third generation TKI's are currently in clinical trials that specifically focus on mutant forms of EGFR, a few of which have shown efficacy in treating patients that failed to respond to earlier generation TKI therapies.",
-      "sources": [],
-      "aliases": []
+      "aliases": [
+          "LEU858ARG",
+          "RS121434568"
+      ],
+      "sources": []
     },
     {
       "type": "molecular_profile",
       "id": 12,
       "variant_ids": [
-        12
+          12
       ],
       "name": "BRAF V600E",
       "molecular_profile_score": 1353.5,
       "description": "BRAF V600E has been shown to be recurrent in many cancer types. It is one of the most widely studied variants in cancer. This variant is correlated with poor prognosis in certain cancer types, including colorectal cancer and papillary thyroid cancer. The targeted therapeutic dabrafenib has been shown to be effective in clinical trials with an array of BRAF mutations and cancer types. Dabrafenib has also shown to be effective when combined with the MEK inhibitor trametinib in colorectal cancer and melanoma. However, in patients with TP53, CDKN2A and KRAS mutations, dabrafenib resistance has been reported. Ipilimumab, regorafenib, vemurafenib, and a number of combination therapies have been successful in treating V600E mutations. However, cetuximab and panitumumab have been largely shown to be ineffective without supplementary treatment.",
-      "sources": [],
-      "aliases": []
+      "aliases": [
+          "RS113488022",
+          "VAL600GLU",
+          "V640E",
+          "VAL640GLU"
+      ],
+      "sources": []
     }
   ]
 }


### PR DESCRIPTION
Addresses #254 for molecular profiles. Note to self: check to see if test data is incomplete/outdated 🤦‍♀️ 

* 58ec1b210 resolved for variants, but not molecular profiles. The test data was outdated