### PR TITLE
cicd: fix elastic beanstalk deployment

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-web: gunicorn -k uvicorn.workers.UvicornWorker metakb.main:app --timeout 1000 --log-level debug
+web: cd src && gunicorn -k uvicorn.workers.UvicornWorker metakb.main:app --timeout 1000 --log-level debug


### PR DESCRIPTION
Elastic beanstalk deployment was failing due to this

* Procfile command updated for new src layout