### PR TITLE
feat: add python-dotenv

### DIFF
--- a/server/.env.example
+++ b/server/.env.example
@@ -1,12 +1,10 @@
+METAKB_EB_PROD=
 METAKB_DB_URL=bolt://localhost:7687
 METAKB_DB_USERNAME=neo4j
 METAKB_DB_PASSWORD=neo4j
 METAKB_DB_SECRET=
-DISEASE_AWS_ENV_VAR_NAME=disease_normalizer
 DISEASE_NORM_DB_URL=http://localhost:8000
-THERAPY_AWS_ENV_VAR_NAME=therapy_normalizer
 THERAPY_NORM_DB_URL=http://localhost:8000
-GENE_AWS_ENV_VAR_NAME=gene_normalizer
 GENE_NORM_DB_URL=http://localhost:8000
 UTA_DB_URL=postgresql://uta_admin:password@localhost:5432/uta/uta_20210129b
 SEQREPO_ROOT_DIR=/usr/local/share/seqrepo/latest

--- a/server/.env.example
+++ b/server/.env.example
@@ -1,0 +1,12 @@
+METAKB_DB_URL=bolt://localhost:7687
+METAKB_DB_USERNAME=neo4j
+METAKB_DB_PASSWORD=neo4j
+METAKB_DB_SECRET=
+DISEASE_AWS_ENV_VAR_NAME=disease_normalizer
+DISEASE_NORM_DB_URL=http://localhost:8000
+THERAPY_AWS_ENV_VAR_NAME=therapy_normalizer
+THERAPY_NORM_DB_URL=http://localhost:8000
+GENE_AWS_ENV_VAR_NAME=gene_normalizer
+GENE_NORM_DB_URL=http://localhost:8000
+UTA_DB_URL=postgresql://uta_admin:password@localhost:5432/uta/uta_20210129b
+SEQREPO_ROOT_DIR=/usr/local/share/seqrepo/latest

--- a/server/pyproject.toml
+++ b/server/pyproject.toml
@@ -40,6 +40,7 @@ dependencies = [
     "boto3",
     "botocore",
     "asyncclick",
+    "python-dotenv",
 ]
 dynamic = ["version"]
 

--- a/server/src/metakb/cli.py
+++ b/server/src/metakb/cli.py
@@ -16,6 +16,7 @@ import asyncclick as click
 import boto3
 from boto3.exceptions import ResourceLoadException
 from botocore.config import Config
+from dotenv import load_dotenv
 from neo4j import Driver
 
 from metakb import APP_ROOT, DATE_FMT
@@ -37,6 +38,8 @@ from metakb.schemas.app import SourceName
 from metakb.transformers import CivicTransformer, MoaTransformer
 
 _logger = logging.getLogger(__name__)
+
+load_dotenv()
 
 
 def _echo_info(msg: str) -> None:

--- a/server/src/metakb/database.py
+++ b/server/src/metakb/database.py
@@ -49,7 +49,7 @@ def _get_credentials(
     :return: tuple containing host, and a second tuple containing username/password
     """
     if not (uri and credentials[0] and credentials[1]):
-        if "METAKB_EB_PROD" in environ:
+        if environ.get("METAKB_EB_PROD"):
             secret = ast.literal_eval(_get_secret())
             uri = f"bolt://{secret['host']}:{secret['port']}"
             credentials = (secret["username"], secret["password"])

--- a/server/src/metakb/log_handle.py
+++ b/server/src/metakb/log_handle.py
@@ -36,7 +36,7 @@ def configure_logs(log_level: int = logging.DEBUG, quiet_upstream: bool = True) 
     if quiet_upstream:
         _quiet_upstream_libs()
     log_filename = (
-        "/tmp/metakb.log" if "METAKB_EB_PROD" in os.environ else "metakb.log"  # noqa: S108
+        "/tmp/metakb.log" if os.environ.get("METAKB_EB_PROD") else "metakb.log"  # noqa: S108
     )
     logging.basicConfig(
         filename=log_filename,

--- a/server/src/metakb/main.py
+++ b/server/src/metakb/main.py
@@ -4,6 +4,7 @@ from collections.abc import AsyncGenerator
 from contextlib import asynccontextmanager
 from typing import Annotated
 
+from dotenv import load_dotenv
 from fastapi import FastAPI, Query
 from fastapi.openapi.utils import get_openapi
 
@@ -17,6 +18,8 @@ from metakb.schemas.api import (
     SearchStatementsService,
     ServiceMeta,
 )
+
+load_dotenv()
 
 query = QueryHandler()
 


### PR DESCRIPTION
Add `python-dotenv` to backend entry points.

This is a simple quality-of-life improvement driven by my unending frustration with the mountain of environment variables upon which metakb sits. Store a `.env` file in `server/` and it'll load env vars from there.

* I have aspirations for a more featureful configuration experience. I'd made an initial attempt [here](https://github.com/GenomicMedLab/software-templates/pull/78) but I'm not totally happy with it. I have an issue [here](https://github.com/GenomicMedLab/software-templates/issues/106) to take up someday where I try and do something better, but I think that would entail implementation in all of the library dependencies first. For now I think this PR is just fine though.