### PR TITLE
refactor!: remove `extract_harvester` from `transform` method

### DIFF
--- a/src/metakb/cli.py
+++ b/src/metakb/cli.py
@@ -617,7 +617,7 @@ async def _transform_source(
     transformer: CivicTransform | MoaTransform = transform_sources[source](
         normalizers=normalizer_handler, harvester_path=harvest_file
     )
-    harvested_data = transformer.extract_harvester()
+    harvested_data = transformer.extract_harvested_data()
     await transformer.transform(harvested_data)
     end = timer()
     _echo_info(f"{source.as_print_case()} transform finished in {(end - start):.2f} s.")

--- a/src/metakb/cli.py
+++ b/src/metakb/cli.py
@@ -617,7 +617,8 @@ async def _transform_source(
     transformer: CivicTransform | MoaTransform = transform_sources[source](
         normalizers=normalizer_handler, harvester_path=harvest_file
     )
-    await transformer.transform()
+    harvested_data = transformer.extract_harvester()
+    await transformer.transform(harvested_data)
     end = timer()
     _echo_info(f"{source.as_print_case()} transform finished in {(end - start):.2f} s.")
     output_file = (

--- a/src/metakb/harvesters/base.py
+++ b/src/metakb/harvesters/base.py
@@ -17,6 +17,28 @@ class _HarvestedData(BaseModel):
 
     variants: list[dict]
 
+    @classmethod
+    def get_subclass_by_prefix(
+        cls: type["_HarvestedData"], prefix: str
+    ) -> type["_HarvestedData"]:
+        """Get subclass whose name starts with provided prefix
+
+        :param prefix: Prefix to search for in subclass names
+        :raises ValueError: If no subclasses defined or if no subclass found with prefix
+        :return: Matching subclass with given prefix, if found
+        """
+        subclasses = cls.__subclasses__()
+        if not subclasses:
+            msg = "No subclasses have been defined"
+            raise ValueError(msg)
+
+        for subclass in subclasses:
+            if subclass.__name__.lower().startswith(prefix):
+                return subclass
+
+        msg = f"No subclass starting with '{prefix}' found"
+        raise ValueError(msg)
+
 
 class Harvester(ABC):
     """A base class for content harvesters."""

--- a/src/metakb/transform/base.py
+++ b/src/metakb/transform/base.py
@@ -250,7 +250,7 @@ class Transform(ABC):
         :param harvested_data: Source harvested data
         """
 
-    def extract_harvester(self) -> _HarvestedData:
+    def extract_harvested_data(self) -> _HarvestedData:
         """Get harvested data from file.
 
         :return: Harvested data

--- a/src/metakb/transform/moa.py
+++ b/src/metakb/transform/moa.py
@@ -18,6 +18,7 @@ from ga4gh.core._internal.models import (
 from ga4gh.vrs import models
 
 from metakb import APP_ROOT
+from metakb.harvesters.moa import MoaHarvestedData
 from metakb.normalizers import ViccNormalizers
 from metakb.schemas.annotation import Direction, Document
 from metakb.schemas.categorical_variation import ProteinSequenceConsequence
@@ -66,20 +67,20 @@ class MoaTransform(Transform):
             "documents": {},
         }
 
-    async def transform(self) -> None:
+    async def transform(self, harvested_data: MoaHarvestedData) -> None:
         """Transform MOA harvested JSON to common data model. Will store transformed
         results in instance variables.
-        """
-        data = self.extract_harvester()
 
+        :param harvested_data: MOA harvested data
+        """
         # Add gene, variant, and source data to instance variables (`genes`,
         # `variations`, and `documents`)
-        self._add_genes(data["genes"])
-        await self._add_protein_consequences(data["variants"])
-        self._add_documents(data["sources"])
+        self._add_genes(harvested_data.genes)
+        await self._add_protein_consequences(harvested_data.variants)
+        self._add_documents(harvested_data.sources)
 
         # Add variant therapeutic response study data. Will update `studies`
-        await self._add_variant_therapeutic_response_studies(data["assertions"])
+        await self._add_variant_therapeutic_response_studies(harvested_data.assertions)
 
     async def _add_variant_therapeutic_response_studies(
         self, assertions: list[dict]

--- a/tests/unit/transform/test_civic_transform_therapeutic.py
+++ b/tests/unit/transform/test_civic_transform_therapeutic.py
@@ -18,7 +18,8 @@ async def data(normalizers):
     c = CivicTransform(
         data_dir=DATA_DIR, harvester_path=harvester_path, normalizers=normalizers
     )
-    await c.transform()
+    harvested_data = c.extract_harvester()
+    await c.transform(harvested_data)
     c.create_json(DATA_DIR / FILENAME)
     with (DATA_DIR / FILENAME).open() as f:
         return json.load(f)

--- a/tests/unit/transform/test_civic_transform_therapeutic.py
+++ b/tests/unit/transform/test_civic_transform_therapeutic.py
@@ -18,7 +18,7 @@ async def data(normalizers):
     c = CivicTransform(
         data_dir=DATA_DIR, harvester_path=harvester_path, normalizers=normalizers
     )
-    harvested_data = c.extract_harvester()
+    harvested_data = c.extract_harvested_data()
     await c.transform(harvested_data)
     c.create_json(DATA_DIR / FILENAME)
     with (DATA_DIR / FILENAME).open() as f:

--- a/tests/unit/transform/test_moa_transform.py
+++ b/tests/unit/transform/test_moa_transform.py
@@ -19,7 +19,7 @@ async def data(normalizers):
         harvester_path=harvester_path,
         normalizers=normalizers,
     )
-    harvested_data = moa.extract_harvester()
+    harvested_data = moa.extract_harvested_data()
     await moa.transform(harvested_data)
     moa.create_json(cdm_filepath=TEST_TRANSFORM_DIR / FILENAME)
     with (TEST_TRANSFORM_DIR / FILENAME).open() as f:

--- a/tests/unit/transform/test_moa_transform.py
+++ b/tests/unit/transform/test_moa_transform.py
@@ -19,7 +19,8 @@ async def data(normalizers):
         harvester_path=harvester_path,
         normalizers=normalizers,
     )
-    await moa.transform()
+    harvested_data = moa.extract_harvester()
+    await moa.transform(harvested_data)
     moa.create_json(cdm_filepath=TEST_TRANSFORM_DIR / FILENAME)
     with (TEST_TRANSFORM_DIR / FILENAME).open() as f:
         return json.load(f)


### PR DESCRIPTION
close #341

* create new method `extract_harvested_data` to separate these out
* `transform` now accepts harvested data as a parameter

Notes:
* I was considering moving extract harvester to the Harvester class or module. Decided not to for now and may address it in a separate issue 