### PR TITLE
feat!: update backend schema to support expanded catvar searches

### DIFF
--- a/server/src/metakb/load_data.py
+++ b/server/src/metakb/load_data.py
@@ -269,6 +269,22 @@ def _add_variation(tx: ManagedTransaction, variation_in: dict) -> None:
     tx.run(query, **v)
 
 
+def _reformat_allele(allele: dict) -> dict:
+    allele_dao = {
+        "id": allele["id"],
+        "state_object": json.dumps(allele["state"]),
+        "literal_state": allele["state"]["sequence"],
+    }
+    for expr in allele.get("expressions", []):
+        syntax = expr["syntax"].replace(".", "_")
+        key = f"expression_{syntax}"
+        if key in allele_dao:
+            allele_dao[key].append(expr["value"])
+        else:
+            allele_dao[key] = [expr["value"]]
+    return allele_dao
+
+
 def _add_psq_cv(
     tx: ManagedTransaction,
     catvar: dict,

--- a/server/src/metakb/load_data.py
+++ b/server/src/metakb/load_data.py
@@ -232,7 +232,7 @@ def _add_psq_cv(
     """Load ProteinSequenceConsequence CatVar.
 
     Adds
-    * CategoricalVariation itself
+    * CategoricalVariant itself
     * DefiningAlleleConstraint
     * Allele which defines the constraint
     * Member alleles of the category
@@ -240,7 +240,7 @@ def _add_psq_cv(
     """
     cv_merge_statement = """
     UNWIND $members as m
-    MERGE (cv:CategoricalVariation { id: $cv_id })
+    MERGE (cv:CategoricalVariant:ProteinSequenceConsequence { id: $cv_id })
     ON CREATE SET cv += {
         name: $cv.name,
         description: $cv_description,
@@ -248,8 +248,8 @@ def _add_psq_cv(
         extensions: $cv_extensions,
         mappings: $cv_mappings
     }
-    MERGE (cv) -[:HAS_CONSTRAINT]-> (constr:DefiningAlleleConstraint { id: $constraint_id })
-    MERGE (allele:Allele { id: $allele.id })
+    MERGE (cv) -[:HAS_CONSTRAINT]-> (constr:Constraint:DefiningAlleleConstraint { id: $constraint_id })
+    MERGE (allele:MolecularVariation:Allele { id: $allele.id })
     ON CREATE SET allele += {
         name: $allele.name,
         literal_state: $allele.literal_state,
@@ -266,7 +266,7 @@ def _add_psq_cv(
         refget_accession: $sl.sequenceReference.refgetAccession
     }
     MERGE (allele) -[:HAS_LOCATION]-> (sl)
-    MERGE (member_allele:Allele { id: m.id })
+    MERGE (member_allele:MolecularVariation:Allele { id: m.id })
     ON CREATE SET member_allele += {
         name: m.name,
         literal_state: m.literal_state,
@@ -546,8 +546,8 @@ def _get_statement_query(statement: dict, is_evidence: bool) -> str:
     rel_line += "MERGE (s) -[:IS_SPECIFIED_BY] -> (m)\n"
 
     variant_id = proposition["subjectVariant"]["id"]
-    match_line += f"MERGE (v:Variation {{ id: '{variant_id}' }})\n"
-    rel_line += "MERGE (s) -[:HAS_VARIANT] -> (v)\n"
+    match_line += f"MERGE (v:CategoricalVariant {{ id: '{variant_id}' }})\n"
+    rel_line += "MERGE (s) -[:HAS_SUBJECT_VARIANT] -> (v)\n"
 
     therapeutic = proposition.get("objectTherapeutic")
     if therapeutic:

--- a/server/src/metakb/load_data.py
+++ b/server/src/metakb/load_data.py
@@ -6,6 +6,7 @@ import uuid
 from pathlib import Path
 
 from ga4gh.va_spec.base import MembershipOperator
+from ga4gh.vrs import VrsType
 from neo4j import Driver, ManagedTransaction
 
 from metakb.database import get_driver
@@ -212,7 +213,9 @@ def _reformat_allele(allele: dict) -> dict:
     allele_dao = {
         "id": allele["id"],
         "state_object": json.dumps(allele["state"]),
-        "literal_state": allele["state"]["sequence"],
+        "literal_state": allele["state"]["sequence"]
+        if allele["state"]["type"] == VrsType.LIT_SEQ_EXPR
+        else None,
         "name": allele.get("name", ""),
         "location": allele["location"],
         "expression_hgvs_g": [],

--- a/server/src/metakb/query.py
+++ b/server/src/metakb/query.py
@@ -633,7 +633,7 @@ class QueryHandler:
         ]:
             syntax = expression_type.split("expression_")[-1].replace("_", ".")
             expressions.extend(Expression(syntax=syntax, value=v) for v in expression)
-        return Allele(state=state, location=location, **allele_node)
+        return Allele(state=state, location=location, id=allele_node["id"])
 
     def _get_cat_var(self, node: dict) -> CategoricalVariant:
         """Get categorical variant data from a node with relationship ``HAS_VARIANT``


### PR DESCRIPTION
Update graph schema to support catvar-based searches. Adds a node for constraints. Cleans up some upload and data retrieval queries.
