### PR TITLE
refactor: use updated annotation API

### DIFF
--- a/src/metakb/main.py
+++ b/src/metakb/main.py
@@ -1,6 +1,7 @@
 """Main application for FastAPI."""
 from collections.abc import AsyncGenerator
 from contextlib import asynccontextmanager
+from typing import Annotated
 
 from fastapi import FastAPI, Query
 from fastapi.openapi.utils import get_openapi
@@ -78,11 +79,11 @@ search_study_response_descr = "A response to a validly-formed query."
     description=search_studies_descr,
 )
 async def get_studies(
-    variation: str | None = Query(None, description=v_description),
-    disease: str | None = Query(None, description=d_description),
-    therapy: str | None = Query(None, description=t_description),
-    gene: str | None = Query(None, description=g_description),
-    study_id: str | None = Query(None, description=s_description),
+    variation: Annotated[str | None, Query(description=v_description)] = None,
+    disease: Annotated[str | None, Query(description=d_description)] = None,
+    therapy: Annotated[str | None, Query(description=t_description)] = None,
+    gene: Annotated[str | None, Query(description=g_description)] = None,
+    study_id: Annotated[str | None, Query(description=s_description)] = None,
 ) -> dict:
     """Get nested studies from queried concepts that match all conditions provided.
     For example, if `variation` and `therapy` are provided, will return all studies
@@ -113,9 +114,7 @@ _batch_search_studies_descr = {
     description=_batch_search_studies_descr["description"],
 )
 async def batch_get_studies(
-    variations: list[str] | None = Query(  # noqa: B008
-        None, description=_batch_search_studies_descr["arg_variations"]
-    ),
+    variations: Annotated[list[str] | None, Query(description=_batch_search_studies_descr["arg_variations"])] = None
 ) -> dict:
     """Fetch all studies associated with `any` of the provided variations.
 


### PR DESCRIPTION
apparently [this is the way you're supposed to do it now](https://fastapi.tiangolo.com/tutorial/query-params-str-validations/#use-annotated-in-the-type-for-the-q-parameter)