### PR TITLE
feat: add batch search by variations

### DIFF
--- a/src/metakb/main.py
+++ b/src/metakb/main.py
@@ -102,7 +102,6 @@ async def get_studies(
 
 _batch_search_studies_descr = {
     "summary": "Get nested studies for all provided variations.",
-    "response_description": "todo",
     "description": "Return nested studies associated with any of the provided variations.",
     "arg_variations": "Variations (subject) to search. Can be free text or VRS variation ID.",
 }

--- a/src/metakb/main.py
+++ b/src/metakb/main.py
@@ -117,7 +117,7 @@ async def batch_get_studies(
         None, description=_batch_search_studies_descr["arg_variations"]
     ),
 ) -> dict:
-    """Fetch all studies associated with the provided variations.
+    """Fetch all studies associated with `any` of the provided variations.
 
     :param variations: variations to match against
     :return: batch response object

--- a/src/metakb/main.py
+++ b/src/metakb/main.py
@@ -98,3 +98,30 @@ async def get_studies(
     """
     resp = await query.search_studies(variation, disease, therapy, gene, study_id)
     return resp.model_dump(exclude_none=True)
+
+
+_batch_search_studies_descr = {
+    "summary": "Get nested studies for all provided variations.",
+    "response_description": "todo",
+    "description": "Return nested studies associated with any of the provided variations.",
+    "arg_variations": "Variations (subject) to search. Can be free text or VRS variation ID.",
+}
+
+
+@app.get(
+    "/api/v2/batch_search/studies",
+    summary=_batch_search_studies_descr["summary"],
+    description=_batch_search_studies_descr["description"],
+)
+async def batch_get_studies(
+    variations: list[str] | None = Query(  # noqa: B008
+        None, description=_batch_search_studies_descr["arg_variations"]
+    ),
+) -> dict:
+    """Fetch all studies associated with the provided variations.
+
+    :param variations: variations to match against
+    :return: batch response object
+    """
+    response = await query.batch_search_studies(variations)
+    return response.model_dump(exclude_none=True)

--- a/src/metakb/query.py
+++ b/src/metakb/query.py
@@ -719,10 +719,25 @@ class QueryHandler:
         self,
         variations: list[str] | None = None,
     ) -> BatchSearchStudiesService:
-        """Fetch all studies associated with the provided variation description strings.
+        """Fetch all studies associated with any of the provided variation description
+        strings.
 
         Because this method could be expanded to include other kinds of search terms,
         ``variations`` is optionally nullable.
+
+        >>> from metakb.query import QueryHandler
+        >>> qh = QueryHandler()
+        >>> response = await qh.batch_search_studies(["EGFR L858R"])
+        >>> response.study_ids[:3]
+        ['civic.eid:229', 'civic.eid:3811', 'moa.assertion:268']
+
+        All terms are normalized, so redundant terms don't alter search results:
+
+        >>> redundant_response = await qh.batch_search_studies(
+        ...     ["EGFR L858R", "NP_005219.2:p.Leu858Arg"]
+        ... )
+        >>> len(response.study_ids) == len(redundant_response.study_ids)
+        True
 
         :param variations: a list of variation description strings, e.g.
             ``["BRAF V600E"]``

--- a/src/metakb/query.py
+++ b/src/metakb/query.py
@@ -89,54 +89,6 @@ class QueryHandler:
         self.driver = Graph(uri, creds).driver
         self.vicc_normalizers = normalizers
 
-    async def batch_search_studies(
-        self,
-        variations: list[str] | None = None,
-    ) -> BatchSearchStudiesService:
-        """Fetch all studies associated with the provided variation description strings.
-
-        Because this method could be expanded to include other kinds of search terms,
-        ``variations`` is optionally nullable.
-
-        :param variations: a list of variation description strings, e.g.
-            ``["BRAF V600E"]``
-        :return: response object including all matching studies
-        """
-        response = BatchSearchStudiesService(
-            query=BatchSearchStudiesQuery(variations=variations or []),
-            service_meta_=ServiceMeta(),
-            warnings=[],
-        )
-        if not variations:
-            response.warnings.append("No search terms provided.")
-            return response
-
-        variation_ids = []
-        if variations:
-            for query_variation in variations:
-                variation_id = await self._get_normalized_variation(
-                    query_variation, response.warnings
-                )
-                if variation_id:
-                    variation_ids.append(variation_id)
-        if not variation_ids:
-            response.warnings.append("Unable to normalize any provided query terms.")
-            return response
-
-        with self.driver.session() as session:
-            query = """
-                MATCH (s) -[:HAS_VARIANT] -> (cv:CategoricalVariation)
-                MATCH (cv) -[:HAS_DEFINING_CONTEXT|:HAS_MEMBERS] -> (v:Variation)
-                WHERE v.id IN $v_ids
-                RETURN s
-            """
-            result = session.run(query, v_ids=variation_ids)
-            study_nodes = [r[0] for r in result]
-            response.study_ids = [n["id"] for n in study_nodes]
-            studies = self._get_nested_studies(session, study_nodes)
-            response.studies = [VariantTherapeuticResponseStudy(**s) for s in studies]
-        return response
-
     async def search_studies(
         self,
         variation: str | None = None,
@@ -761,3 +713,51 @@ class QueryHandler:
 
         ta_params["extensions"] = extensions
         return TherapeuticAgent(**ta_params)
+
+    async def batch_search_studies(
+        self,
+        variations: list[str] | None = None,
+    ) -> BatchSearchStudiesService:
+        """Fetch all studies associated with the provided variation description strings.
+
+        Because this method could be expanded to include other kinds of search terms,
+        ``variations`` is optionally nullable.
+
+        :param variations: a list of variation description strings, e.g.
+            ``["BRAF V600E"]``
+        :return: response object including all matching studies
+        """
+        response = BatchSearchStudiesService(
+            query=BatchSearchStudiesQuery(variations=variations or []),
+            service_meta_=ServiceMeta(),
+            warnings=[],
+        )
+        if not variations:
+            response.warnings.append("No search terms provided.")
+            return response
+
+        variation_ids = []
+        for query_variation in variations:
+            variation_id = await self._get_normalized_variation(
+                query_variation, response.warnings
+            )
+            if variation_id:
+                variation_ids.append(variation_id)
+        if not variation_ids:
+            response.warnings.append("Unable to normalize any provided query terms.")
+            return response
+        variation_ids = list(set(variation_ids))
+
+        with self.driver.session() as session:
+            query = """
+                MATCH (s) -[:HAS_VARIANT] -> (cv:CategoricalVariation)
+                MATCH (cv) -[:HAS_DEFINING_CONTEXT|HAS_MEMBERS] -> (v:Variation)
+                WHERE v.id IN $v_ids
+                RETURN s
+            """
+            result = session.run(query, v_ids=variation_ids)
+            study_nodes = [r[0] for r in result]
+            response.study_ids = list({n["id"] for n in study_nodes})
+            studies = self._get_nested_studies(session, study_nodes)
+            response.studies = [VariantTherapeuticResponseStudy(**s) for s in studies]
+        return response

--- a/src/metakb/query.py
+++ b/src/metakb/query.py
@@ -751,7 +751,7 @@ class QueryHandler:
         if not variations:
             return response
 
-        for query_variation in variations:
+        for query_variation in set(variations):
             variation_id = await self._get_normalized_variation(
                 query_variation, response.warnings
             )

--- a/src/metakb/schemas/api.py
+++ b/src/metakb/schemas/api.py
@@ -45,3 +45,19 @@ class SearchStudiesService(BaseModel):
     study_ids: list[StrictStr] = []
     studies: list[VariantTherapeuticResponseStudy] = []
     service_meta_: ServiceMeta
+
+
+class BatchSearchStudiesQuery(BaseModel):
+    """Define query as reported in batch search studies endpoint."""
+
+    variations: list[StrictStr] = []
+
+
+class BatchSearchStudiesService(BaseModel):
+    """Define response model for batch search studies endpoint response."""
+
+    query: BatchSearchStudiesQuery
+    warnings: list[StrictStr] = []
+    study_ids: list[StrictStr] = []
+    studies: list[VariantTherapeuticResponseStudy] = []
+    service_meta_: ServiceMeta

--- a/src/metakb/schemas/api.py
+++ b/src/metakb/schemas/api.py
@@ -47,10 +47,17 @@ class SearchStudiesService(BaseModel):
     service_meta_: ServiceMeta
 
 
+class NormalizedQuery(BaseModel):
+    """Define structure of user-provided query. If possible, add normalized ID."""
+
+    term: StrictStr
+    normalized_id: StrictStr | None = None
+
+
 class BatchSearchStudiesQuery(BaseModel):
     """Define query as reported in batch search studies endpoint."""
 
-    variations: list[StrictStr] = []
+    variations: list[NormalizedQuery] = []
 
 
 class BatchSearchStudiesService(BaseModel):

--- a/tests/unit/test_search_studies.py
+++ b/tests/unit/test_search_studies.py
@@ -3,7 +3,11 @@
 import pytest
 
 from metakb.query import QueryHandler
-from metakb.schemas.api import SearchStudiesService
+from metakb.schemas.api import (
+    BatchSearchStudiesService,
+    NormalizedQuery,
+    SearchStudiesService,
+)
 
 
 @pytest.fixture(scope="module")
@@ -30,7 +34,7 @@ def assert_no_match(response):
 
 
 def find_and_check_study(
-    resp: SearchStudiesService,
+    resp: SearchStudiesService | BatchSearchStudiesService,
     expected_study: dict,
     assertion_checks: callable,
     should_find_match: bool = True,
@@ -223,24 +227,45 @@ async def test_no_matches(query_handler):
 
 
 @pytest.mark.asyncio(scope="module")
-async def test_batch_search(query_handler: QueryHandler):
+async def test_batch_search(
+    query_handler: QueryHandler,
+    assertion_checks,
+    civic_eid2997_study,
+    civic_eid816_study,
+):
     """Test batch search studies method."""
     assert_no_match(await query_handler.batch_search_studies([]))
     assert_no_match(await query_handler.batch_search_studies(["gibberish variant"]))
 
-    braf_response = await query_handler.batch_search_studies(
-        ["ga4gh:VA.Otc5ovrw906Ack087o1fhegB4jDRqCAe"]
-    )
-    assert braf_response.warnings == []
+    braf_va_id = "ga4gh:VA.Otc5ovrw906Ack087o1fhegB4jDRqCAe"
+    braf_response = await query_handler.batch_search_studies([braf_va_id])
+    assert braf_response.query.variations == [
+        NormalizedQuery(
+            term=braf_va_id,
+            normalized_id=braf_va_id,
+        )
+    ]
+    find_and_check_study(braf_response, civic_eid816_study, assertion_checks)
 
     redundant_braf_response = await query_handler.batch_search_studies(
-        ["ga4gh:VA.Otc5ovrw906Ack087o1fhegB4jDRqCAe", "BRAF V600E"]
+        [braf_va_id, "NC_000007.13:g.140453136A>T"]
     )
-    assert braf_response.warnings == []
+    assert redundant_braf_response.query.variations == [
+        NormalizedQuery(
+            term=braf_va_id,
+            normalized_id=braf_va_id,
+        ),
+        NormalizedQuery(
+            term="NC_000007.13:g.140453136A>T",
+            normalized_id=braf_va_id,
+        ),
+    ]
+    find_and_check_study(redundant_braf_response, civic_eid816_study, assertion_checks)
     assert len(braf_response.study_ids) == len(redundant_braf_response.study_ids)
 
     braf_egfr_response = await query_handler.batch_search_studies(
-        ["ga4gh:VA.Otc5ovrw906Ack087o1fhegB4jDRqCAe", "EGFR L858R"]
+        [braf_va_id, "EGFR L858R"]
     )
-    assert braf_response.warnings == []
+    find_and_check_study(braf_egfr_response, civic_eid816_study, assertion_checks)
+    find_and_check_study(braf_egfr_response, civic_eid2997_study, assertion_checks)
     assert len(braf_egfr_response.study_ids) > len(braf_response.study_ids)

--- a/tests/unit/test_search_studies.py
+++ b/tests/unit/test_search_studies.py
@@ -220,3 +220,27 @@ async def test_no_matches(query_handler):
     # valid queries, but no matches with combination
     resp = await query_handler.search_studies(variation="BRAF V600E", gene="EGFR")
     assert_no_match(resp)
+
+
+@pytest.mark.asyncio(scope="module")
+async def test_batch_search(query_handler: QueryHandler):
+    """Test batch search studies method."""
+    assert_no_match(await query_handler.batch_search_studies([]))
+    assert_no_match(await query_handler.batch_search_studies(["gibberish variant"]))
+
+    braf_response = await query_handler.batch_search_studies(
+        ["ga4gh:VA.Otc5ovrw906Ack087o1fhegB4jDRqCAe"]
+    )
+    assert braf_response.warnings == []
+
+    redundant_braf_response = await query_handler.batch_search_studies(
+        ["ga4gh:VA.Otc5ovrw906Ack087o1fhegB4jDRqCAe", "BRAF V600E"]
+    )
+    assert braf_response.warnings == []
+    assert len(braf_response.study_ids) == len(redundant_braf_response.study_ids)
+
+    braf_egfr_response = await query_handler.batch_search_studies(
+        ["ga4gh:VA.Otc5ovrw906Ack087o1fhegB4jDRqCAe", "EGFR L858R"]
+    )
+    assert braf_response.warnings == []
+    assert len(braf_egfr_response.study_ids) > len(braf_response.study_ids)


### PR DESCRIPTION
close #290 

Current use case is variations only (e.g. in the context of a VCF), but the objects/API are structured in such a way to (relatively) smoothly accommodate other kinds of terms*.

Very naively implemented. Tune-ups in #311 should include fetching everything in a single query rather than iteratively getting every study once study IDs are acquired. I also wonder if there's anything else we can do cache-wise to optimize for those cases where a user is performing repeated lookups on things that are probably pretty closely located in the genome, such as VCFs (seqrepo already uses a big LRU cache for sequence lookups so that might be all that's necessary)

The ability to submit multiple terms for the same kind of entity raises questions about transparent management of redundancy, failed lookups, etc. I added an extra field to supply the normalized ID, if available, for each term, so that the client can tell if terms are normalizing to the same ID or if they fail to normalize at all:

```JSON
  "query": {
    "variations": [
      {
        "term": "EGFR L858R",
        "normalized_id": "ga4gh:VA.S41CcMJT2bcd8R4-qXZWH1PoHWNtG2PZ"
      },
      {
        "term": "matthew cannon 2"
      },
      {
        "term": "ga4gh:VA.S41CcMJT2bcd8R4-qXZWH1PoHWNtG2PZ",
        "normalized_id": "ga4gh:VA.S41CcMJT2bcd8R4-qXZWH1PoHWNtG2PZ"
      }
    ]
  }
```

This also makes it possible to understand which studies correspond to each search term.

* Caveat about including other kinds of entities: I can understand why we'd want it, but it potentially makes search very weird. Say you search for drug A, drug B, variation A, and variation B. Do you just include any study that includes any of those terms? (I don't know what the use case for that is, but I think it's the most intuitive result). Or do you just include studies that include variation A + drug A or drug B, or variation B + drug A or drug B? (actually a pretty reasonable thing to search for, but a bit counterintuitive to frame). 
* A note about response structure. As a first pass, I made it consistent with `get_search_studies` -- `response.studies` is just a list of studies. If you wanted to figure out which ones came from a given search term, you could take the normalized ID from `response.queries` and then filter through `response.studies` based on the value in `study.variant.definingContext.id` (for ProteinSequenceConsequences, or something else for CategoricalVariations). Alternatively, you could group `response.studies` into a dict where the key is the normalized ID and the value is the list of studies for that ID. However, that becomes VERY messy if you *do* want to support searching by multiple entity types (what would the key be, a concatenated string or something?). 