### PR TITLE
fix: replace `StrEnum` with `Enum`

### DIFF
--- a/src/metakb/schemas/annotation.py
+++ b/src/metakb/schemas/annotation.py
@@ -1,13 +1,13 @@
 """Module containing GK pilot annotation definitions"""
 import datetime
-from enum import StrEnum
+from enum import Enum
 from typing import Dict, List, Literal, Optional, Union
 
 from ga4gh.core import core_models
 from pydantic import Field, StrictInt, StrictStr, constr, field_validator
 
 
-class AgentSubtype(StrEnum):
+class AgentSubtype(str, Enum):
     """Define constraints for agent subtype"""
 
     PERSON = "person"
@@ -15,7 +15,7 @@ class AgentSubtype(StrEnum):
     COMPUTER = "computer"
 
 
-class Direction(StrEnum):
+class Direction(str, Enum):
     """Define constraints for direction"""
 
     SUPPORTS = "supports"

--- a/src/metakb/schemas/app.py
+++ b/src/metakb/schemas/app.py
@@ -1,8 +1,8 @@
 """Module containing app schemas and enums"""
-from enum import StrEnum
+from enum import Enum
 
 
-class SourceName(StrEnum):
+class SourceName(str, Enum):
     """Define enum for sources that are supported"""
 
     CIVIC = "civic"

--- a/src/metakb/schemas/categorical_variation.py
+++ b/src/metakb/schemas/categorical_variation.py
@@ -1,5 +1,5 @@
 """Module containing GA4GH categorical variation definitions"""
-from enum import StrEnum
+from enum import Enum
 from typing import List, Literal, Optional, Union
 
 from ga4gh.core import core_models
@@ -7,7 +7,7 @@ from ga4gh.vrs import models
 from pydantic import Field, RootModel, StrictStr
 
 
-class LocationMatchCharacteristic(StrEnum):
+class LocationMatchCharacteristic(str, Enum):
     """The characteristics of a valid match between a contextual CNV location (the
     query) and the Categorical CNV location (the domain), when both query and domain are
     represented on the same  reference sequence. An `exact` match requires the location

--- a/src/metakb/schemas/variation_statement.py
+++ b/src/metakb/schemas/variation_statement.py
@@ -1,5 +1,5 @@
 """Module containing variant statement definitions"""
-from enum import StrEnum
+from enum import Enum
 from typing import List, Literal, Optional, Union
 
 from ga4gh.core import core_models
@@ -10,7 +10,7 @@ from metakb.schemas.annotation import Document, _StatementBase
 from metakb.schemas.categorical_variation import CategoricalVariation
 
 
-class Penetrance(StrEnum):
+class Penetrance(str, Enum):
     """The extent to which the variant impact is expressed by individuals carrying it as
     a measure of the proportion of carriers exhibiting the condition.
     """
@@ -20,7 +20,7 @@ class Penetrance(StrEnum):
     RISK_ALLELE = "risk allele"
 
 
-class ModeOfInheritance(StrEnum):
+class ModeOfInheritance(str, Enum):
     """The pattern of inheritance expected for the pathogenic effect of this variant."""
 
     AUTOSOMAL_DOMINANT = "autosomal dominant"
@@ -30,7 +30,7 @@ class ModeOfInheritance(StrEnum):
     MITOCHONDRIAL = "mitochondrial"
 
 
-class VariantOncogenicityStudyPredicate(StrEnum):
+class VariantOncogenicityStudyPredicate(str, Enum):
     """Define constraints for Variant Oncogenicity Study predicate"""
 
     IS_ONCOGENIC_FOR = "isOncogenicFor"
@@ -38,7 +38,7 @@ class VariantOncogenicityStudyPredicate(StrEnum):
     IS_PREDISPOSING_FOR = "isPredisposingFor"
 
 
-class AlleleOrigin(StrEnum):
+class AlleleOrigin(str, Enum):
     """Whether the statement should be interpreted in the context of an inherited
     (germline) variant, an acquired (somatic) mutation, or both (combined).
     """
@@ -48,7 +48,7 @@ class AlleleOrigin(StrEnum):
     COMBINED = "combined"
 
 
-class AllelePrevalence(StrEnum):
+class AllelePrevalence(str, Enum):
     """Whether the statement should be interpreted in the context of the variant being
     rare or common.
     """
@@ -57,7 +57,7 @@ class AllelePrevalence(StrEnum):
     COMMON = "common"
 
 
-class VariantTherapeuticResponseStudyPredicate(StrEnum):
+class VariantTherapeuticResponseStudyPredicate(str, Enum):
     """Predicate for Variant Therapeutic Response Study"""
 
     PREDICTS_SENSITIVITY_TO = "predictsSensitivityTo"

--- a/src/metakb/transform/base.py
+++ b/src/metakb/transform/base.py
@@ -3,7 +3,7 @@ import datetime
 import json
 import logging
 from abc import abstractmethod
-from enum import StrEnum
+from enum import Enum
 from pathlib import Path
 from typing import ClassVar, Dict, List, Optional, Set, Union
 
@@ -24,21 +24,21 @@ from metakb.schemas.annotation import Document, Method
 logger = logging.getLogger(__name__)
 
 
-class EcoLevel(StrEnum):
+class EcoLevel(str, Enum):
     """Define constraints for Evidence Ontology levels"""
 
     EVIDENCE = "ECO:0000000"
     CLINICAL_STUDY_EVIDENCE = "ECO:0000180"
 
 
-class MethodId(StrEnum):
+class MethodId(str, Enum):
     """Create method id constants"""
 
     CIVIC_EID_SOP = "civic.method:2019"
     MOA_ASSERTION_BIORXIV = "moa.method:2021"
 
 
-class CivicEvidenceLevel(StrEnum):
+class CivicEvidenceLevel(str, Enum):
     """Define constraints for CIViC evidence levels"""
 
     A = "civic.evidence_level:A"
@@ -48,7 +48,7 @@ class CivicEvidenceLevel(StrEnum):
     E = "civic.evidence_level:E"
 
 
-class MoaEvidenceLevel(StrEnum):
+class MoaEvidenceLevel(str, Enum):
     """Define constraints MOAlmanac evidence levels"""
 
     FDA_APPROVED = "moa.evidence_level:fda_approved"
@@ -59,7 +59,7 @@ class MoaEvidenceLevel(StrEnum):
     INFERENTIAL = "moa.evidence_level:inferential_evidence"
 
 
-class TherapeuticProcedureType(StrEnum):
+class TherapeuticProcedureType(str, Enum):
     """Define types for supported Therapeutic Procedures"""
 
     THERAPEUTIC_AGENT = "TherapeuticAgent"


### PR DESCRIPTION
close #301 

* `StrEnum` was introduced in Python 3.11 but MetaKB supports Python >= 3.8