### PR TITLE
build: fix pipenv build

### DIFF
--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -31,7 +31,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          python -m pip install pipenv
+          python -m pip install pipenv==2023.12.1
           pipenv install --skip-lock  # this is what Elastic beanstalk uses
   lint:
     name: lint

--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -31,7 +31,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          python -m pip install pipenv==2023.12.1
+          python -m pip install pipenv
           pipenv install --skip-lock  # this is what Elastic beanstalk uses
   lint:
     name: lint


### PR DESCRIPTION
close #350 

wellllll AWS currently uses pipenv version 2023.12.1 so pinning it doesn't seem like it's totally cheating https://docs.aws.amazon.com/elasticbeanstalk/latest/platforms/platforms-supported.html#platforms-supported.python

but I'm not able to even reproduce the github actions error locally so I'm not totally sure how to durably fix it