### PR TITLE
feat: add more reasonable graph credential config control flow

### DIFF
--- a/server/src/metakb/database.py
+++ b/server/src/metakb/database.py
@@ -54,21 +54,13 @@ def _get_credentials(
             uri = f"bolt://{secret['host']}:{secret['port']}"
             credentials = (secret["username"], secret["password"])
         else:
-            if all(
-                [
-                    "METAKB_DB_URL" in environ,
-                    "METAKB_DB_USERNAME" in environ,
-                    "METAKB_DB_PASSWORD" in environ,
-                ]
-            ):
-                uri = environ["METAKB_DB_URL"]
+            if not uri:
+                uri = environ.get("METAKB_DB_URL", "bolt://localhost:7687")
+            if (not credentials[0]) and (not credentials[1]):
                 credentials = (
-                    environ["METAKB_DB_USERNAME"],
-                    environ["METAKB_DB_PASSWORD"],
+                    environ.get("METAKB_DB_USERNAME", "neo4j"),
+                    environ.get("METAKB_DB_PASSWORD", "neo4j"),
                 )
-            else:  # local default settings
-                uri = "bolt://localhost:7687"
-                credentials = ("neo4j", "password")
     return uri, credentials
 
 


### PR DESCRIPTION
* use a default password (`"neo4j"`) matching the actual neo4j default
* separate default behavior for credentials and DB location. Previously you'd have to set both to avoid default behavior. In practice it seems like neo4j tends to think of them as separate though (credentials are usually passed in tandem though so I didn't separate them further). So now, you can pass your own DB location but use default username/password, or vice versa.