### PR TITLE
feat: clean up config with pydantic-settings

### DIFF
--- a/server/pyproject.toml
+++ b/server/pyproject.toml
@@ -33,6 +33,7 @@ dependencies = [
     "civicpy~=3.1",
     "requests",
     "pydantic==2.*",
+    "pydantic-settings",
     "requests-cache",
     "neo4j==5.*",
     "uvicorn",
@@ -40,7 +41,6 @@ dependencies = [
     "boto3",
     "botocore",
     "asyncclick",
-    "python-dotenv",
 ]
 dynamic = ["version"]
 
@@ -51,11 +51,14 @@ tests = [
     "mock",
     "pytest-asyncio",
     "deepdiff",
+    "httpx",
     "jsonschema~=4.24",  # pin to avoid deprecation of ref resolver
+    "pyyaml",
 ]
 dev = [
     "pre-commit>=4.2.0",
-    "ruff==0.12.1"
+    "ruff==0.12.1",
+    "fastapi[standard]",
 ]
 notebooks = ["ipykernel", "jupyterlab"]
 docs = [

--- a/server/src/metakb/database.py
+++ b/server/src/metakb/database.py
@@ -9,7 +9,7 @@ import boto3
 from botocore.exceptions import ClientError
 from neo4j import Driver, GraphDatabase, ManagedTransaction
 
-from metakb.config import get_configs
+from metakb.config import get_config
 from metakb.schemas.api import ServiceEnvironment
 
 _logger = logging.getLogger(__name__)
@@ -106,7 +106,7 @@ def get_driver(
     :param initialize: whether to perform additional DB setup (e.g. add constraints, indexes)
     :return: Neo4j driver instance
     """
-    configs = get_configs()
+    configs = get_config()
     if configs.env == ServiceEnvironment.PROD:
         # overrule ANY provided configs and get connection url from AWS secrets
 

--- a/server/src/metakb/harvesters/base.py
+++ b/server/src/metakb/harvesters/base.py
@@ -9,7 +9,7 @@ from pathlib import Path
 from pydantic import BaseModel
 
 from metakb import DATE_FMT
-from metakb.config import get_configs
+from metakb.config import get_config
 
 logger = logging.getLogger(__name__)
 
@@ -68,7 +68,7 @@ class Harvester(ABC):
         src_name = self.__class__.__name__.lower().split("harvest")[0]
 
         if not harvested_filepath:
-            harvester_dir = get_configs().data_root / src_name / "harvester"
+            harvester_dir = get_config().data_dir / src_name / "harvester"
             harvester_dir.mkdir(exist_ok=True, parents=True)
             today = datetime.datetime.strftime(
                 datetime.datetime.now(tz=datetime.UTC), DATE_FMT

--- a/server/src/metakb/log_handle.py
+++ b/server/src/metakb/log_handle.py
@@ -27,7 +27,7 @@ def _quiet_upstream_libs() -> None:
         logging.getLogger(lib).setLevel(logging.INFO)
 
 
-def configure_logs(log_level: int = logging.DEBUG, quiet_upstream: bool = True) -> None:
+def configure_logs(log_level: int = logging.INFO, quiet_upstream: bool = True) -> None:
     """Configure logging.
 
     :param log_level: global log level to set

--- a/server/src/metakb/main.py
+++ b/server/src/metakb/main.py
@@ -1,15 +1,15 @@
 """Main application for FastAPI."""
 
+import logging
 from collections.abc import AsyncGenerator
 from contextlib import asynccontextmanager
 from enum import Enum
 from typing import Annotated
 
-from dotenv import load_dotenv
 from fastapi import FastAPI, HTTPException, Query, Request
 
 from metakb import __version__
-from metakb.config import get_configs
+from metakb.config import get_config
 from metakb.log_handle import configure_logs
 from metakb.query import EmptySearchError, QueryHandler
 from metakb.schemas.api import (
@@ -29,8 +29,7 @@ async def lifespan(app: FastAPI) -> AsyncGenerator:
     :param app: FastAPI app instance
     :return: async context handler
     """
-    load_dotenv()
-    configure_logs()
+    configure_logs(logging.DEBUG) if get_config().debug else configure_logs()
     query = QueryHandler()
     app.state.query = query
     yield
@@ -78,7 +77,7 @@ def service_info() -> ServiceInfo:
     return ServiceInfo(
         organization=ServiceOrganization(),
         type=ServiceType(),
-        environment=get_configs().env,
+        environment=get_config().env,
     )
 
 

--- a/server/src/metakb/transformers/base.py
+++ b/server/src/metakb/transformers/base.py
@@ -52,7 +52,7 @@ from therapy.schemas import (
 )
 
 from metakb import DATE_FMT
-from metakb.config import get_configs
+from metakb.config import get_config
 from metakb.harvesters.base import _HarvestedData
 from metakb.normalizers import (
     ViccNormalizers,
@@ -298,7 +298,7 @@ class Transformer(ABC):
         if data_dir:
             self.data_dir = data_dir
         else:
-            self.data_dir = get_configs().data_root / self.name
+            self.data_dir = get_config().data_dir / self.name
         self.harvester_path = harvester_path
         self.vicc_normalizers = (
             ViccNormalizers() if normalizers is None else normalizers


### PR DESCRIPTION
close #538 

Reflects https://github.com/GenomicMedLab/software-templates/pull/120. Implement a centralized module for setting configurations, loads from .env if available.

Use new `debug` option to set log level (INFO if unset, DEBUG if set). We could also rename this or use a different variable to configure it if we wanted more granular control but these two options seem fine for now imo.

`test` config option isn't used for anything yet. In other cases, we've used it to control whether or not "mock" or "fake" implementations of things like DBs should be injected, or if live services should be used. We haven't done this work yet, but I hope to soon.