### PR TITLE
build: temporarily pin ga4gh.vrs==2.0.0a6

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -4,7 +4,7 @@ verify_ssl = true
 name = "pypi"
 
 [packages]
-"ga4gh.vrs" = "~=2.0.0a5"
+"ga4gh.vrs" = "==2.0.0a6"
 gene-normalizer = {version = "~=0.3.0-dev1", extras = ["etl"]}
 variation-normalizer = "~=0.8.2"
 disease-normalizer = {version = "~=0.4.0.dev3", extras = ["etl"]}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ requires-python = ">=3.10"
 description = "A search interface for cancer variant interpretations assembled by aggregating and harmonizing across multiple cancer variant interpretation knowledgebases."
 license = {file = "LICENSE"}
 dependencies = [
-    "ga4gh.vrs~=2.0.0a5",
+    "ga4gh.vrs==2.0.0a6",
     "gene-normalizer[etl]~=0.3.0-dev1",
     "variation-normalizer~=0.8.2",
     "disease-normalizer[etl]~=0.4.0.dev3",


### PR DESCRIPTION
* Variation Normalizer has not been updated yet with these changes. Temp pin until a new release is made