### PR TITLE
feat!: refactor graph DB code, streamline unneeded query transaction usage

### DIFF
--- a/docs/source/reference/api/metakb.database.rst
+++ b/docs/source/reference/api/metakb.database.rst
@@ -1,0 +1,8 @@
+﻿metakb.database
+===============
+
+.. automodule:: metakb.database
+   :members:
+   :undoc-members:
+   :special-members: __init__
+   :exclude-members: model_fields, model_config, model_computed_fields

--- a/docs/source/reference/api/metakb.load_data.rst
+++ b/docs/source/reference/api/metakb.load_data.rst
@@ -1,0 +1,8 @@
+﻿metakb.load_data
+================
+
+.. automodule:: metakb.load_data
+   :members:
+   :undoc-members:
+   :special-members: __init__
+   :exclude-members: model_fields, model_config, model_computed_fields

--- a/docs/source/reference/index.rst
+++ b/docs/source/reference/index.rst
@@ -14,6 +14,17 @@ Core
    metakb.query
    metakb.normalizers
 
+Data Management
+---------------
+
+.. autosummary::
+   :nosignatures:
+   :toctree: api/
+   :template: module_summary.rst
+
+   metakb.load_data
+   metakb.database
+
 
 Data Schemas
 ------------

--- a/src/metakb/cli.py
+++ b/src/metakb/cli.py
@@ -18,6 +18,7 @@ from botocore.config import Config
 from neo4j import Driver
 
 from metakb import APP_ROOT, DATE_FMT
+from metakb.database import clear_graph as clear_metakb_graph
 from metakb.database import get_driver
 from metakb.harvesters.civic import CivicHarvester
 from metakb.harvesters.moa import MoaHarvester
@@ -334,7 +335,7 @@ def _get_driver(db_url: str, db_creds: str | None) -> Generator[Driver, None, No
     :param db_url: URL endpoint for the application Neo4j database.
     :param db_creds: DB username and password, separated by a colon, e.g.
         ``"username:password"``.
-    :return: Graph instance
+    :return: Graph driver instance
     """
     if not db_creds:
         credentials = ("", "")  # revert to default behavior in graph constructor
@@ -354,7 +355,15 @@ def _get_driver(db_url: str, db_creds: str | None) -> Generator[Driver, None, No
 @cli.command()
 @click.option("--db_url", "-u", default="", help=_neo4j_db_url_description)
 @click.option("--db_credentials", "-c", help=_neo4j_creds_description)
-def clear_graph(db_url: str, db_credentials: str | None) -> None:
+@click.option(
+    "--keep_constraints",
+    is_flag=True,
+    default=False,
+    help="if true, don't clear graph constraints",
+)
+def clear_graph(
+    db_url: str, db_credentials: str | None, keep_constraints: bool
+) -> None:
     """Wipe graph DB.
 
         $ metakb clear-graph
@@ -370,9 +379,10 @@ def clear_graph(db_url: str, db_credentials: str | None) -> None:
     :param db_url: URL endpoint for the application Neo4j database.
     :param db_credentials: DB username and password, separated by a colon, e.g.
         ``"username:password"``.
+    :param keep_constraints: if True, don't clear graph constraints
     """  # noqa: D301
     driver = next(_get_driver(db_url, db_credentials))
-    clear_graph(driver)
+    clear_metakb_graph(driver, keep_constraints)
 
 
 @cli.command()

--- a/src/metakb/database.py
+++ b/src/metakb/database.py
@@ -1,4 +1,4 @@
-"""Graph database for storing CDM data."""
+"""Acquire connection to Neo4j graph database."""
 import ast
 import logging
 from os import environ

--- a/src/metakb/database.py
+++ b/src/metakb/database.py
@@ -1,636 +1,135 @@
 """Graph database for storing CDM data."""
 import ast
-import json
 import logging
 from os import environ
-from pathlib import Path
 
 import boto3
 from botocore.exceptions import ClientError
-from neo4j import GraphDatabase, ManagedTransaction
-
-from metakb.schemas.app import SourceName
+from neo4j import Driver, GraphDatabase, ManagedTransaction
 
 logger = logging.getLogger(__name__)
 
 
-def _create_parameterized_query(
-    entity: dict, params: tuple[str, ...], entity_param_prefix: str = ""
-) -> str:
-    """Create parameterized query string for requested params if non-null in entity.
+def _get_secret() -> str:
+    """Get secrets for MetaKB instances.
 
-    :param entity: entity to check against, eg a Variation or Study
-    :param params: Parameter names to check
-    :param entity_param_prefix: Prefix for parameter names in entity object
-    :return: Parameterized query, such as (`name:$name`)
+    :return: code structured as string for consumption in ``ast.literal_eval``
     """
-    nonnull_keys = [
-        f"{key}:${entity_param_prefix}{key}" for key in params if entity.get(key)
+    secret_name = environ["METAKB_DB_SECRET"]
+    region_name = "us-east-2"
+
+    # Create a Secrets Manager client
+    session = boto3.session.Session()
+    client = session.client(service_name="secretsmanager", region_name=region_name)
+
+    try:
+        get_secret_value_response = client.get_secret_value(SecretId=secret_name)
+    except ClientError as e:
+        # For a list of exceptions thrown, see
+        # https://docs.aws.amazon.com/secretsmanager/latest/apireference/API_GetSecretValue.html
+        logger.error(e)
+        raise e
+    else:
+        return get_secret_value_response["SecretString"]
+
+
+def _get_credentials(
+    uri: str, credentials: tuple[str, str]
+) -> tuple[str, tuple[str, str]]:
+    """Acquire structured credentials.
+    * Arguments are required. If they're not empty strings, return them as credentials.
+    * If in a production environment, fetch from AWS Secrets Manager.
+    * If all env vars declared, use them
+    * Otherwise, use defaults
+    :param uri: connection URI, formatted a la ``bolt://<host>:<port #>``
+    :param credentials: tuple containing username and password
+    :return: tuple containing host, and a second tuple containing username/password
+    """
+    if not (uri and credentials[0] and credentials[1]):
+        if "METAKB_NORM_EB_PROD" in environ:
+            secret = ast.literal_eval(_get_secret())
+            uri = f"bolt://{secret['host']}:{secret['port']}"
+            credentials = (secret["username"], secret["password"])
+        else:
+            if all(
+                [
+                    "METAKB_DB_URL" in environ,
+                    "METAKB_DB_USERNAME" in environ,
+                    "METAKB_DB_PASSWORD" in environ,
+                ]
+            ):
+                uri = environ["METAKB_DB_URL"]
+                credentials = (
+                    environ["METAKB_DB_USERNAME"],
+                    environ["METAKB_DB_PASSWORD"],
+                )
+            else:  # local default settings
+                uri = "bolt://localhost:7687"
+                credentials = ("neo4j", "password")
+    return uri, credentials
+
+
+def get_driver(uri: str = "", credentials: tuple[str, str] = ("", "")) -> Driver:
+    """Initialize Graph driver instance.
+
+    Connection URI/credentials are resolved as follows:
+
+    1. Use function args if given
+    2. Use values from AWS secrets manager if env var ``METAKB_NORM_EB_PROD`` is set
+    3. Use values from env vars ``METAKB_DB_URL``, ``METAKB_DB_USERNAME``, and
+        ``METAKB_DB_PASSWORD``, if all are defined
+    4. Use local defaults: ``"bolt://localhost:7687"``, with username ``"neo4j"``
+        and password ``"password"``
+
+    :param uri: address of Neo4j DB
+    :param credentials: tuple containing username and password
+    :return: Neo4j driver instance
+    """
+    uri, credentials = _get_credentials(uri, credentials)
+    driver = GraphDatabase.driver(uri, auth=credentials)
+    with driver.session() as session:
+        session.execute_write(_create_constraints)
+    return driver
+
+
+def clear_graph(driver: Driver) -> None:
+    """Debugging helper - wipe out DB."""
+
+    def delete_all(tx: ManagedTransaction) -> None:
+        """Delete all nodes and relationships
+
+        :param tx: Transaction object provided to transaction functions
+        """
+        tx.run("MATCH (n) DETACH DELETE n;")
+
+    with driver.session() as session:
+        session.execute_write(delete_all)
+
+
+def _create_constraints(tx: ManagedTransaction) -> None:
+    """Create unique property constraints for nodes
+
+    :param tx: Transaction object provided to transaction functions
+    """
+    queries = [
+        "CREATE CONSTRAINT coding_constraint IF NOT EXISTS FOR (c:Coding) REQUIRE (c.code, c.label, c.system) IS UNIQUE;",
     ]
-    return ", ".join(nonnull_keys)
 
-
-class Graph:
-    """Manage requests to graph datastore."""
-
-    def __init__(self, uri: str = "", credentials: tuple[str, str] = ("", "")) -> None:
-        """Initialize Graph driver instance.
-
-        Connection URI/credentials are resolved as follows:
-
-        1. Use class constructor args if given
-        2. Use values from AWS secrets manager if env var ``METAKB_NORM_EB_PROD`` is set
-        3. Use values from env vars ``METAKB_DB_URL``, ``METAKB_DB_USERNAME``, and
-            ``METAKB_DB_PASSWORD``, if all are defined
-        4. Use local defaults: ``"bolt://localhost:7687"``, with username ``"neo4j"``
-            and password ``"password"``
-
-        :param uri: address of Neo4j DB
-        :param credentials: tuple containing username and password
-        """
-        if not (uri and credentials[0] and credentials[1]):
-            if "METAKB_NORM_EB_PROD" in environ:
-                secret = ast.literal_eval(self.get_secret())
-                uri = f"bolt://{secret['host']}:{secret['port']}"
-                credentials = (secret["username"], secret["password"])
-            else:
-                if all(
-                    [
-                        "METAKB_DB_URL" in environ,
-                        "METAKB_DB_USERNAME" in environ,
-                        "METAKB_DB_PASSWORD" in environ,
-                    ]
-                ):
-                    uri = environ["METAKB_DB_URL"]
-                    credentials = (
-                        environ["METAKB_DB_USERNAME"],
-                        environ["METAKB_DB_PASSWORD"],
-                    )
-                else:  # local default settings
-                    uri = "bolt://localhost:7687"
-                    credentials = ("neo4j", "password")
-        self.driver = GraphDatabase.driver(uri, auth=credentials)
-        with self.driver.session() as session:
-            session.execute_write(self._create_constraints)
-
-    def close(self) -> None:
-        """Close Neo4j driver."""
-        self.driver.close()
-
-    def clear(self) -> None:
-        """Debugging helper - wipe out DB."""
-
-        def delete_all(tx: ManagedTransaction) -> None:
-            """Delete all nodes and relationships
-
-            :param tx: Transaction object provided to transaction functions
-            """
-            tx.run("MATCH (n) DETACH DELETE n;")
-
-        with self.driver.session() as session:
-            session.execute_write(delete_all)
-
-    def load_from_json(self, src_transformed_cdm: Path) -> None:
-        """Load evidence into DB from given CDM JSON file.
-
-        :param src_transformed_cdm: path to file for a source's transformed data to
-            common data model containing studies, variation, therapeutic procedures,
-            conditions, genes, methods, documents, etc.
-        """
-        logger.info("Loading data from %s", src_transformed_cdm)
-        with src_transformed_cdm.open() as f:
-            items = json.load(f)
-            src_name = SourceName(
-                str(src_transformed_cdm).split("/")[-1].split("_cdm")[0]
-            )
-            self.add_transformed_data(items, src_name)
-
-    @staticmethod
-    def _create_constraints(tx: ManagedTransaction) -> None:
-        """Create unique property constraints for nodes
-
-        :param tx: Transaction object provided to transaction functions
-        """
-        queries = [
-            "CREATE CONSTRAINT coding_constraint IF NOT EXISTS FOR (c:Coding) REQUIRE (c.code, c.label, c.system) IS UNIQUE;",
-        ]
-
-        for label in [
-            "Gene",
-            "Disease",
-            "TherapeuticProcedure",
-            "Variation",
-            "CategoricalVariation",
-            "VariantGroup",
-            "Location",
-            "Document",
-            "Study",
-            "Method",
-        ]:
-            queries.append(
-                f"CREATE CONSTRAINT {label.lower()}_id_constraint IF NOT EXISTS FOR (n:{label}) REQUIRE n.id IS UNIQUE;"
-            )
-
-        for query in queries:
-            tx.run(query)
-
-    def add_transformed_data(self, data: dict, src_name: SourceName) -> None:
-        """Add set of data formatted per Common Data Model to DB.
-
-        :param data: contains key/value pairs for data objects to add to DB, including
-            studies, variation, therapeutic procedures, conditions, genes, methods,
-            documents, etc.
-        :param src_name: Name of source for `data`
-        """
-        # Used to keep track of IDs that are in studies. This is used to prevent adding
-        # nodes that aren't associated to studies
-        ids_in_studies = self._get_ids_from_studies(data.get("studies", []))
-
-        with self.driver.session() as session:
-            loaded_study_count = 0
-
-            for cv in data.get("categorical_variations", []):
-                session.execute_write(
-                    self._add_categorical_variation, cv, ids_in_studies
-                )
-
-            for doc in data.get("documents", []):
-                session.execute_write(self._add_document, doc, ids_in_studies)
-
-            for method in data.get("methods", []):
-                session.execute_write(self._add_method, method, ids_in_studies)
-
-            for obj_type in {"genes", "conditions"}:
-                for obj in data.get(obj_type, []):
-                    session.execute_write(
-                        self._add_gene_or_disease, obj, ids_in_studies
-                    )
-
-            for tp in data.get("therapeutic_procedures", []):
-                session.execute_write(
-                    self._add_therapeutic_procedure, tp, ids_in_studies
-                )
-
-            # This should always be done last
-            for study in data.get("studies", []):
-                session.execute_write(self._add_study, study)
-                loaded_study_count += 1
-
-            logger.info("Successfully loaded %s studies.", loaded_study_count)
-
-    @staticmethod
-    def _add_mappings_and_exts_to_obj(obj: dict, obj_keys: list[str]) -> None:
-        """Get mappings and extensions from object and add to `obj` and `obj_keys`
-
-        :param obj: Object to update with mappings and extensions (if found)
-        :param obj_keys: Parameterized queries. This will be mutated if mappings and
-            extensions exists
-        """
-        mappings = obj.get("mappings", [])
-        if mappings:
-            obj["mappings"] = json.dumps(mappings)
-            obj_keys.append("mappings:$mappings")
-
-        extensions = obj.get("extensions", [])
-        for ext in extensions:
-            if ext["name"].endswith("_normalizer_data"):
-                obj_type = ext["name"].split("_normalizer_data")[0]
-                name = f"{obj_type}_normalizer_id"
-                obj[name] = ext["value"]["normalized_id"]
-            else:
-                name = "_".join(ext["name"].split()).lower()
-                val = ext["value"]
-                if isinstance(val, (dict | list)):
-                    obj[name] = json.dumps(val)
-                else:
-                    obj[name] = val
-            obj_keys.append(f"{name}:${name}")
-
-    def _add_method(
-        self, tx: ManagedTransaction, method: dict, ids_in_studies: set[str]
-    ) -> None:
-        """Add Method node and its relationships to DB
-
-        :param tx: Transaction object provided to transaction functions
-        :param method: CDM method object
-        :param ids_in_studies: IDs found in studies
-        """
-        if method["id"] not in ids_in_studies:
-            return
-
-        query = """
-        MERGE (m:Method {id:$id, label:$label})
-        """
-
-        is_reported_in = method.get("isReportedIn")
-        if is_reported_in:
-            # Method's documents are unique and do not currently have IDs
-            self._add_document(tx, is_reported_in, ids_in_studies)
-            doc_doi = is_reported_in["doi"]
-            query += f"""
-            MERGE (d:Document {{ doi:'{doc_doi}' }})
-            MERGE (m) -[:IS_REPORTED_IN] -> (d)
-            """
-
-        tx.run(query, **method)
-
-    def _add_gene_or_disease(
-        self, tx: ManagedTransaction, obj_in: dict, ids_in_studies: set[str]
-    ) -> None:
-        """Add gene or disease node and its relationships to DB
-
-        :param tx: Transaction object provided to transaction functions
-        :param obj_in: CDM gene or disease object
-        :param ids_in_studies: IDs found in studies
-        :raises TypeError: When `obj_in` is not a disease or gene
-        """
-        if obj_in["id"] not in ids_in_studies:
-            return
-
-        obj = obj_in.copy()
-
-        obj_type = obj["type"]
-        if obj_type not in {"Gene", "Disease"}:
-            msg = f"Invalid object type: {obj_type}"
-            raise TypeError(msg)
-
-        obj_keys = [
-            _create_parameterized_query(
-                obj, ("id", "label", "description", "aliases", "type")
-            )
-        ]
-
-        self._add_mappings_and_exts_to_obj(obj, obj_keys)
-        obj_keys = ", ".join(obj_keys)
-
-        if obj_type == "Gene":
-            query = f"""
-            MERGE (g:Gene {{ {obj_keys} }});
-            """
-        else:
-            query = f"""
-            MERGE (d:Disease:Condition {{ {obj_keys} }});
-            """
-        tx.run(query, **obj)
-
-    def _add_therapeutic_procedure(
-        self,
-        tx: ManagedTransaction,
-        therapeutic_procedure: dict,
-        ids_in_studies: set[str],
-    ) -> None:
-        """Add therapeutic procedure node and its relationships
-
-        :param tx: Transaction object provided to transaction functions
-        :param therapeutic_procedure: Therapeutic procedure CDM object
-        :param ids_in_studies: IDs found in studies
-        :raises TypeError: When therapeutic procedure type is invalid
-        """
-        if therapeutic_procedure["id"] not in ids_in_studies:
-            return
-
-        tp = therapeutic_procedure.copy()
-
-        tp_type = tp["type"]
-        if tp_type == "TherapeuticAgent":
-            self._add_therapeutic_agent(tx, tp)
-        elif tp_type in {"CombinationTherapy", "TherapeuticSubstituteGroup"}:
-            keys = [_create_parameterized_query(tp, ("id", "type"))]
-
-            self._add_mappings_and_exts_to_obj(tp, keys)
-            keys = ", ".join(keys)
-
-            query = f"MERGE (tp:{tp_type}:TherapeuticProcedure {{ {keys} }})"
-            tx.run(query, **tp)
-
-            tas = (
-                tp["components"]
-                if tp_type == "CombinationTherapy"
-                else tp["substitutes"]
-            )
-            for ta in tas:
-                self._add_therapeutic_agent(tx, ta)
-                query = f"""
-                MERGE (tp:{tp_type}:TherapeuticProcedure {{id: '{tp['id']}'}})
-                MERGE (ta:TherapeuticAgent:TherapeuticProcedure {{id: '{ta['id']}'}})
-                """
-
-                if tp_type == "CombinationTherapy":
-                    query += "MERGE (tp) -[:HAS_COMPONENTS] -> (ta)"
-                else:
-                    query += "MERGE (tp) -[:HAS_SUBSTITUTES] -> (ta)"
-
-                tx.run(query)
-        else:
-            msg = f"Invalid therapeutic procedure type: {tp_type}"
-            raise TypeError(msg)
-
-    def _add_therapeutic_agent(
-        self, tx: ManagedTransaction, therapeutic_agent: dict
-    ) -> None:
-        """Add therapeutic agent node and its relationships
-
-        :param tx: Transaction object provided to transaction functions
-        :param therapeutic_agent: Therapeutic Agent CDM object
-        """
-        ta = therapeutic_agent.copy()
-        nonnull_keys = [
-            _create_parameterized_query(ta, ("id", "label", "aliases", "type"))
-        ]
-
-        self._add_mappings_and_exts_to_obj(ta, nonnull_keys)
-        nonnull_keys = ", ".join(nonnull_keys)
-
-        query = f"""
-        MERGE (ta:TherapeuticAgent:TherapeuticProcedure {{ {nonnull_keys} }})
-        """
-        tx.run(query, **ta)
-
-    @staticmethod
-    def _add_location(tx: ManagedTransaction, location_in: dict) -> None:
-        """Add location node and its relationships
-
-        :param tx: Transaction object provided to transaction functions
-        :param location_in: Location CDM object
-        """
-        loc = location_in.copy()
-        loc_keys = [
-            f"loc.{key}=${key}"
-            for key in ("id", "digest", "start", "end", "type")
-            if loc.get(key) is not None  # start could be 0
-        ]
-        loc["sequence_reference"] = json.dumps(loc["sequenceReference"])
-        loc_keys.append("loc.sequence_reference=$sequence_reference")
-        loc_keys = ", ".join(loc_keys)
-
-        query = f"""
-        MERGE (loc:{loc['type']}:Location {{ id: '{loc['id']}' }})
-        ON CREATE SET {loc_keys}
-        """
-        tx.run(query, **loc)
-
-    def _add_variation(self, tx: ManagedTransaction, variation_in: dict) -> None:
-        """Add variation node and its relationships
-
-        :param tx: Transaction object provided to transaction functions
-        :param variation_in: Variation CDM object
-        """
-        v = variation_in.copy()
-        v_keys = [
-            f"v.{key}=${key}" for key in ("id", "label", "digest", "type") if v.get(key)
-        ]
-
-        expressions = v.get("expressions", [])
-        for expr in expressions:
-            syntax = expr["syntax"].replace(".", "_")
-            key = f"expression_{syntax}"
-            if key in v:
-                v[key].append(expr["value"])
-            else:
-                v_keys.append(f"v.{key}=${key}")
-                v[key] = [expr["value"]]
-
-        state = v.get("state")
-        if state:
-            v["state"] = json.dumps(state)
-            v_keys.append("v.state=$state")
-
-        v_keys = ", ".join(v_keys)
-
-        query = f"""
-        MERGE (v:{v['type']}:Variation {{ id: '{v['id']}' }})
-        ON CREATE SET {v_keys}
-        """
-
-        loc = v.get("location")
-        if loc:
-            self._add_location(tx, loc)
-            query += f"""
-            MERGE (loc:{loc['type']}:Location {{ id: '{loc['id']}' }})
-            MERGE (v) -[:HAS_LOCATION] -> (loc)
-            """
-
-        tx.run(query, **v)
-
-    def _add_categorical_variation(
-        self,
-        tx: ManagedTransaction,
-        categorical_variation_in: dict,
-        ids_in_studies: set[str],
-    ) -> None:
-        """Add categorical variation objects to DB.
-
-        :param tx: Transaction object provided to transaction functions
-        :param categorical_variation_in: Categorical variation CDM object
-        :param ids_in_studies: IDs found in studies
-        """
-        if categorical_variation_in["id"] not in ids_in_studies:
-            return
-
-        cv = categorical_variation_in.copy()
-
-        mp_nonnull_keys = [
-            _create_parameterized_query(
-                cv, ("id", "label", "description", "aliases", "type")
-            )
-        ]
-
-        self._add_mappings_and_exts_to_obj(cv, mp_nonnull_keys)
-        mp_keys = ", ".join(mp_nonnull_keys)
-
-        defining_context = cv["definingContext"]
-        self._add_variation(tx, defining_context)
-        dc_type = defining_context["type"]
-
-        members_match = ""
-        members_relation = ""
-        for ix, member in enumerate(cv.get("members", [])):
-            self._add_variation(tx, member)
-            name = f"member_{ix}"
-            cv[name] = member
-            members_match += f"MERGE ({name} {{ id: '{member['id']}' }})\n"
-            members_relation += f"MERGE (v) -[:HAS_MEMBERS] -> ({name})\n"
-
-        query = f"""
-        {members_match}
-        MERGE (dc:{dc_type}:Variation {{ id: '{defining_context['id']}' }})
-        MERGE (dc) -[:HAS_LOCATION] -> (loc)
-        MERGE (v:{cv['type']}:CategoricalVariation {{ {mp_keys} }})
-        MERGE (v) -[:HAS_DEFINING_CONTEXT] -> (dc)
-        {members_relation}
-        """
-        tx.run(query, **cv)
-
-    def _add_document(
-        self, tx: ManagedTransaction, document_in: dict, ids_in_studies: set[str]
-    ) -> None:
-        """Add Document object to DB.
-
-        :param tx: Transaction object provided to transaction functions
-        :param document: Document CDM object
-        :param ids_in_studies: IDs found in studies
-        """
-        # Not all document's have IDs. These are the fields that can uniquely identify
-        # a document
-        if "id" in document_in:
-            query = "MATCH (n:Document {id:$id}) RETURN n"
-            if document_in["id"] not in ids_in_studies:
-                return
-        elif "doi" in document_in:
-            query = "MATCH (n:Document {doi:$doi}) RETURN n"
-        elif "pmid" in document_in:
-            query = "MATCH (n:Document {pmid:$pmid}) RETURN n"
-        else:
-            query = None
-
-        result = tx.run(query, **document_in) if query else None
-
-        if (not result) or (result and not result.single()):
-            document = document_in.copy()
-            formatted_keys = [
-                _create_parameterized_query(
-                    document, ("id", "label", "title", "pmid", "url", "doi")
-                )
-            ]
-
-            self._add_mappings_and_exts_to_obj(document, formatted_keys)
-            formatted_keys = ", ".join(formatted_keys)
-
-            query = f"""
-            MERGE (n:Document {{ {formatted_keys} }});
-            """
-            tx.run(query, **document)
-
-    def _get_ids_from_studies(self, studies: list[dict]) -> set[str]:
-        """Get unique IDs from studies
-
-        :param studies: List of studies
-        :return: Set of IDs found in studies
-        """
-
-        def _add_obj_id_to_set(obj: dict, ids_set: set[str]) -> None:
-            """Add object id to set of IDs
-
-            :param obj: Object to get ID for
-            :param ids_set: IDs found in studies. This will be mutated.
-            """
-            obj_id = obj.get("id")
-            if obj_id:
-                ids_set.add(obj_id)
-
-        ids_in_studies = set()
-
-        for study in studies:
-            for obj in [
-                study.get("specifiedBy"),  # method
-                study.get("isReportedIn"),
-                study.get("variant"),
-                study.get("therapeutic"),
-                study.get("tumorType"),
-                study.get("qualifiers", {}).get("geneContext"),
-            ]:
-                if obj:
-                    if isinstance(obj, list):
-                        for item in obj:
-                            _add_obj_id_to_set(item, ids_in_studies)
-                    else:  # This is a dictionary
-                        _add_obj_id_to_set(obj, ids_in_studies)
-
-        return ids_in_studies
-
-    @staticmethod
-    def _add_study(tx: ManagedTransaction, study_in: dict) -> None:
-        """Add study node and its relationships
-
-        :param tx: Transaction object provided to transaction functions
-        :param study_in: Study CDM object
-        """
-        study = study_in.copy()
-        study_type = study["type"]
-        study_keys = _create_parameterized_query(
-            study, ("id", "description", "direction", "predicate", "type")
+    for label in [
+        "Gene",
+        "Disease",
+        "TherapeuticProcedure",
+        "Variation",
+        "CategoricalVariation",
+        "VariantGroup",
+        "Location",
+        "Document",
+        "Study",
+        "Method",
+    ]:
+        queries.append(
+            f"CREATE CONSTRAINT {label.lower()}_id_constraint IF NOT EXISTS FOR (n:{label}) REQUIRE n.id IS UNIQUE;"
         )
 
-        match_line = ""
-        rel_line = ""
-
-        is_reported_in_docs = study.get("isReportedIn", [])
-        for ri_doc in is_reported_in_docs:
-            ri_doc_id = ri_doc["id"]
-            name = f"doc_{ri_doc_id.split(':')[-1]}"
-            match_line += f"MERGE ({name} {{ id: '{ri_doc_id}'}})\n"
-            rel_line += f"MERGE (s) -[:IS_REPORTED_IN] -> ({name})\n"
-
-        qualifiers = study.get("qualifiers")
-        if qualifiers:
-            allele_origin = qualifiers.get("alleleOrigin")
-            study["alleleOrigin"] = allele_origin
-            match_line += "SET s.alleleOrigin=$alleleOrigin\n"
-
-            gene_context_id = qualifiers.get("geneContext", {}).get("id")
-            if gene_context_id:
-                match_line += f"MERGE (g:Gene {{id: '{gene_context_id}'}})\n"
-                rel_line += "MERGE (s) -[:HAS_GENE_CONTEXT] -> (g)\n"
-
-        method_id = study["specifiedBy"]["id"]
-        match_line += f"MERGE (m {{ id: '{method_id}' }})\n"
-        rel_line += "MERGE (s) -[:IS_SPECIFIED_BY] -> (m)\n"
-
-        coding = study.get("strength")
-        if coding:
-            coding_key_fields = ("code", "label", "system")
-
-            coding_keys = _create_parameterized_query(
-                coding, coding_key_fields, entity_param_prefix="coding_"
-            )
-            for k in coding_key_fields:
-                v = coding.get(k)
-                if v:
-                    study[f"coding_{k}"] = v
-
-            match_line += f"MERGE (c:Coding {{ {coding_keys} }})\n"
-            rel_line += "MERGE (s) -[:HAS_STRENGTH] -> (c)\n"
-
-        variant_id = study["variant"]["id"]
-        if study["variant"]["type"] == "ProteinSequenceConsequence":
-            v_parent_type = "CategoricalVariation"
-        else:
-            v_parent_type = "Variation"
-        match_line += f"MERGE (v:{v_parent_type} {{ id: '{variant_id}' }})\n"
-        rel_line += "MERGE (s) -[:HAS_VARIANT] -> (v)\n"
-
-        therapeutic_id = study["therapeutic"]["id"]
-        match_line += f"MERGE (t:TherapeuticProcedure {{ id: '{therapeutic_id}' }})\n"
-        rel_line += "MERGE (s) -[:HAS_THERAPEUTIC] -> (t)\n"
-
-        tumor_type_id = study["tumorType"]["id"]
-        match_line += f"MERGE (tt:Condition {{ id: '{tumor_type_id}' }})\n"
-        rel_line += "MERGE (s) -[:HAS_TUMOR_TYPE] -> (tt)\n"
-
-        query = f"""
-        MERGE (s:{study_type}:Study {{ {study_keys} }})
-        {match_line}
-        {rel_line}
-        """
-
-        tx.run(query, **study)
-
-    @staticmethod
-    def get_secret() -> str:
-        """Get secrets for MetaKB instances."""
-        secret_name = environ["METAKB_DB_SECRET"]
-        region_name = "us-east-2"
-
-        # Create a Secrets Manager client
-        session = boto3.session.Session()
-        client = session.client(service_name="secretsmanager", region_name=region_name)
-
-        try:
-            get_secret_value_response = client.get_secret_value(SecretId=secret_name)
-        except ClientError as e:
-            # For a list of exceptions thrown, see
-            # https://docs.aws.amazon.com/secretsmanager/latest/apireference/API_GetSecretValue.html
-            logger.error(e)
-            raise e
-        else:
-            return get_secret_value_response["SecretString"]
+    for query in queries:
+        tx.run(query)

--- a/src/metakb/load_data.py
+++ b/src/metakb/load_data.py
@@ -1,0 +1,519 @@
+"""Provide methods for loading data into the database."""
+import json
+import logging
+from pathlib import Path
+
+from neo4j import Driver, ManagedTransaction
+
+from metakb.database import get_driver
+from metakb.schemas.app import SourceName
+
+_logger = logging.getLogger(__name__)
+
+
+def _create_parameterized_query(
+    entity: dict, params: tuple[str, ...], entity_param_prefix: str = ""
+) -> str:
+    """Create parameterized query string for requested params if non-null in entity.
+
+    :param entity: entity to check against, eg a Variation or Study
+    :param params: Parameter names to check
+    :param entity_param_prefix: Prefix for parameter names in entity object
+    :return: Parameterized query, such as (`name:$name`)
+    """
+    nonnull_keys = [
+        f"{key}:${entity_param_prefix}{key}" for key in params if entity.get(key)
+    ]
+    return ", ".join(nonnull_keys)
+
+
+@staticmethod
+def _add_mappings_and_exts_to_obj(obj: dict, obj_keys: list[str]) -> None:
+    """Get mappings and extensions from object and add to `obj` and `obj_keys`
+
+    :param obj: Object to update with mappings and extensions (if found)
+    :param obj_keys: Parameterized queries. This will be mutated if mappings and
+        extensions exists
+    """
+    mappings = obj.get("mappings", [])
+    if mappings:
+        obj["mappings"] = json.dumps(mappings)
+        obj_keys.append("mappings:$mappings")
+
+    extensions = obj.get("extensions", [])
+    for ext in extensions:
+        if ext["name"].endswith("_normalizer_data"):
+            obj_type = ext["name"].split("_normalizer_data")[0]
+            name = f"{obj_type}_normalizer_id"
+            obj[name] = ext["value"]["normalized_id"]
+        else:
+            name = "_".join(ext["name"].split()).lower()
+            val = ext["value"]
+            if isinstance(val, (dict | list)):
+                obj[name] = json.dumps(val)
+            else:
+                obj[name] = val
+        obj_keys.append(f"{name}:${name}")
+
+
+def _add_method(tx: ManagedTransaction, method: dict, ids_in_studies: set[str]) -> None:
+    """Add Method node and its relationships to DB
+
+    :param tx: Transaction object provided to transaction functions
+    :param method: CDM method object
+    :param ids_in_studies: IDs found in studies
+    """
+    if method["id"] not in ids_in_studies:
+        return
+
+    query = """
+    MERGE (m:Method {id:$id, label:$label})
+    """
+
+    is_reported_in = method.get("isReportedIn")
+    if is_reported_in:
+        # Method's documents are unique and do not currently have IDs
+        _add_document(tx, is_reported_in, ids_in_studies)
+        doc_doi = is_reported_in["doi"]
+        query += f"""
+        MERGE (d:Document {{ doi:'{doc_doi}' }})
+        MERGE (m) -[:IS_REPORTED_IN] -> (d)
+        """
+
+    tx.run(query, **method)
+
+
+def _add_gene_or_disease(
+    tx: ManagedTransaction, obj_in: dict, ids_in_studies: set[str]
+) -> None:
+    """Add gene or disease node and its relationships to DB
+
+    :param tx: Transaction object provided to transaction functions
+    :param obj_in: CDM gene or disease object
+    :param ids_in_studies: IDs found in studies
+    :raises TypeError: When `obj_in` is not a disease or gene
+    """
+    if obj_in["id"] not in ids_in_studies:
+        return
+
+    obj = obj_in.copy()
+
+    obj_type = obj["type"]
+    if obj_type not in {"Gene", "Disease"}:
+        msg = f"Invalid object type: {obj_type}"
+        raise TypeError(msg)
+
+    obj_keys = [
+        _create_parameterized_query(
+            obj, ("id", "label", "description", "aliases", "type")
+        )
+    ]
+
+    _add_mappings_and_exts_to_obj(obj, obj_keys)
+    obj_keys = ", ".join(obj_keys)
+
+    if obj_type == "Gene":
+        query = f"""
+        MERGE (g:Gene {{ {obj_keys} }});
+        """
+    else:
+        query = f"""
+        MERGE (d:Disease:Condition {{ {obj_keys} }});
+        """
+    tx.run(query, **obj)
+
+
+def _add_therapeutic_procedure(
+    tx: ManagedTransaction,
+    therapeutic_procedure: dict,
+    ids_in_studies: set[str],
+) -> None:
+    """Add therapeutic procedure node and its relationships
+
+    :param tx: Transaction object provided to transaction functions
+    :param therapeutic_procedure: Therapeutic procedure CDM object
+    :param ids_in_studies: IDs found in studies
+    :raises TypeError: When therapeutic procedure type is invalid
+    """
+    if therapeutic_procedure["id"] not in ids_in_studies:
+        return
+
+    tp = therapeutic_procedure.copy()
+
+    tp_type = tp["type"]
+    if tp_type == "TherapeuticAgent":
+        _add_therapeutic_agent(tx, tp)
+    elif tp_type in {"CombinationTherapy", "TherapeuticSubstituteGroup"}:
+        keys = [_create_parameterized_query(tp, ("id", "type"))]
+
+        _add_mappings_and_exts_to_obj(tp, keys)
+        keys = ", ".join(keys)
+
+        query = f"MERGE (tp:{tp_type}:TherapeuticProcedure {{ {keys} }})"
+        tx.run(query, **tp)
+
+        tas = tp["components"] if tp_type == "CombinationTherapy" else tp["substitutes"]
+        for ta in tas:
+            _add_therapeutic_agent(tx, ta)
+            query = f"""
+            MERGE (tp:{tp_type}:TherapeuticProcedure {{id: '{tp['id']}'}})
+            MERGE (ta:TherapeuticAgent:TherapeuticProcedure {{id: '{ta['id']}'}})
+            """
+
+            if tp_type == "CombinationTherapy":
+                query += "MERGE (tp) -[:HAS_COMPONENTS] -> (ta)"
+            else:
+                query += "MERGE (tp) -[:HAS_SUBSTITUTES] -> (ta)"
+
+            tx.run(query)
+    else:
+        msg = f"Invalid therapeutic procedure type: {tp_type}"
+        raise TypeError(msg)
+
+
+def _add_therapeutic_agent(tx: ManagedTransaction, therapeutic_agent: dict) -> None:
+    """Add therapeutic agent node and its relationships
+
+    :param tx: Transaction object provided to transaction functions
+    :param therapeutic_agent: Therapeutic Agent CDM object
+    """
+    ta = therapeutic_agent.copy()
+    nonnull_keys = [_create_parameterized_query(ta, ("id", "label", "aliases", "type"))]
+
+    _add_mappings_and_exts_to_obj(ta, nonnull_keys)
+    nonnull_keys = ", ".join(nonnull_keys)
+
+    query = f"""
+    MERGE (ta:TherapeuticAgent:TherapeuticProcedure {{ {nonnull_keys} }})
+    """
+    tx.run(query, **ta)
+
+
+@staticmethod
+def _add_location(tx: ManagedTransaction, location_in: dict) -> None:
+    """Add location node and its relationships
+
+    :param tx: Transaction object provided to transaction functions
+    :param location_in: Location CDM object
+    """
+    loc = location_in.copy()
+    loc_keys = [
+        f"loc.{key}=${key}"
+        for key in ("id", "digest", "start", "end", "type")
+        if loc.get(key) is not None  # start could be 0
+    ]
+    loc["sequence_reference"] = json.dumps(loc["sequenceReference"])
+    loc_keys.append("loc.sequence_reference=$sequence_reference")
+    loc_keys = ", ".join(loc_keys)
+
+    query = f"""
+    MERGE (loc:{loc['type']}:Location {{ id: '{loc['id']}' }})
+    ON CREATE SET {loc_keys}
+    """
+    tx.run(query, **loc)
+
+
+def _add_variation(tx: ManagedTransaction, variation_in: dict) -> None:
+    """Add variation node and its relationships
+
+    :param tx: Transaction object provided to transaction functions
+    :param variation_in: Variation CDM object
+    """
+    v = variation_in.copy()
+    v_keys = [
+        f"v.{key}=${key}" for key in ("id", "label", "digest", "type") if v.get(key)
+    ]
+
+    expressions = v.get("expressions", [])
+    for expr in expressions:
+        syntax = expr["syntax"].replace(".", "_")
+        key = f"expression_{syntax}"
+        if key in v:
+            v[key].append(expr["value"])
+        else:
+            v_keys.append(f"v.{key}=${key}")
+            v[key] = [expr["value"]]
+
+    state = v.get("state")
+    if state:
+        v["state"] = json.dumps(state)
+        v_keys.append("v.state=$state")
+
+    v_keys = ", ".join(v_keys)
+
+    query = f"""
+    MERGE (v:{v['type']}:Variation {{ id: '{v['id']}' }})
+    ON CREATE SET {v_keys}
+    """
+
+    loc = v.get("location")
+    if loc:
+        _add_location(tx, loc)
+        query += f"""
+        MERGE (loc:{loc['type']}:Location {{ id: '{loc['id']}' }})
+        MERGE (v) -[:HAS_LOCATION] -> (loc)
+        """
+
+    tx.run(query, **v)
+
+
+def _add_categorical_variation(
+    tx: ManagedTransaction,
+    categorical_variation_in: dict,
+    ids_in_studies: set[str],
+) -> None:
+    """Add categorical variation objects to DB.
+
+    :param tx: Transaction object provided to transaction functions
+    :param categorical_variation_in: Categorical variation CDM object
+    :param ids_in_studies: IDs found in studies
+    """
+    if categorical_variation_in["id"] not in ids_in_studies:
+        return
+
+    cv = categorical_variation_in.copy()
+
+    mp_nonnull_keys = [
+        _create_parameterized_query(
+            cv, ("id", "label", "description", "aliases", "type")
+        )
+    ]
+
+    _add_mappings_and_exts_to_obj(cv, mp_nonnull_keys)
+    mp_keys = ", ".join(mp_nonnull_keys)
+
+    defining_context = cv["definingContext"]
+    _add_variation(tx, defining_context)
+    dc_type = defining_context["type"]
+
+    members_match = ""
+    members_relation = ""
+    for ix, member in enumerate(cv.get("members", [])):
+        _add_variation(tx, member)
+        name = f"member_{ix}"
+        cv[name] = member
+        members_match += f"MERGE ({name} {{ id: '{member['id']}' }})\n"
+        members_relation += f"MERGE (v) -[:HAS_MEMBERS] -> ({name})\n"
+
+    query = f"""
+    {members_match}
+    MERGE (dc:{dc_type}:Variation {{ id: '{defining_context['id']}' }})
+    MERGE (dc) -[:HAS_LOCATION] -> (loc)
+    MERGE (v:{cv['type']}:CategoricalVariation {{ {mp_keys} }})
+    MERGE (v) -[:HAS_DEFINING_CONTEXT] -> (dc)
+    {members_relation}
+    """
+    tx.run(query, **cv)
+
+
+def _add_document(
+    tx: ManagedTransaction, document_in: dict, ids_in_studies: set[str]
+) -> None:
+    """Add Document object to DB.
+
+    :param tx: Transaction object provided to transaction functions
+    :param document: Document CDM object
+    :param ids_in_studies: IDs found in studies
+    """
+    # Not all document's have IDs. These are the fields that can uniquely identify
+    # a document
+    if "id" in document_in:
+        query = "MATCH (n:Document {id:$id}) RETURN n"
+        if document_in["id"] not in ids_in_studies:
+            return
+    elif "doi" in document_in:
+        query = "MATCH (n:Document {doi:$doi}) RETURN n"
+    elif "pmid" in document_in:
+        query = "MATCH (n:Document {pmid:$pmid}) RETURN n"
+    else:
+        query = None
+
+    result = tx.run(query, **document_in) if query else None
+
+    if (not result) or (result and not result.single()):
+        document = document_in.copy()
+        formatted_keys = [
+            _create_parameterized_query(
+                document, ("id", "label", "title", "pmid", "url", "doi")
+            )
+        ]
+
+        _add_mappings_and_exts_to_obj(document, formatted_keys)
+        formatted_keys = ", ".join(formatted_keys)
+
+        query = f"""
+        MERGE (n:Document {{ {formatted_keys} }});
+        """
+        tx.run(query, **document)
+
+
+def _get_ids_from_studies(studies: list[dict]) -> set[str]:
+    """Get unique IDs from studies
+
+    :param studies: List of studies
+    :return: Set of IDs found in studies
+    """
+
+    def _add_obj_id_to_set(obj: dict, ids_set: set[str]) -> None:
+        """Add object id to set of IDs
+
+        :param obj: Object to get ID for
+        :param ids_set: IDs found in studies. This will be mutated.
+        """
+        obj_id = obj.get("id")
+        if obj_id:
+            ids_set.add(obj_id)
+
+    ids_in_studies = set()
+
+    for study in studies:
+        for obj in [
+            study.get("specifiedBy"),  # method
+            study.get("isReportedIn"),
+            study.get("variant"),
+            study.get("therapeutic"),
+            study.get("tumorType"),
+            study.get("qualifiers", {}).get("geneContext"),
+        ]:
+            if obj:
+                if isinstance(obj, list):
+                    for item in obj:
+                        _add_obj_id_to_set(item, ids_in_studies)
+                else:  # This is a dictionary
+                    _add_obj_id_to_set(obj, ids_in_studies)
+
+    return ids_in_studies
+
+
+@staticmethod
+def _add_study(tx: ManagedTransaction, study_in: dict) -> None:
+    """Add study node and its relationships
+
+    :param tx: Transaction object provided to transaction functions
+    :param study_in: Study CDM object
+    """
+    study = study_in.copy()
+    study_type = study["type"]
+    study_keys = _create_parameterized_query(
+        study, ("id", "description", "direction", "predicate", "type")
+    )
+
+    match_line = ""
+    rel_line = ""
+
+    is_reported_in_docs = study.get("isReportedIn", [])
+    for ri_doc in is_reported_in_docs:
+        ri_doc_id = ri_doc["id"]
+        name = f"doc_{ri_doc_id.split(':')[-1]}"
+        match_line += f"MERGE ({name} {{ id: '{ri_doc_id}'}})\n"
+        rel_line += f"MERGE (s) -[:IS_REPORTED_IN] -> ({name})\n"
+
+    qualifiers = study.get("qualifiers")
+    if qualifiers:
+        allele_origin = qualifiers.get("alleleOrigin")
+        study["alleleOrigin"] = allele_origin
+        match_line += "SET s.alleleOrigin=$alleleOrigin\n"
+
+        gene_context_id = qualifiers.get("geneContext", {}).get("id")
+        if gene_context_id:
+            match_line += f"MERGE (g:Gene {{id: '{gene_context_id}'}})\n"
+            rel_line += "MERGE (s) -[:HAS_GENE_CONTEXT] -> (g)\n"
+
+    method_id = study["specifiedBy"]["id"]
+    match_line += f"MERGE (m {{ id: '{method_id}' }})\n"
+    rel_line += "MERGE (s) -[:IS_SPECIFIED_BY] -> (m)\n"
+
+    coding = study.get("strength")
+    if coding:
+        coding_key_fields = ("code", "label", "system")
+
+        coding_keys = _create_parameterized_query(
+            coding, coding_key_fields, entity_param_prefix="coding_"
+        )
+        for k in coding_key_fields:
+            v = coding.get(k)
+            if v:
+                study[f"coding_{k}"] = v
+
+        match_line += f"MERGE (c:Coding {{ {coding_keys} }})\n"
+        rel_line += "MERGE (s) -[:HAS_STRENGTH] -> (c)\n"
+
+    variant_id = study["variant"]["id"]
+    if study["variant"]["type"] == "ProteinSequenceConsequence":
+        v_parent_type = "CategoricalVariation"
+    else:
+        v_parent_type = "Variation"
+    match_line += f"MERGE (v:{v_parent_type} {{ id: '{variant_id}' }})\n"
+    rel_line += "MERGE (s) -[:HAS_VARIANT] -> (v)\n"
+
+    therapeutic_id = study["therapeutic"]["id"]
+    match_line += f"MERGE (t:TherapeuticProcedure {{ id: '{therapeutic_id}' }})\n"
+    rel_line += "MERGE (s) -[:HAS_THERAPEUTIC] -> (t)\n"
+
+    tumor_type_id = study["tumorType"]["id"]
+    match_line += f"MERGE (tt:Condition {{ id: '{tumor_type_id}' }})\n"
+    rel_line += "MERGE (s) -[:HAS_TUMOR_TYPE] -> (tt)\n"
+
+    query = f"""
+    MERGE (s:{study_type}:Study {{ {study_keys} }})
+    {match_line}
+    {rel_line}
+    """
+
+    tx.run(query, **study)
+
+
+def add_transformed_data(driver: Driver, data: dict, src_name: SourceName) -> None:
+    """Add set of data formatted per Common Data Model to DB.
+
+    :param data: contains key/value pairs for data objects to add to DB, including
+        studies, variation, therapeutic procedures, conditions, genes, methods,
+        documents, etc.
+    :param src_name: Name of source for `data`
+    """
+    # Used to keep track of IDs that are in studies. This is used to prevent adding
+    # nodes that aren't associated to studies
+    ids_in_studies = _get_ids_from_studies(data.get("studies", []))
+
+    with driver.session() as session:
+        loaded_study_count = 0
+
+        for cv in data.get("categorical_variations", []):
+            session.execute_write(_add_categorical_variation, cv, ids_in_studies)
+
+        for doc in data.get("documents", []):
+            session.execute_write(_add_document, doc, ids_in_studies)
+
+        for method in data.get("methods", []):
+            session.execute_write(_add_method, method, ids_in_studies)
+
+        for obj_type in {"genes", "conditions"}:
+            for obj in data.get(obj_type, []):
+                session.execute_write(_add_gene_or_disease, obj, ids_in_studies)
+
+        for tp in data.get("therapeutic_procedures", []):
+            session.execute_write(_add_therapeutic_procedure, tp, ids_in_studies)
+
+        # This should always be done last
+        for study in data.get("studies", []):
+            session.execute_write(_add_study, study)
+            loaded_study_count += 1
+
+        _logger.info("Successfully loaded %s studies.", loaded_study_count)
+
+
+def load_from_json(src_transformed_cdm: Path, driver: Driver | None = None) -> None:
+    """Load evidence into DB from given CDM JSON file.
+
+    :param src_transformed_cdm: path to file for a source's transformed data to
+        common data model containing studies, variation, therapeutic procedures,
+        conditions, genes, methods, documents, etc.
+    :param driver: Neo4j graph driver, if available
+    """
+    _logger.info("Loading data from %s", src_transformed_cdm)
+    if not driver:
+        driver = get_driver()
+    with src_transformed_cdm.open() as f:
+        items = json.load(f)
+        src_name = SourceName(str(src_transformed_cdm).split("/")[-1].split("_cdm")[0])
+        add_transformed_data(driver, items, src_name)

--- a/src/metakb/load_data.py
+++ b/src/metakb/load_data.py
@@ -112,13 +112,9 @@ def _add_gene_or_disease(
     obj_keys = ", ".join(obj_keys)
 
     if obj_type == "Gene":
-        query = f"""
-        MERGE (g:Gene {{ {obj_keys} }});
-        """
+        query = f"MERGE (g:Gene {{ {obj_keys} }});"
     else:
-        query = f"""
-        MERGE (d:Disease:Condition {{ {obj_keys} }});
-        """
+        query = f"MERGE (d:Disease:Condition {{ {obj_keys} }});"
     tx.run(query, **obj)
 
 

--- a/src/metakb/load_data.py
+++ b/src/metakb/load_data.py
@@ -27,7 +27,6 @@ def _create_parameterized_query(
     return ", ".join(nonnull_keys)
 
 
-@staticmethod
 def _add_mappings_and_exts_to_obj(obj: dict, obj_keys: list[str]) -> None:
     """Get mappings and extensions from object and add to `obj` and `obj_keys`
 
@@ -189,7 +188,6 @@ def _add_therapeutic_agent(tx: ManagedTransaction, therapeutic_agent: dict) -> N
     tx.run(query, **ta)
 
 
-@staticmethod
 def _add_location(tx: ManagedTransaction, location_in: dict) -> None:
     """Add location node and its relationships
 
@@ -385,7 +383,6 @@ def _get_ids_from_studies(studies: list[dict]) -> set[str]:
     return ids_in_studies
 
 
-@staticmethod
 def _add_study(tx: ManagedTransaction, study_in: dict) -> None:
     """Add study node and its relationships
 

--- a/src/metakb/query.py
+++ b/src/metakb/query.py
@@ -86,14 +86,21 @@ class QueryHandler:
         """Initialize neo4j driver and the VICC normalizers.
 
         All arguments are optional; if not given, resources acquisition will be
-        attempted with default parameters. Pass arguments for ``uri`` and ``creds``
-        to provide them manually:
+        attempted with default parameters.
 
         >>> from metakb.query import QueryHandler
-        >>> from metakb.database import get_driver
-        >>> qh = QueryHandler(get_driver("bolt://localhost:7687", ("neo4j", "password")))
+        >>> qh = QueryHandler()
 
-        :param graph: database handler instance
+        Otherwise, pass resources directly to avoid duplication:
+
+        >>> from metakb.database import get_driver
+        >>> from metakb.normalizers import ViccNormalizers
+        >>> qh = QueryHandler(
+        ...     get_driver("bolt://localhost:7687", ("neo4j", "password")),
+        ...     ViccNormalizers("http://localhost:8000")
+        ... )
+
+        :param driver: driver instance for graph connection
         :param normalizers: normalizer collection instance
         """
         if driver is None:

--- a/tests/unit/database/test_database.py
+++ b/tests/unit/database/test_database.py
@@ -17,7 +17,7 @@ def sources_count():
 
 @pytest.fixture(scope="module")
 def driver():
-    """Return graph object."""
+    """Return Neo4j graph connection driver object."""
     driver = get_driver(uri="bolt://localhost:7687", credentials=("neo4j", "password"))
     yield driver
     driver.close()
@@ -30,7 +30,7 @@ def get_node_by_id(driver: Driver):
     def _get_node(node_id: str):
         query = f"MATCH (n {{id: '{node_id}'}}) RETURN (n)"
         result = driver.execute_query(query)
-        return result.records[0]
+        return result.records[0]["n"]
 
     return _get_node
 
@@ -227,417 +227,415 @@ def test_gene_rules(
     check_node_props(gene, civic_gid5, expected_keys, extension_names)
 
 
-#
-#
-# def test_variation_rules(
-#     graph,
-#     check_unique_property,
-#     check_relation_count,
-#     get_node_by_id,
-#     check_node_labels,
-#     civic_vid12,
-# ):
-#     """Verify property and relationship rules for Variation nodes."""
-#     check_unique_property("Variation", "id")
-#     # members dont have defining context
-#     check_relation_count(
-#         "Variation",
-#         "CategoricalVariation",
-#         "HAS_DEFINING_CONTEXT",
-#         direction="in",
-#         min_rels=0,
-#         max_rels=None,
-#     )
-#     check_relation_count(
-#         "Variation",
-#         "CategoricalVariation",
-#         "HAS_MEMBERS",
-#         min_rels=0,
-#         max_rels=None,
-#         direction="in",
-#     )
-#
-#     expected_labels = [{"Variation", "Allele"}]
-#     check_node_labels("Variation", expected_labels, 1)
-#
-#     # all Alleles are Variations and all Variations are Alleles
-#     label_query = """
-#     MATCH (v:Variation)
-#     WHERE NOT (v:Allele)
-#     RETURN COUNT(v)
-#     UNION
-#     MATCH (v:Allele)
-#     WHERE NOT (v:Variation)
-#     RETURN COUNT(v)
-#     """
-#     with graph.driver.session() as s:
-#         record = s.run(label_query).single()
-#     assert record.values()[0] == 0
-#
-#     v = get_node_by_id(civic_vid12["id"])
-#     assert set(v.keys()) == {
-#         "id",
-#         "label",
-#         "digest",
-#         "state",
-#         "expression_hgvs_p",
-#         "expression_hgvs_c",
-#         "expression_hgvs_g",
-#         "type",
-#     }
-#
-#     assert v["type"] == "Allele"
-#     assert v["label"] == civic_vid12["label"]
-#     assert v["digest"] == civic_vid12["digest"]
-#     assert json.loads(v["state"]) == civic_vid12["state"]
-#     expected_p, expected_c, expected_g = [], [], []
-#     for expr in civic_vid12["expressions"]:
-#         syntax = expr["syntax"]
-#         val = expr["value"]
-#         if syntax == "hgvs.p":
-#             expected_p.append(val)
-#         elif syntax == "hgvs.c":
-#             expected_c.append(val)
-#         elif syntax == "hgvs.g":
-#             expected_g.append(val)
-#
-#     assert v["expression_hgvs_p"] == expected_p
-#     assert set(v["expression_hgvs_c"]) == set(expected_c)
-#     assert v["expression_hgvs_g"] == expected_g
-#
-#
-# def test_categorical_variation_rules(
-#     check_unique_property,
-#     check_relation_count,
-#     check_node_labels,
-#     get_node_by_id,
-#     civic_mpid12,
-# ):
-#     """Verify property and relationship rules for Categorical Variation nodes."""
-#     check_unique_property("CategoricalVariation", "id")
-#     check_relation_count(
-#         "CategoricalVariation", "Variation", "HAS_DEFINING_CONTEXT", max_rels=1
-#     )
-#     check_relation_count(
-#         "CategoricalVariation", "Variation", "HAS_MEMBERS", min_rels=0, max_rels=None
-#     )
-#
-#     expected_node_labels = [{"CategoricalVariation", "ProteinSequenceConsequence"}]
-#     check_node_labels("CategoricalVariation", expected_node_labels, 1)
-#
-#     cv = get_node_by_id(civic_mpid12["id"])
-#     assert set(cv.keys()) == {
-#         "id",
-#         "label",
-#         "description",
-#         "aliases",
-#         "civic_molecular_profile_score",
-#         "civic_representative_coordinate",
-#         "mappings",
-#         "variant_types",
-#         "type",
-#     }
-#     assert cv["type"] == civic_mpid12["type"]
-#     assert cv["label"] == civic_mpid12["label"]
-#     assert cv["description"] == civic_mpid12["description"]
-#     assert set(cv["aliases"]) == set(civic_mpid12["aliases"])
-#     assert isinstance(cv["civic_molecular_profile_score"], float)
-#     crc = json.loads(cv["civic_representative_coordinate"])
-#     assert set(crc.keys()) == {
-#         "ensembl_version",
-#         "reference_build",
-#         "reference_bases",
-#         "variant_bases",
-#         "representative_transcript",
-#         "chromosome",
-#         "start",
-#         "stop",
-#         "type",
-#     }
-#     mappings = json.loads(cv["mappings"])
-#     for m in mappings:
-#         assert isinstance(m["coding"], dict)
-#         assert isinstance(m["relation"], str)
-#
-#     variant_types = json.loads(cv["variant_types"])
-#     for vt in variant_types:
-#         assert set(vt.keys()) == {"label", "system", "version", "code"}
-#
-#
-# def test_location_rules(
-#     check_unique_property, check_relation_count, check_node_labels, get_node_by_id
-# ):
-#     """Verify property and relationship rules for Location nodes."""
-#     check_unique_property("Location", "id")
-#     check_relation_count(
-#         "Location", "Variation", "HAS_LOCATION", direction="in", max_rels=None
-#     )
-#
-#     expected_labels = [{"Location", "SequenceLocation"}]
-#     check_node_labels("Location", expected_labels, 1)
-#
-#     # NP_005219.2:p.Val769_Asp770insAlaSerVal
-#     loc_digest = "7qyw-4VUk3oCczBuoaF_8vGQo19dM_mk"
-#     loc = get_node_by_id(f"ga4gh:SL.{loc_digest}")
-#     assert set(loc.keys()) == {
-#         "id",
-#         "digest",
-#         "sequence_reference",
-#         "start",
-#         "end",
-#         "type",
-#     }
-#     assert json.loads(loc["sequence_reference"]) == {
-#         "type": "SequenceReference",
-#         "refgetAccession": "SQ.vyo55F6mA6n2LgN4cagcdRzOuh38V4mE",
-#     }
-#     assert loc["start"] == 766
-#     assert loc["end"] == 769
-#     assert loc["type"] == "SequenceLocation"
-#     assert loc["digest"] == loc_digest
-#
-#
-# def test_therapeutic_procedure_rules(
-#     check_unique_property,
-#     check_relation_count,
-#     check_node_labels,
-#     get_node_by_id,
-#     civic_tid146,
-#     check_node_props,
-#     check_extension_props,
-#     civic_ct,
-#     civic_tsg,
-# ):
-#     """Verify property and relationship rules for Therapeutic Procedure nodes."""
-#     check_unique_property("TherapeuticProcedure", "id")
-#     # min_rels is 0 because TherapeuticAgent may not be attached to study directly, but
-#     # through CombinationTherapy and TherapeuticSubstituteGroup
-#     check_relation_count(
-#         "TherapeuticProcedure",
-#         "Study",
-#         "HAS_THERAPEUTIC",
-#         min_rels=0,
-#         max_rels=None,
-#         direction="in",
-#     )
-#     check_relation_count(
-#         "CombinationTherapy", "TherapeuticAgent", "HAS_COMPONENTS", max_rels=None
-#     )
-#     check_relation_count(
-#         "CombinationTherapy", "Study", "HAS_THERAPEUTIC", max_rels=None, direction="in"
-#     )
-#     check_relation_count(
-#         "TherapeuticSubstituteGroup",
-#         "TherapeuticAgent",
-#         "HAS_SUBSTITUTES",
-#         max_rels=None,
-#     )
-#     check_relation_count(
-#         "TherapeuticSubstituteGroup",
-#         "Study",
-#         "HAS_THERAPEUTIC",
-#         max_rels=None,
-#         direction="in",
-#     )
-#
-#     expected_node_labels = [
-#         {"TherapeuticProcedure", "TherapeuticAgent"},
-#         {"TherapeuticProcedure", "CombinationTherapy"},
-#         {"TherapeuticProcedure", "TherapeuticSubstituteGroup"},
-#     ]
-#     check_node_labels("TherapeuticProcedure", expected_node_labels, 3)
-#
-#     # Test TherapeuticAgent
-#     ta = get_node_by_id(civic_tid146["id"])
-#     extension_names = {"therapy_normalizer_id", "regulatory_approval"}
-#     check_extension_props(ta, civic_tid146["extensions"], extension_names)
-#     expected_keys = {
-#         "id",
-#         "label",
-#         "aliases",
-#         "therapy_normalizer_id",
-#         "regulatory_approval",
-#         "mappings",
-#         "type",
-#     }
-#     check_node_props(ta, civic_tid146, expected_keys, extension_names)
-#
-#     # Test CombinationTherapy
-#     ct = get_node_by_id(civic_ct["id"])
-#     check_extension_props(
-#         ct, civic_ct["extensions"], {"civic_therapy_interaction_type"}
-#     )
-#     assert ct["type"] == civic_ct["type"]
-#
-#     # Test TherapeuticSubstituteGroup
-#     tsg = get_node_by_id(civic_tsg["id"])
-#     check_extension_props(
-#         tsg, civic_tsg["extensions"], {"civic_therapy_interaction_type"}
-#     )
-#     assert tsg["type"] == tsg["type"]
-#
-#
-# def test_condition_rules(
-#     check_unique_property,
-#     check_relation_count,
-#     check_node_labels,
-#     get_node_by_id,
-#     civic_did8,
-#     check_node_props,
-#     check_extension_props,
-# ):
-#     """Verify property and relationship rules for condition nodes."""
-#     check_unique_property("Condition", "id")
-#     check_relation_count(
-#         "Condition", "Study", "HAS_TUMOR_TYPE", max_rels=None, direction="in"
-#     )
-#
-#     expected_node_labels = [{"Disease", "Condition"}]
-#     check_node_labels("Condition", expected_node_labels, 1)
-#
-#     disease = get_node_by_id(civic_did8["id"])
-#     extension_names = {"disease_normalizer_id"}
-#     check_extension_props(disease, civic_did8["extensions"], extension_names)
-#     expected_keys = {"id", "label", "mappings", "disease_normalizer_id", "type"}
-#     check_node_props(disease, civic_did8, expected_keys, extension_names)
-#
-#
-# def test_study_rules(
-#     graph: Graph,
-#     check_unique_property,
-#     check_relation_count,
-#     check_node_labels,
-#     get_node_by_id,
-#     civic_eid2997_study,
-#     check_node_props,
-# ):
-#     """Verify property and relationship rules for Study nodes."""
-#     check_unique_property("Study", "id")
-#
-#     check_relation_count("Study", "CategoricalVariation", "HAS_VARIANT")
-#     check_relation_count("Study", "Condition", "HAS_TUMOR_TYPE")
-#     check_relation_count("Study", "TherapeuticProcedure", "HAS_THERAPEUTIC")
-#     check_relation_count("Study", "Coding", "HAS_STRENGTH")
-#     check_relation_count("Study", "Method", "IS_SPECIFIED_BY", max_rels=None)
-#     check_relation_count("Study", "Gene", "HAS_GENE_CONTEXT", max_rels=None)
-#
-#     expected_node_labels = [{"Study", "VariantTherapeuticResponseStudy"}]
-#     check_node_labels("Study", expected_node_labels, 1)
-#
-#     cite_query = """
-#     MATCH (s:Study)
-#     OPTIONAL MATCH (s)-[:IS_REPORTED_IN]->(d:Document)
-#     WITH s, COUNT(d) as d_count
-#     WHERE d_count < 1
-#     RETURN COUNT(s)
-#     """
-#     with graph.driver.session() as s:
-#         record = s.run(cite_query).single()
-#     assert record.values()[0] == 0
-#
-#     study = get_node_by_id(civic_eid2997_study["id"])
-#     expected_keys = {
-#         "id",
-#         "description",
-#         "direction",
-#         "predicate",
-#         "alleleOrigin",
-#         "type",
-#     }
-#     civic_eid2997_study_cp = civic_eid2997_study.copy()
-#     civic_eid2997_study_cp["alleleOrigin"] = civic_eid2997_study_cp["qualifiers"][
-#         "alleleOrigin"
-#     ]
-#     check_node_props(study, civic_eid2997_study_cp, expected_keys)
-#
-#
-# def test_document_rules(
-#     graph,
-#     check_unique_property,
-#     check_node_labels,
-#     check_relation_count,
-#     get_node_by_id,
-#     moa_source45,
-#     check_node_props,
-#     check_extension_props,
-# ):
-#     """Verify property and relationship rules for Document nodes."""
-#     check_unique_property("Document", "id")
-#     check_relation_count(
-#         "Document", "Study", "IS_REPORTED_IN", min_rels=0, max_rels=None, direction="in"
-#     )
-#
-#     expected_labels = [{"Document"}]
-#     check_node_labels("Document", expected_labels, 1)
-#
-#     # PMIDs: 31779674 and 35121878 do not have this relationship
-#     is_reported_in_query = """
-#     MATCH (s:Document)
-#     OPTIONAL MATCH (s)<-[:IS_REPORTED_IN]-(d:Study)
-#     WITH s, COUNT(d) as d_count
-#     WHERE (d_count < 1) AND (s.pmid <> 31779674) AND (s.pmid <> 35121878)
-#     RETURN COUNT(s)
-#     """
-#     with graph.driver.session() as s:
-#         record = s.run(is_reported_in_query).single()
-#     assert record.values()[0] == 0
-#
-#     # PMIDs: 31779674 and 35121878 are only used in methods
-#     is_reported_in_query = """
-#     MATCH (s)<-[:IS_REPORTED_IN]-(d:Method)
-#     RETURN collect(s.pmid)
-#     """
-#     with graph.driver.session() as s:
-#         record = s.run(is_reported_in_query).single()
-#     assert set(record.values()[0]) == {31779674, 35121878}
-#
-#     doc = get_node_by_id(moa_source45["id"])
-#     extension_names = {"source_type"}
-#     check_extension_props(doc, moa_source45["extensions"], extension_names)
-#     expected_keys = {"id", "title", "doi", "source_type", "url", "pmid"}
-#     check_node_props(doc, moa_source45, expected_keys, extension_names)
-#
-#
-# def test_method_rules(
-#     check_unique_property,
-#     check_node_labels,
-#     check_relation_count,
-#     get_node_by_id,
-#     civic_method,
-#     check_node_props,
-# ):
-#     """Verify property and relationship rules for Method nodes."""
-#     check_unique_property("Method", "id")
-#     check_relation_count(
-#         "Method", "Study", "IS_SPECIFIED_BY", max_rels=None, direction="in"
-#     )
-#
-#     expected_node_labels = [{"Method"}]
-#     check_node_labels("Method", expected_node_labels, 1)
-#
-#     method = get_node_by_id(civic_method["id"])
-#     expected_keys = {"id", "label"}
-#     check_node_props(method, civic_method, expected_keys)
-#
-#
-# def test_no_lost_nodes(graph: Graph):
-#     """Verify that no unlabeled or isolated nodes have been created."""
-#     # non-normalizable nodes can be excepted
-#     labels_query = """
-#     MATCH (n)
-#     WHERE size(labels(n)) = 0
-#     AND NOT (n)<-[:IS_REPORTED_IN]-(:Study)
-#     RETURN COUNT(n)
-#     """
-#     with graph.driver.session() as s:
-#         record = s.run(labels_query).single()
-#     assert record.values()[0] == 0
-#
-#     rels_query = """
-#     MATCH (n)
-#     WHERE NOT (n)--()
-#     RETURN COUNT(n)
-#     """
-#     with graph.driver.session() as s:
-#         result = s.run(rels_query).single()
-#     assert result.values()[0] == 0
+def test_variation_rules(
+    driver: Driver,
+    check_unique_property,
+    check_relation_count,
+    get_node_by_id,
+    check_node_labels,
+    civic_vid12,
+):
+    """Verify property and relationship rules for Variation nodes."""
+    check_unique_property("Variation", "id")
+    # members dont have defining context
+    check_relation_count(
+        "Variation",
+        "CategoricalVariation",
+        "HAS_DEFINING_CONTEXT",
+        direction="in",
+        min_rels=0,
+        max_rels=None,
+    )
+    check_relation_count(
+        "Variation",
+        "CategoricalVariation",
+        "HAS_MEMBERS",
+        min_rels=0,
+        max_rels=None,
+        direction="in",
+    )
+
+    expected_labels = [{"Variation", "Allele"}]
+    check_node_labels("Variation", expected_labels, 1)
+
+    # all Alleles are Variations and all Variations are Alleles
+    label_query = """
+    MATCH (v:Variation)
+    WHERE NOT (v:Allele)
+    RETURN COUNT(v)
+    UNION
+    MATCH (v:Allele)
+    WHERE NOT (v:Variation)
+    RETURN COUNT(v)
+    """
+    with driver.session() as s:
+        record = s.run(label_query).single()
+    assert record.values()[0] == 0
+
+    v = get_node_by_id(civic_vid12["id"])
+    assert set(v.keys()) == {
+        "id",
+        "label",
+        "digest",
+        "state",
+        "expression_hgvs_p",
+        "expression_hgvs_c",
+        "expression_hgvs_g",
+        "type",
+    }
+
+    assert v["type"] == "Allele"
+    assert v["label"] == civic_vid12["label"]
+    assert v["digest"] == civic_vid12["digest"]
+    assert json.loads(v["state"]) == civic_vid12["state"]
+    expected_p, expected_c, expected_g = [], [], []
+    for expr in civic_vid12["expressions"]:
+        syntax = expr["syntax"]
+        val = expr["value"]
+        if syntax == "hgvs.p":
+            expected_p.append(val)
+        elif syntax == "hgvs.c":
+            expected_c.append(val)
+        elif syntax == "hgvs.g":
+            expected_g.append(val)
+
+    assert v["expression_hgvs_p"] == expected_p
+    assert set(v["expression_hgvs_c"]) == set(expected_c)
+    assert v["expression_hgvs_g"] == expected_g
+
+
+def test_categorical_variation_rules(
+    check_unique_property,
+    check_relation_count,
+    check_node_labels,
+    get_node_by_id,
+    civic_mpid12,
+):
+    """Verify property and relationship rules for Categorical Variation nodes."""
+    check_unique_property("CategoricalVariation", "id")
+    check_relation_count(
+        "CategoricalVariation", "Variation", "HAS_DEFINING_CONTEXT", max_rels=1
+    )
+    check_relation_count(
+        "CategoricalVariation", "Variation", "HAS_MEMBERS", min_rels=0, max_rels=None
+    )
+
+    expected_node_labels = [{"CategoricalVariation", "ProteinSequenceConsequence"}]
+    check_node_labels("CategoricalVariation", expected_node_labels, 1)
+
+    cv = get_node_by_id(civic_mpid12["id"])
+    assert set(cv.keys()) == {
+        "id",
+        "label",
+        "description",
+        "aliases",
+        "civic_molecular_profile_score",
+        "civic_representative_coordinate",
+        "mappings",
+        "variant_types",
+        "type",
+    }
+    assert cv["type"] == civic_mpid12["type"]
+    assert cv["label"] == civic_mpid12["label"]
+    assert cv["description"] == civic_mpid12["description"]
+    assert set(cv["aliases"]) == set(civic_mpid12["aliases"])
+    assert isinstance(cv["civic_molecular_profile_score"], float)
+    crc = json.loads(cv["civic_representative_coordinate"])
+    assert set(crc.keys()) == {
+        "ensembl_version",
+        "reference_build",
+        "reference_bases",
+        "variant_bases",
+        "representative_transcript",
+        "chromosome",
+        "start",
+        "stop",
+        "type",
+    }
+    mappings = json.loads(cv["mappings"])
+    for m in mappings:
+        assert isinstance(m["coding"], dict)
+        assert isinstance(m["relation"], str)
+
+    variant_types = json.loads(cv["variant_types"])
+    for vt in variant_types:
+        assert set(vt.keys()) == {"label", "system", "version", "code"}
+
+
+def test_location_rules(
+    check_unique_property, check_relation_count, check_node_labels, get_node_by_id
+):
+    """Verify property and relationship rules for Location nodes."""
+    check_unique_property("Location", "id")
+    check_relation_count(
+        "Location", "Variation", "HAS_LOCATION", direction="in", max_rels=None
+    )
+
+    expected_labels = [{"Location", "SequenceLocation"}]
+    check_node_labels("Location", expected_labels, 1)
+
+    # NP_005219.2:p.Val769_Asp770insAlaSerVal
+    loc_digest = "7qyw-4VUk3oCczBuoaF_8vGQo19dM_mk"
+    loc = get_node_by_id(f"ga4gh:SL.{loc_digest}")
+    assert set(loc.keys()) == {
+        "id",
+        "digest",
+        "sequence_reference",
+        "start",
+        "end",
+        "type",
+    }
+    assert json.loads(loc["sequence_reference"]) == {
+        "type": "SequenceReference",
+        "refgetAccession": "SQ.vyo55F6mA6n2LgN4cagcdRzOuh38V4mE",
+    }
+    assert loc["start"] == 766
+    assert loc["end"] == 769
+    assert loc["type"] == "SequenceLocation"
+    assert loc["digest"] == loc_digest
+
+
+def test_therapeutic_procedure_rules(
+    check_unique_property,
+    check_relation_count,
+    check_node_labels,
+    get_node_by_id,
+    civic_tid146,
+    check_node_props,
+    check_extension_props,
+    civic_ct,
+    civic_tsg,
+):
+    """Verify property and relationship rules for Therapeutic Procedure nodes."""
+    check_unique_property("TherapeuticProcedure", "id")
+    # min_rels is 0 because TherapeuticAgent may not be attached to study directly, but
+    # through CombinationTherapy and TherapeuticSubstituteGroup
+    check_relation_count(
+        "TherapeuticProcedure",
+        "Study",
+        "HAS_THERAPEUTIC",
+        min_rels=0,
+        max_rels=None,
+        direction="in",
+    )
+    check_relation_count(
+        "CombinationTherapy", "TherapeuticAgent", "HAS_COMPONENTS", max_rels=None
+    )
+    check_relation_count(
+        "CombinationTherapy", "Study", "HAS_THERAPEUTIC", max_rels=None, direction="in"
+    )
+    check_relation_count(
+        "TherapeuticSubstituteGroup",
+        "TherapeuticAgent",
+        "HAS_SUBSTITUTES",
+        max_rels=None,
+    )
+    check_relation_count(
+        "TherapeuticSubstituteGroup",
+        "Study",
+        "HAS_THERAPEUTIC",
+        max_rels=None,
+        direction="in",
+    )
+
+    expected_node_labels = [
+        {"TherapeuticProcedure", "TherapeuticAgent"},
+        {"TherapeuticProcedure", "CombinationTherapy"},
+        {"TherapeuticProcedure", "TherapeuticSubstituteGroup"},
+    ]
+    check_node_labels("TherapeuticProcedure", expected_node_labels, 3)
+
+    # Test TherapeuticAgent
+    ta = get_node_by_id(civic_tid146["id"])
+    extension_names = {"therapy_normalizer_id", "regulatory_approval"}
+    check_extension_props(ta, civic_tid146["extensions"], extension_names)
+    expected_keys = {
+        "id",
+        "label",
+        "aliases",
+        "therapy_normalizer_id",
+        "regulatory_approval",
+        "mappings",
+        "type",
+    }
+    check_node_props(ta, civic_tid146, expected_keys, extension_names)
+
+    # Test CombinationTherapy
+    ct = get_node_by_id(civic_ct["id"])
+    check_extension_props(
+        ct, civic_ct["extensions"], {"civic_therapy_interaction_type"}
+    )
+    assert ct["type"] == civic_ct["type"]
+
+    # Test TherapeuticSubstituteGroup
+    tsg = get_node_by_id(civic_tsg["id"])
+    check_extension_props(
+        tsg, civic_tsg["extensions"], {"civic_therapy_interaction_type"}
+    )
+    assert tsg["type"] == tsg["type"]
+
+
+def test_condition_rules(
+    check_unique_property,
+    check_relation_count,
+    check_node_labels,
+    get_node_by_id,
+    civic_did8,
+    check_node_props,
+    check_extension_props,
+):
+    """Verify property and relationship rules for condition nodes."""
+    check_unique_property("Condition", "id")
+    check_relation_count(
+        "Condition", "Study", "HAS_TUMOR_TYPE", max_rels=None, direction="in"
+    )
+
+    expected_node_labels = [{"Disease", "Condition"}]
+    check_node_labels("Condition", expected_node_labels, 1)
+
+    disease = get_node_by_id(civic_did8["id"])
+    extension_names = {"disease_normalizer_id"}
+    check_extension_props(disease, civic_did8["extensions"], extension_names)
+    expected_keys = {"id", "label", "mappings", "disease_normalizer_id", "type"}
+    check_node_props(disease, civic_did8, expected_keys, extension_names)
+
+
+def test_study_rules(
+    driver: Driver,
+    check_unique_property,
+    check_relation_count,
+    check_node_labels,
+    get_node_by_id,
+    civic_eid2997_study,
+    check_node_props,
+):
+    """Verify property and relationship rules for Study nodes."""
+    check_unique_property("Study", "id")
+
+    check_relation_count("Study", "CategoricalVariation", "HAS_VARIANT")
+    check_relation_count("Study", "Condition", "HAS_TUMOR_TYPE")
+    check_relation_count("Study", "TherapeuticProcedure", "HAS_THERAPEUTIC")
+    check_relation_count("Study", "Coding", "HAS_STRENGTH")
+    check_relation_count("Study", "Method", "IS_SPECIFIED_BY", max_rels=None)
+    check_relation_count("Study", "Gene", "HAS_GENE_CONTEXT", max_rels=None)
+
+    expected_node_labels = [{"Study", "VariantTherapeuticResponseStudy"}]
+    check_node_labels("Study", expected_node_labels, 1)
+
+    cite_query = """
+    MATCH (s:Study)
+    OPTIONAL MATCH (s)-[:IS_REPORTED_IN]->(d:Document)
+    WITH s, COUNT(d) as d_count
+    WHERE d_count < 1
+    RETURN COUNT(s)
+    """
+    with driver.session() as s:
+        record = s.run(cite_query).single()
+    assert record.values()[0] == 0
+
+    study = get_node_by_id(civic_eid2997_study["id"])
+    expected_keys = {
+        "id",
+        "description",
+        "direction",
+        "predicate",
+        "alleleOrigin",
+        "type",
+    }
+    civic_eid2997_study_cp = civic_eid2997_study.copy()
+    civic_eid2997_study_cp["alleleOrigin"] = civic_eid2997_study_cp["qualifiers"][
+        "alleleOrigin"
+    ]
+    check_node_props(study, civic_eid2997_study_cp, expected_keys)
+
+
+def test_document_rules(
+    driver: Driver,
+    check_unique_property,
+    check_node_labels,
+    check_relation_count,
+    get_node_by_id,
+    moa_source45,
+    check_node_props,
+    check_extension_props,
+):
+    """Verify property and relationship rules for Document nodes."""
+    check_unique_property("Document", "id")
+    check_relation_count(
+        "Document", "Study", "IS_REPORTED_IN", min_rels=0, max_rels=None, direction="in"
+    )
+
+    expected_labels = [{"Document"}]
+    check_node_labels("Document", expected_labels, 1)
+
+    # PMIDs: 31779674 and 35121878 do not have this relationship
+    is_reported_in_query = """
+    MATCH (s:Document)
+    OPTIONAL MATCH (s)<-[:IS_REPORTED_IN]-(d:Study)
+    WITH s, COUNT(d) as d_count
+    WHERE (d_count < 1) AND (s.pmid <> 31779674) AND (s.pmid <> 35121878)
+    RETURN COUNT(s)
+    """
+    with driver.session() as s:
+        record = s.run(is_reported_in_query).single()
+    assert record.values()[0] == 0
+
+    # PMIDs: 31779674 and 35121878 are only used in methods
+    is_reported_in_query = """
+    MATCH (s)<-[:IS_REPORTED_IN]-(d:Method)
+    RETURN collect(s.pmid)
+    """
+    with driver.session() as s:
+        record = s.run(is_reported_in_query).single()
+    assert set(record.values()[0]) == {31779674, 35121878}
+
+    doc = get_node_by_id(moa_source45["id"])
+    extension_names = {"source_type"}
+    check_extension_props(doc, moa_source45["extensions"], extension_names)
+    expected_keys = {"id", "title", "doi", "source_type", "url", "pmid"}
+    check_node_props(doc, moa_source45, expected_keys, extension_names)
+
+
+def test_method_rules(
+    check_unique_property,
+    check_node_labels,
+    check_relation_count,
+    get_node_by_id,
+    civic_method,
+    check_node_props,
+):
+    """Verify property and relationship rules for Method nodes."""
+    check_unique_property("Method", "id")
+    check_relation_count(
+        "Method", "Study", "IS_SPECIFIED_BY", max_rels=None, direction="in"
+    )
+
+    expected_node_labels = [{"Method"}]
+    check_node_labels("Method", expected_node_labels, 1)
+
+    method = get_node_by_id(civic_method["id"])
+    expected_keys = {"id", "label"}
+    check_node_props(method, civic_method, expected_keys)
+
+
+def test_no_lost_nodes(driver: Driver):
+    """Verify that no unlabeled or isolated nodes have been created."""
+    # non-normalizable nodes can be excepted
+    labels_query = """
+    MATCH (n)
+    WHERE size(labels(n)) = 0
+    AND NOT (n)<-[:IS_REPORTED_IN]-(:Study)
+    RETURN COUNT(n)
+    """
+    with driver.session() as s:
+        record = s.run(labels_query).single()
+    assert record.values()[0] == 0
+
+    rels_query = """
+    MATCH (n)
+    WHERE NOT (n)--()
+    RETURN COUNT(n)
+    """
+    with driver.session() as s:
+        result = s.run(rels_query).single()
+    assert result.values()[0] == 0

--- a/tests/unit/database/test_database.py
+++ b/tests/unit/database/test_database.py
@@ -2,9 +2,10 @@
 import json
 
 import pytest
+from neo4j import Driver
 from neo4j.graph import Node
 
-from metakb.database import Graph
+from metakb.database import get_driver
 from metakb.schemas.app import SourceName
 
 
@@ -15,28 +16,27 @@ def sources_count():
 
 
 @pytest.fixture(scope="module")
-def graph():
+def driver():
     """Return graph object."""
-    g = Graph(uri="bolt://localhost:7687", credentials=("neo4j", "password"))
-    yield g
-    g.close()
+    driver = get_driver(uri="bolt://localhost:7687", credentials=("neo4j", "password"))
+    yield driver
+    driver.close()
 
 
 @pytest.fixture(scope="module")
-def get_node_by_id(graph: Graph):
+def get_node_by_id(driver: Driver):
     """Return node by its ID"""
 
     def _get_node(node_id: str):
         query = f"MATCH (n {{id: '{node_id}'}}) RETURN (n)"
-        with graph.driver.session() as s:
-            record = s.run(query).single(strict=True)
-        return record[0]
+        result = driver.execute_query(query)
+        return result.records[0]
 
     return _get_node
 
 
 @pytest.fixture(scope="module")
-def check_unique_property(graph: Graph):
+def check_unique_property(driver: Driver):
     """Verify that nodes satisfy uniqueness property"""
 
     def _check_function(label: str, prop: str):
@@ -46,7 +46,7 @@ def check_unique_property(graph: Graph):
         WHERE x_count > 1
         RETURN COUNT({prop})
         """
-        with graph.driver.session() as s:
+        with driver.session() as s:
             record = s.run(query).single()
 
         assert record.values()[0] == 0
@@ -55,7 +55,7 @@ def check_unique_property(graph: Graph):
 
 
 @pytest.fixture(scope="module")
-def get_node_labels(graph: Graph):
+def get_node_labels(driver: Driver):
     """Get node labels"""
 
     def _get_labels_function(parent_label: str):
@@ -63,7 +63,7 @@ def get_node_labels(graph: Graph):
         MATCH (n:{parent_label})
         RETURN collect(DISTINCT labels(n))
         """
-        with graph.driver.session() as s:
+        with driver.session() as s:
             record = s.run(query).single()
         return record.values()[0]
 
@@ -87,7 +87,7 @@ def check_node_labels(get_node_labels: callable):
 
 
 @pytest.fixture(scope="module")
-def check_study_relation(graph: Graph):
+def check_study_relation(driver: Driver):
     """Check that node is used in a study."""
 
     def _check_function(value_label: str):
@@ -98,7 +98,7 @@ def check_study_relation(graph: Graph):
         WHERE s_count < 1
         RETURN COUNT(s_count)
         """
-        with graph.driver.session() as s:
+        with driver.session() as s:
             record = s.run(query).single()
         assert record.values()[0] == 0
 
@@ -106,7 +106,7 @@ def check_study_relation(graph: Graph):
 
 
 @pytest.fixture(scope="module")
-def check_relation_count(graph: Graph):
+def check_relation_count(driver: Driver):
     """Check that the quantity of relationships from one Node type to another
     are within a certain range.
     """
@@ -136,7 +136,7 @@ def check_relation_count(graph: Graph):
             {f"OR d_count > {max_rels}" if max_rels is not None else ""}
         RETURN COUNT(s)
         """
-        with graph.driver.session() as s:
+        with driver.session() as s:
             record = s.run(query).single()
         assert record.values()[0] == 0
 
@@ -227,415 +227,417 @@ def test_gene_rules(
     check_node_props(gene, civic_gid5, expected_keys, extension_names)
 
 
-def test_variation_rules(
-    graph,
-    check_unique_property,
-    check_relation_count,
-    get_node_by_id,
-    check_node_labels,
-    civic_vid12,
-):
-    """Verify property and relationship rules for Variation nodes."""
-    check_unique_property("Variation", "id")
-    # members dont have defining context
-    check_relation_count(
-        "Variation",
-        "CategoricalVariation",
-        "HAS_DEFINING_CONTEXT",
-        direction="in",
-        min_rels=0,
-        max_rels=None,
-    )
-    check_relation_count(
-        "Variation",
-        "CategoricalVariation",
-        "HAS_MEMBERS",
-        min_rels=0,
-        max_rels=None,
-        direction="in",
-    )
-
-    expected_labels = [{"Variation", "Allele"}]
-    check_node_labels("Variation", expected_labels, 1)
-
-    # all Alleles are Variations and all Variations are Alleles
-    label_query = """
-    MATCH (v:Variation)
-    WHERE NOT (v:Allele)
-    RETURN COUNT(v)
-    UNION
-    MATCH (v:Allele)
-    WHERE NOT (v:Variation)
-    RETURN COUNT(v)
-    """
-    with graph.driver.session() as s:
-        record = s.run(label_query).single()
-    assert record.values()[0] == 0
-
-    v = get_node_by_id(civic_vid12["id"])
-    assert set(v.keys()) == {
-        "id",
-        "label",
-        "digest",
-        "state",
-        "expression_hgvs_p",
-        "expression_hgvs_c",
-        "expression_hgvs_g",
-        "type",
-    }
-
-    assert v["type"] == "Allele"
-    assert v["label"] == civic_vid12["label"]
-    assert v["digest"] == civic_vid12["digest"]
-    assert json.loads(v["state"]) == civic_vid12["state"]
-    expected_p, expected_c, expected_g = [], [], []
-    for expr in civic_vid12["expressions"]:
-        syntax = expr["syntax"]
-        val = expr["value"]
-        if syntax == "hgvs.p":
-            expected_p.append(val)
-        elif syntax == "hgvs.c":
-            expected_c.append(val)
-        elif syntax == "hgvs.g":
-            expected_g.append(val)
-
-    assert v["expression_hgvs_p"] == expected_p
-    assert set(v["expression_hgvs_c"]) == set(expected_c)
-    assert v["expression_hgvs_g"] == expected_g
-
-
-def test_categorical_variation_rules(
-    check_unique_property,
-    check_relation_count,
-    check_node_labels,
-    get_node_by_id,
-    civic_mpid12,
-):
-    """Verify property and relationship rules for Categorical Variation nodes."""
-    check_unique_property("CategoricalVariation", "id")
-    check_relation_count(
-        "CategoricalVariation", "Variation", "HAS_DEFINING_CONTEXT", max_rels=1
-    )
-    check_relation_count(
-        "CategoricalVariation", "Variation", "HAS_MEMBERS", min_rels=0, max_rels=None
-    )
-
-    expected_node_labels = [{"CategoricalVariation", "ProteinSequenceConsequence"}]
-    check_node_labels("CategoricalVariation", expected_node_labels, 1)
-
-    cv = get_node_by_id(civic_mpid12["id"])
-    assert set(cv.keys()) == {
-        "id",
-        "label",
-        "description",
-        "aliases",
-        "civic_molecular_profile_score",
-        "civic_representative_coordinate",
-        "mappings",
-        "variant_types",
-        "type",
-    }
-    assert cv["type"] == civic_mpid12["type"]
-    assert cv["label"] == civic_mpid12["label"]
-    assert cv["description"] == civic_mpid12["description"]
-    assert set(cv["aliases"]) == set(civic_mpid12["aliases"])
-    assert isinstance(cv["civic_molecular_profile_score"], float)
-    crc = json.loads(cv["civic_representative_coordinate"])
-    assert set(crc.keys()) == {
-        "ensembl_version",
-        "reference_build",
-        "reference_bases",
-        "variant_bases",
-        "representative_transcript",
-        "chromosome",
-        "start",
-        "stop",
-        "type",
-    }
-    mappings = json.loads(cv["mappings"])
-    for m in mappings:
-        assert isinstance(m["coding"], dict)
-        assert isinstance(m["relation"], str)
-
-    variant_types = json.loads(cv["variant_types"])
-    for vt in variant_types:
-        assert set(vt.keys()) == {"label", "system", "version", "code"}
-
-
-def test_location_rules(
-    check_unique_property, check_relation_count, check_node_labels, get_node_by_id
-):
-    """Verify property and relationship rules for Location nodes."""
-    check_unique_property("Location", "id")
-    check_relation_count(
-        "Location", "Variation", "HAS_LOCATION", direction="in", max_rels=None
-    )
-
-    expected_labels = [{"Location", "SequenceLocation"}]
-    check_node_labels("Location", expected_labels, 1)
-
-    # NP_005219.2:p.Val769_Asp770insAlaSerVal
-    loc_digest = "7qyw-4VUk3oCczBuoaF_8vGQo19dM_mk"
-    loc = get_node_by_id(f"ga4gh:SL.{loc_digest}")
-    assert set(loc.keys()) == {
-        "id",
-        "digest",
-        "sequence_reference",
-        "start",
-        "end",
-        "type",
-    }
-    assert json.loads(loc["sequence_reference"]) == {
-        "type": "SequenceReference",
-        "refgetAccession": "SQ.vyo55F6mA6n2LgN4cagcdRzOuh38V4mE",
-    }
-    assert loc["start"] == 766
-    assert loc["end"] == 769
-    assert loc["type"] == "SequenceLocation"
-    assert loc["digest"] == loc_digest
-
-
-def test_therapeutic_procedure_rules(
-    check_unique_property,
-    check_relation_count,
-    check_node_labels,
-    get_node_by_id,
-    civic_tid146,
-    check_node_props,
-    check_extension_props,
-    civic_ct,
-    civic_tsg,
-):
-    """Verify property and relationship rules for Therapeutic Procedure nodes."""
-    check_unique_property("TherapeuticProcedure", "id")
-    # min_rels is 0 because TherapeuticAgent may not be attached to study directly, but
-    # through CombinationTherapy and TherapeuticSubstituteGroup
-    check_relation_count(
-        "TherapeuticProcedure",
-        "Study",
-        "HAS_THERAPEUTIC",
-        min_rels=0,
-        max_rels=None,
-        direction="in",
-    )
-    check_relation_count(
-        "CombinationTherapy", "TherapeuticAgent", "HAS_COMPONENTS", max_rels=None
-    )
-    check_relation_count(
-        "CombinationTherapy", "Study", "HAS_THERAPEUTIC", max_rels=None, direction="in"
-    )
-    check_relation_count(
-        "TherapeuticSubstituteGroup",
-        "TherapeuticAgent",
-        "HAS_SUBSTITUTES",
-        max_rels=None,
-    )
-    check_relation_count(
-        "TherapeuticSubstituteGroup",
-        "Study",
-        "HAS_THERAPEUTIC",
-        max_rels=None,
-        direction="in",
-    )
-
-    expected_node_labels = [
-        {"TherapeuticProcedure", "TherapeuticAgent"},
-        {"TherapeuticProcedure", "CombinationTherapy"},
-        {"TherapeuticProcedure", "TherapeuticSubstituteGroup"},
-    ]
-    check_node_labels("TherapeuticProcedure", expected_node_labels, 3)
-
-    # Test TherapeuticAgent
-    ta = get_node_by_id(civic_tid146["id"])
-    extension_names = {"therapy_normalizer_id", "regulatory_approval"}
-    check_extension_props(ta, civic_tid146["extensions"], extension_names)
-    expected_keys = {
-        "id",
-        "label",
-        "aliases",
-        "therapy_normalizer_id",
-        "regulatory_approval",
-        "mappings",
-        "type",
-    }
-    check_node_props(ta, civic_tid146, expected_keys, extension_names)
-
-    # Test CombinationTherapy
-    ct = get_node_by_id(civic_ct["id"])
-    check_extension_props(
-        ct, civic_ct["extensions"], {"civic_therapy_interaction_type"}
-    )
-    assert ct["type"] == civic_ct["type"]
-
-    # Test TherapeuticSubstituteGroup
-    tsg = get_node_by_id(civic_tsg["id"])
-    check_extension_props(
-        tsg, civic_tsg["extensions"], {"civic_therapy_interaction_type"}
-    )
-    assert tsg["type"] == tsg["type"]
-
-
-def test_condition_rules(
-    check_unique_property,
-    check_relation_count,
-    check_node_labels,
-    get_node_by_id,
-    civic_did8,
-    check_node_props,
-    check_extension_props,
-):
-    """Verify property and relationship rules for condition nodes."""
-    check_unique_property("Condition", "id")
-    check_relation_count(
-        "Condition", "Study", "HAS_TUMOR_TYPE", max_rels=None, direction="in"
-    )
-
-    expected_node_labels = [{"Disease", "Condition"}]
-    check_node_labels("Condition", expected_node_labels, 1)
-
-    disease = get_node_by_id(civic_did8["id"])
-    extension_names = {"disease_normalizer_id"}
-    check_extension_props(disease, civic_did8["extensions"], extension_names)
-    expected_keys = {"id", "label", "mappings", "disease_normalizer_id", "type"}
-    check_node_props(disease, civic_did8, expected_keys, extension_names)
-
-
-def test_study_rules(
-    graph: Graph,
-    check_unique_property,
-    check_relation_count,
-    check_node_labels,
-    get_node_by_id,
-    civic_eid2997_study,
-    check_node_props,
-):
-    """Verify property and relationship rules for Study nodes."""
-    check_unique_property("Study", "id")
-
-    check_relation_count("Study", "CategoricalVariation", "HAS_VARIANT")
-    check_relation_count("Study", "Condition", "HAS_TUMOR_TYPE")
-    check_relation_count("Study", "TherapeuticProcedure", "HAS_THERAPEUTIC")
-    check_relation_count("Study", "Coding", "HAS_STRENGTH")
-    check_relation_count("Study", "Method", "IS_SPECIFIED_BY", max_rels=None)
-    check_relation_count("Study", "Gene", "HAS_GENE_CONTEXT", max_rels=None)
-
-    expected_node_labels = [{"Study", "VariantTherapeuticResponseStudy"}]
-    check_node_labels("Study", expected_node_labels, 1)
-
-    cite_query = """
-    MATCH (s:Study)
-    OPTIONAL MATCH (s)-[:IS_REPORTED_IN]->(d:Document)
-    WITH s, COUNT(d) as d_count
-    WHERE d_count < 1
-    RETURN COUNT(s)
-    """
-    with graph.driver.session() as s:
-        record = s.run(cite_query).single()
-    assert record.values()[0] == 0
-
-    study = get_node_by_id(civic_eid2997_study["id"])
-    expected_keys = {
-        "id",
-        "description",
-        "direction",
-        "predicate",
-        "alleleOrigin",
-        "type",
-    }
-    civic_eid2997_study_cp = civic_eid2997_study.copy()
-    civic_eid2997_study_cp["alleleOrigin"] = civic_eid2997_study_cp["qualifiers"][
-        "alleleOrigin"
-    ]
-    check_node_props(study, civic_eid2997_study_cp, expected_keys)
-
-
-def test_document_rules(
-    graph,
-    check_unique_property,
-    check_node_labels,
-    check_relation_count,
-    get_node_by_id,
-    moa_source45,
-    check_node_props,
-    check_extension_props,
-):
-    """Verify property and relationship rules for Document nodes."""
-    check_unique_property("Document", "id")
-    check_relation_count(
-        "Document", "Study", "IS_REPORTED_IN", min_rels=0, max_rels=None, direction="in"
-    )
-
-    expected_labels = [{"Document"}]
-    check_node_labels("Document", expected_labels, 1)
-
-    # PMIDs: 31779674 and 35121878 do not have this relationship
-    is_reported_in_query = """
-    MATCH (s:Document)
-    OPTIONAL MATCH (s)<-[:IS_REPORTED_IN]-(d:Study)
-    WITH s, COUNT(d) as d_count
-    WHERE (d_count < 1) AND (s.pmid <> 31779674) AND (s.pmid <> 35121878)
-    RETURN COUNT(s)
-    """
-    with graph.driver.session() as s:
-        record = s.run(is_reported_in_query).single()
-    assert record.values()[0] == 0
-
-    # PMIDs: 31779674 and 35121878 are only used in methods
-    is_reported_in_query = """
-    MATCH (s)<-[:IS_REPORTED_IN]-(d:Method)
-    RETURN collect(s.pmid)
-    """
-    with graph.driver.session() as s:
-        record = s.run(is_reported_in_query).single()
-    assert set(record.values()[0]) == {31779674, 35121878}
-
-    doc = get_node_by_id(moa_source45["id"])
-    extension_names = {"source_type"}
-    check_extension_props(doc, moa_source45["extensions"], extension_names)
-    expected_keys = {"id", "title", "doi", "source_type", "url", "pmid"}
-    check_node_props(doc, moa_source45, expected_keys, extension_names)
-
-
-def test_method_rules(
-    check_unique_property,
-    check_node_labels,
-    check_relation_count,
-    get_node_by_id,
-    civic_method,
-    check_node_props,
-):
-    """Verify property and relationship rules for Method nodes."""
-    check_unique_property("Method", "id")
-    check_relation_count(
-        "Method", "Study", "IS_SPECIFIED_BY", max_rels=None, direction="in"
-    )
-
-    expected_node_labels = [{"Method"}]
-    check_node_labels("Method", expected_node_labels, 1)
-
-    method = get_node_by_id(civic_method["id"])
-    expected_keys = {"id", "label"}
-    check_node_props(method, civic_method, expected_keys)
-
-
-def test_no_lost_nodes(graph: Graph):
-    """Verify that no unlabeled or isolated nodes have been created."""
-    # non-normalizable nodes can be excepted
-    labels_query = """
-    MATCH (n)
-    WHERE size(labels(n)) = 0
-    AND NOT (n)<-[:IS_REPORTED_IN]-(:Study)
-    RETURN COUNT(n)
-    """
-    with graph.driver.session() as s:
-        record = s.run(labels_query).single()
-    assert record.values()[0] == 0
-
-    rels_query = """
-    MATCH (n)
-    WHERE NOT (n)--()
-    RETURN COUNT(n)
-    """
-    with graph.driver.session() as s:
-        result = s.run(rels_query).single()
-    assert result.values()[0] == 0
+#
+#
+# def test_variation_rules(
+#     graph,
+#     check_unique_property,
+#     check_relation_count,
+#     get_node_by_id,
+#     check_node_labels,
+#     civic_vid12,
+# ):
+#     """Verify property and relationship rules for Variation nodes."""
+#     check_unique_property("Variation", "id")
+#     # members dont have defining context
+#     check_relation_count(
+#         "Variation",
+#         "CategoricalVariation",
+#         "HAS_DEFINING_CONTEXT",
+#         direction="in",
+#         min_rels=0,
+#         max_rels=None,
+#     )
+#     check_relation_count(
+#         "Variation",
+#         "CategoricalVariation",
+#         "HAS_MEMBERS",
+#         min_rels=0,
+#         max_rels=None,
+#         direction="in",
+#     )
+#
+#     expected_labels = [{"Variation", "Allele"}]
+#     check_node_labels("Variation", expected_labels, 1)
+#
+#     # all Alleles are Variations and all Variations are Alleles
+#     label_query = """
+#     MATCH (v:Variation)
+#     WHERE NOT (v:Allele)
+#     RETURN COUNT(v)
+#     UNION
+#     MATCH (v:Allele)
+#     WHERE NOT (v:Variation)
+#     RETURN COUNT(v)
+#     """
+#     with graph.driver.session() as s:
+#         record = s.run(label_query).single()
+#     assert record.values()[0] == 0
+#
+#     v = get_node_by_id(civic_vid12["id"])
+#     assert set(v.keys()) == {
+#         "id",
+#         "label",
+#         "digest",
+#         "state",
+#         "expression_hgvs_p",
+#         "expression_hgvs_c",
+#         "expression_hgvs_g",
+#         "type",
+#     }
+#
+#     assert v["type"] == "Allele"
+#     assert v["label"] == civic_vid12["label"]
+#     assert v["digest"] == civic_vid12["digest"]
+#     assert json.loads(v["state"]) == civic_vid12["state"]
+#     expected_p, expected_c, expected_g = [], [], []
+#     for expr in civic_vid12["expressions"]:
+#         syntax = expr["syntax"]
+#         val = expr["value"]
+#         if syntax == "hgvs.p":
+#             expected_p.append(val)
+#         elif syntax == "hgvs.c":
+#             expected_c.append(val)
+#         elif syntax == "hgvs.g":
+#             expected_g.append(val)
+#
+#     assert v["expression_hgvs_p"] == expected_p
+#     assert set(v["expression_hgvs_c"]) == set(expected_c)
+#     assert v["expression_hgvs_g"] == expected_g
+#
+#
+# def test_categorical_variation_rules(
+#     check_unique_property,
+#     check_relation_count,
+#     check_node_labels,
+#     get_node_by_id,
+#     civic_mpid12,
+# ):
+#     """Verify property and relationship rules for Categorical Variation nodes."""
+#     check_unique_property("CategoricalVariation", "id")
+#     check_relation_count(
+#         "CategoricalVariation", "Variation", "HAS_DEFINING_CONTEXT", max_rels=1
+#     )
+#     check_relation_count(
+#         "CategoricalVariation", "Variation", "HAS_MEMBERS", min_rels=0, max_rels=None
+#     )
+#
+#     expected_node_labels = [{"CategoricalVariation", "ProteinSequenceConsequence"}]
+#     check_node_labels("CategoricalVariation", expected_node_labels, 1)
+#
+#     cv = get_node_by_id(civic_mpid12["id"])
+#     assert set(cv.keys()) == {
+#         "id",
+#         "label",
+#         "description",
+#         "aliases",
+#         "civic_molecular_profile_score",
+#         "civic_representative_coordinate",
+#         "mappings",
+#         "variant_types",
+#         "type",
+#     }
+#     assert cv["type"] == civic_mpid12["type"]
+#     assert cv["label"] == civic_mpid12["label"]
+#     assert cv["description"] == civic_mpid12["description"]
+#     assert set(cv["aliases"]) == set(civic_mpid12["aliases"])
+#     assert isinstance(cv["civic_molecular_profile_score"], float)
+#     crc = json.loads(cv["civic_representative_coordinate"])
+#     assert set(crc.keys()) == {
+#         "ensembl_version",
+#         "reference_build",
+#         "reference_bases",
+#         "variant_bases",
+#         "representative_transcript",
+#         "chromosome",
+#         "start",
+#         "stop",
+#         "type",
+#     }
+#     mappings = json.loads(cv["mappings"])
+#     for m in mappings:
+#         assert isinstance(m["coding"], dict)
+#         assert isinstance(m["relation"], str)
+#
+#     variant_types = json.loads(cv["variant_types"])
+#     for vt in variant_types:
+#         assert set(vt.keys()) == {"label", "system", "version", "code"}
+#
+#
+# def test_location_rules(
+#     check_unique_property, check_relation_count, check_node_labels, get_node_by_id
+# ):
+#     """Verify property and relationship rules for Location nodes."""
+#     check_unique_property("Location", "id")
+#     check_relation_count(
+#         "Location", "Variation", "HAS_LOCATION", direction="in", max_rels=None
+#     )
+#
+#     expected_labels = [{"Location", "SequenceLocation"}]
+#     check_node_labels("Location", expected_labels, 1)
+#
+#     # NP_005219.2:p.Val769_Asp770insAlaSerVal
+#     loc_digest = "7qyw-4VUk3oCczBuoaF_8vGQo19dM_mk"
+#     loc = get_node_by_id(f"ga4gh:SL.{loc_digest}")
+#     assert set(loc.keys()) == {
+#         "id",
+#         "digest",
+#         "sequence_reference",
+#         "start",
+#         "end",
+#         "type",
+#     }
+#     assert json.loads(loc["sequence_reference"]) == {
+#         "type": "SequenceReference",
+#         "refgetAccession": "SQ.vyo55F6mA6n2LgN4cagcdRzOuh38V4mE",
+#     }
+#     assert loc["start"] == 766
+#     assert loc["end"] == 769
+#     assert loc["type"] == "SequenceLocation"
+#     assert loc["digest"] == loc_digest
+#
+#
+# def test_therapeutic_procedure_rules(
+#     check_unique_property,
+#     check_relation_count,
+#     check_node_labels,
+#     get_node_by_id,
+#     civic_tid146,
+#     check_node_props,
+#     check_extension_props,
+#     civic_ct,
+#     civic_tsg,
+# ):
+#     """Verify property and relationship rules for Therapeutic Procedure nodes."""
+#     check_unique_property("TherapeuticProcedure", "id")
+#     # min_rels is 0 because TherapeuticAgent may not be attached to study directly, but
+#     # through CombinationTherapy and TherapeuticSubstituteGroup
+#     check_relation_count(
+#         "TherapeuticProcedure",
+#         "Study",
+#         "HAS_THERAPEUTIC",
+#         min_rels=0,
+#         max_rels=None,
+#         direction="in",
+#     )
+#     check_relation_count(
+#         "CombinationTherapy", "TherapeuticAgent", "HAS_COMPONENTS", max_rels=None
+#     )
+#     check_relation_count(
+#         "CombinationTherapy", "Study", "HAS_THERAPEUTIC", max_rels=None, direction="in"
+#     )
+#     check_relation_count(
+#         "TherapeuticSubstituteGroup",
+#         "TherapeuticAgent",
+#         "HAS_SUBSTITUTES",
+#         max_rels=None,
+#     )
+#     check_relation_count(
+#         "TherapeuticSubstituteGroup",
+#         "Study",
+#         "HAS_THERAPEUTIC",
+#         max_rels=None,
+#         direction="in",
+#     )
+#
+#     expected_node_labels = [
+#         {"TherapeuticProcedure", "TherapeuticAgent"},
+#         {"TherapeuticProcedure", "CombinationTherapy"},
+#         {"TherapeuticProcedure", "TherapeuticSubstituteGroup"},
+#     ]
+#     check_node_labels("TherapeuticProcedure", expected_node_labels, 3)
+#
+#     # Test TherapeuticAgent
+#     ta = get_node_by_id(civic_tid146["id"])
+#     extension_names = {"therapy_normalizer_id", "regulatory_approval"}
+#     check_extension_props(ta, civic_tid146["extensions"], extension_names)
+#     expected_keys = {
+#         "id",
+#         "label",
+#         "aliases",
+#         "therapy_normalizer_id",
+#         "regulatory_approval",
+#         "mappings",
+#         "type",
+#     }
+#     check_node_props(ta, civic_tid146, expected_keys, extension_names)
+#
+#     # Test CombinationTherapy
+#     ct = get_node_by_id(civic_ct["id"])
+#     check_extension_props(
+#         ct, civic_ct["extensions"], {"civic_therapy_interaction_type"}
+#     )
+#     assert ct["type"] == civic_ct["type"]
+#
+#     # Test TherapeuticSubstituteGroup
+#     tsg = get_node_by_id(civic_tsg["id"])
+#     check_extension_props(
+#         tsg, civic_tsg["extensions"], {"civic_therapy_interaction_type"}
+#     )
+#     assert tsg["type"] == tsg["type"]
+#
+#
+# def test_condition_rules(
+#     check_unique_property,
+#     check_relation_count,
+#     check_node_labels,
+#     get_node_by_id,
+#     civic_did8,
+#     check_node_props,
+#     check_extension_props,
+# ):
+#     """Verify property and relationship rules for condition nodes."""
+#     check_unique_property("Condition", "id")
+#     check_relation_count(
+#         "Condition", "Study", "HAS_TUMOR_TYPE", max_rels=None, direction="in"
+#     )
+#
+#     expected_node_labels = [{"Disease", "Condition"}]
+#     check_node_labels("Condition", expected_node_labels, 1)
+#
+#     disease = get_node_by_id(civic_did8["id"])
+#     extension_names = {"disease_normalizer_id"}
+#     check_extension_props(disease, civic_did8["extensions"], extension_names)
+#     expected_keys = {"id", "label", "mappings", "disease_normalizer_id", "type"}
+#     check_node_props(disease, civic_did8, expected_keys, extension_names)
+#
+#
+# def test_study_rules(
+#     graph: Graph,
+#     check_unique_property,
+#     check_relation_count,
+#     check_node_labels,
+#     get_node_by_id,
+#     civic_eid2997_study,
+#     check_node_props,
+# ):
+#     """Verify property and relationship rules for Study nodes."""
+#     check_unique_property("Study", "id")
+#
+#     check_relation_count("Study", "CategoricalVariation", "HAS_VARIANT")
+#     check_relation_count("Study", "Condition", "HAS_TUMOR_TYPE")
+#     check_relation_count("Study", "TherapeuticProcedure", "HAS_THERAPEUTIC")
+#     check_relation_count("Study", "Coding", "HAS_STRENGTH")
+#     check_relation_count("Study", "Method", "IS_SPECIFIED_BY", max_rels=None)
+#     check_relation_count("Study", "Gene", "HAS_GENE_CONTEXT", max_rels=None)
+#
+#     expected_node_labels = [{"Study", "VariantTherapeuticResponseStudy"}]
+#     check_node_labels("Study", expected_node_labels, 1)
+#
+#     cite_query = """
+#     MATCH (s:Study)
+#     OPTIONAL MATCH (s)-[:IS_REPORTED_IN]->(d:Document)
+#     WITH s, COUNT(d) as d_count
+#     WHERE d_count < 1
+#     RETURN COUNT(s)
+#     """
+#     with graph.driver.session() as s:
+#         record = s.run(cite_query).single()
+#     assert record.values()[0] == 0
+#
+#     study = get_node_by_id(civic_eid2997_study["id"])
+#     expected_keys = {
+#         "id",
+#         "description",
+#         "direction",
+#         "predicate",
+#         "alleleOrigin",
+#         "type",
+#     }
+#     civic_eid2997_study_cp = civic_eid2997_study.copy()
+#     civic_eid2997_study_cp["alleleOrigin"] = civic_eid2997_study_cp["qualifiers"][
+#         "alleleOrigin"
+#     ]
+#     check_node_props(study, civic_eid2997_study_cp, expected_keys)
+#
+#
+# def test_document_rules(
+#     graph,
+#     check_unique_property,
+#     check_node_labels,
+#     check_relation_count,
+#     get_node_by_id,
+#     moa_source45,
+#     check_node_props,
+#     check_extension_props,
+# ):
+#     """Verify property and relationship rules for Document nodes."""
+#     check_unique_property("Document", "id")
+#     check_relation_count(
+#         "Document", "Study", "IS_REPORTED_IN", min_rels=0, max_rels=None, direction="in"
+#     )
+#
+#     expected_labels = [{"Document"}]
+#     check_node_labels("Document", expected_labels, 1)
+#
+#     # PMIDs: 31779674 and 35121878 do not have this relationship
+#     is_reported_in_query = """
+#     MATCH (s:Document)
+#     OPTIONAL MATCH (s)<-[:IS_REPORTED_IN]-(d:Study)
+#     WITH s, COUNT(d) as d_count
+#     WHERE (d_count < 1) AND (s.pmid <> 31779674) AND (s.pmid <> 35121878)
+#     RETURN COUNT(s)
+#     """
+#     with graph.driver.session() as s:
+#         record = s.run(is_reported_in_query).single()
+#     assert record.values()[0] == 0
+#
+#     # PMIDs: 31779674 and 35121878 are only used in methods
+#     is_reported_in_query = """
+#     MATCH (s)<-[:IS_REPORTED_IN]-(d:Method)
+#     RETURN collect(s.pmid)
+#     """
+#     with graph.driver.session() as s:
+#         record = s.run(is_reported_in_query).single()
+#     assert set(record.values()[0]) == {31779674, 35121878}
+#
+#     doc = get_node_by_id(moa_source45["id"])
+#     extension_names = {"source_type"}
+#     check_extension_props(doc, moa_source45["extensions"], extension_names)
+#     expected_keys = {"id", "title", "doi", "source_type", "url", "pmid"}
+#     check_node_props(doc, moa_source45, expected_keys, extension_names)
+#
+#
+# def test_method_rules(
+#     check_unique_property,
+#     check_node_labels,
+#     check_relation_count,
+#     get_node_by_id,
+#     civic_method,
+#     check_node_props,
+# ):
+#     """Verify property and relationship rules for Method nodes."""
+#     check_unique_property("Method", "id")
+#     check_relation_count(
+#         "Method", "Study", "IS_SPECIFIED_BY", max_rels=None, direction="in"
+#     )
+#
+#     expected_node_labels = [{"Method"}]
+#     check_node_labels("Method", expected_node_labels, 1)
+#
+#     method = get_node_by_id(civic_method["id"])
+#     expected_keys = {"id", "label"}
+#     check_node_props(method, civic_method, expected_keys)
+#
+#
+# def test_no_lost_nodes(graph: Graph):
+#     """Verify that no unlabeled or isolated nodes have been created."""
+#     # non-normalizable nodes can be excepted
+#     labels_query = """
+#     MATCH (n)
+#     WHERE size(labels(n)) = 0
+#     AND NOT (n)<-[:IS_REPORTED_IN]-(:Study)
+#     RETURN COUNT(n)
+#     """
+#     with graph.driver.session() as s:
+#         record = s.run(labels_query).single()
+#     assert record.values()[0] == 0
+#
+#     rels_query = """
+#     MATCH (n)
+#     WHERE NOT (n)--()
+#     RETURN COUNT(n)
+#     """
+#     with graph.driver.session() as s:
+#         result = s.run(rels_query).single()
+#     assert result.values()[0] == 0


### PR DESCRIPTION
The main performance change here is to do away with querying code that employs transactions where it doesn't need to -- for reads, if subquery 1 (e.g. checking that a study ID is valid) runs successfully, but then something wrong happens in query 2 (e.g. fetching the nested data for that study), we don't need to do anything to the result of query 1 (it already happened). Everything in the `query` module is a read, so we can just use the now-standard `driver.execute_query` method for reads instead of creating a `session` context manager every time. This overhead is probably quite minimal but I think it also simplifies things.

Similarly, when preparing a read-only connection, we probably don't need to check for the existence of constraints, so an option is added to suppress that check.

The `Graph` class is also refactored here to separate responsibilities better between code that acquires/handles DB connections (which remains in the `database` module) and code that transforms knowledgebase data into write queries to store in the DB (moved to the `load_data` (???) module). 

Finally, we weren't really making meaningful use of anything stateful in the Graph code, so it's refactored down to functions, rather than a class. The `QueryHandler` wasn't even using the graph (just the driver), so rather than a class that creates and holds onto a driver, the `get_driver()` function handles credentials processing and provides a Neo4j `Driver` instance to downstream users (the CLI, the QueryHandler).

close #373  (there's more work to do there but fine to cross it out for now especially with possible changes to the data model still incoming)