### PR TITLE
fix: don't use deprecated graph driver destructor

### DIFF
--- a/src/metakb/cli.py
+++ b/src/metakb/cli.py
@@ -448,7 +448,6 @@ def load_cdm(
 
             graph.load_from_json(path)
 
-    graph.close()
     end = timer()
     _echo_info(f"Successfully loaded neo4j database in {(end - start):.5f} s")
 

--- a/src/metakb/cli.py
+++ b/src/metakb/cli.py
@@ -5,6 +5,7 @@ import datetime
 import logging
 import re
 import tempfile
+from collections.abc import Generator
 from enum import Enum
 from pathlib import Path
 from timeit import default_timer as timer
@@ -325,7 +326,7 @@ async def transform_file(
     )
 
 
-def _get_graph(db_url: str, db_creds: str | None) -> Graph:
+def _get_graph(db_url: str, db_creds: str | None) -> Generator[Graph, None, None]:
     """Acquire Neo4j graph.
 
     :param db_url: URL endpoint for the application Neo4j database.
@@ -343,7 +344,9 @@ def _get_graph(db_url: str, db_creds: str | None) -> Graph:
             _help_msg(
                 f"Argument to --db_credentialss appears invalid. Got '{db_creds}'. Should follow pattern 'username:password'."
             )
-    return Graph(uri=db_url, credentials=credentials)
+    graph = Graph(uri=db_url, credentials=credentials)
+    yield graph
+    graph.close()
 
 
 @cli.command()
@@ -366,9 +369,9 @@ def clear_graph(db_url: str, db_credentials: str | None) -> None:
     :param db_credentials: DB username and password, separated by a colon, e.g.
         ``"username:password"``.
     """  # noqa: D301
-    graph = _get_graph(db_url, db_credentials)
+    graph = next(_get_graph(db_url, db_credentials))
     graph.clear()
-    graph.close()
+    # graph.close()
 
 
 @cli.command()
@@ -426,7 +429,7 @@ def load_cdm(
     start = timer()
     _echo_info("Loading Neo4j database...")
 
-    graph = _get_graph(db_url, db_credentials)
+    graph = next(_get_graph(db_url, db_credentials))
 
     if cdm_files:
         for file in cdm_files:
@@ -514,7 +517,7 @@ async def update(
     start = timer()
     _echo_info("Loading Neo4j database...")
 
-    graph = _get_graph(db_url, db_credentials)
+    graph = next(_get_graph(db_url, db_credentials))
 
     if not sources:
         sources = tuple(SourceName)

--- a/src/metakb/cli.py
+++ b/src/metakb/cli.py
@@ -371,7 +371,6 @@ def clear_graph(db_url: str, db_credentials: str | None) -> None:
     """  # noqa: D301
     graph = next(_get_graph(db_url, db_credentials))
     graph.clear()
-    # graph.close()
 
 
 @cli.command()

--- a/src/metakb/main.py
+++ b/src/metakb/main.py
@@ -9,6 +9,8 @@ from metakb.log_handle import configure_logs
 from metakb.query import QueryHandler
 from metakb.version import __version__
 
+query = QueryHandler()
+
 
 @asynccontextmanager
 async def lifespan(app: FastAPI) -> AsyncGenerator:
@@ -19,6 +21,7 @@ async def lifespan(app: FastAPI) -> AsyncGenerator:
     """
     configure_logs()
     yield
+    query.driver.close()
 
 
 app = FastAPI(
@@ -27,7 +30,6 @@ app = FastAPI(
     swagger_ui_parameters={"tryItOutEnabled": True},
     lifespan=lifespan,
 )
-query = QueryHandler()
 
 
 def custom_openapi() -> dict:

--- a/tests/unit/test_search_studies.py
+++ b/tests/unit/test_search_studies.py
@@ -9,7 +9,9 @@ from metakb.schemas.api import SearchStudiesService
 @pytest.fixture(scope="module")
 def query_handler(normalizers):
     """Create query handler test fixture"""
-    return QueryHandler(normalizers=normalizers)
+    qh = QueryHandler(normalizers=normalizers)
+    yield qh
+    qh.driver.close()
 
 
 def assert_general_search_studies(response):


### PR DESCRIPTION
close #278 

I have some broader in-progress changes occuring under the mantle of #357 but for now I think it'd be better to just make the quick fix -- the reason we were seeing this warning was because one of our tests wasn't properly closing the graph