### PR TITLE
feat: add search examples

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -2,7 +2,7 @@ import { BrowserRouter as Router, Routes, Route } from 'react-router-dom'
 import Home from './pages/Home'
 import { ThemeProvider } from '@mui/material'
 import theme from './theme'
-import GeneResult from './pages/Results/GeneResult'
+import ResultPage from './pages/Results/ResultPage'
 
 function App() {
   return (
@@ -10,7 +10,7 @@ function App() {
       <Router>
         <Routes>
           <Route path="/" element={<Home />} />
-          <Route path="/search" element={<GeneResult />} />
+          <Route path="/search" element={<ResultPage />} />
           {/* Fallback for invalid routes */}
           <Route path="*" element={<Home />} />
         </Routes>

--- a/client/src/pages/Home.tsx
+++ b/client/src/pages/Home.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react'
 import Header from '../components/Header'
-import { Box, Button, MenuItem, Select, TextField, Typography } from '@mui/material'
+import { Box, Button, Link, MenuItem, Select, TextField, Typography } from '@mui/material'
 import SearchIcon from '@mui/icons-material/Search'
 import { useNavigate } from 'react-router-dom'
 
@@ -61,6 +61,18 @@ const HomePage = () => {
               <SearchIcon />
               Search
             </Button>
+            <Box id="example-searches" display="flex" gap={1}>
+              <Typography>Examples: </Typography>
+              <Link href="/search?gene=BRAF" rel="noreferrer">
+                <span>BRAF</span>
+              </Link>
+              <Link href="/search?gene=ncbigene:5290" rel="noreferrer">
+                <span>ncbigene:5290</span>
+              </Link>
+              <Link href="/search?gene=hgnc:427" rel="noreferrer">
+                <span>hgnc:427</span>
+              </Link>
+            </Box>
           </Box>
         </Box>
       </main>

--- a/client/src/pages/Home.tsx
+++ b/client/src/pages/Home.tsx
@@ -87,7 +87,9 @@ const HomePage = () => {
                   <Link href="/search?variation=BRAF%20V600E" rel="noreferrer">
                     <span>BRAF V600E</span>
                   </Link>
-                  {/* TODO: other types of variant searches? */}
+                  <Link href="/search?variation=NC_000007.13:g.55259515T>G" rel="noreferrer">
+                    <span>{'NC_000007.13:g.55259515T>G'}</span>
+                  </Link>
                 </Box>
               )}
             </Box>

--- a/client/src/pages/Home.tsx
+++ b/client/src/pages/Home.tsx
@@ -39,7 +39,13 @@ const HomePage = () => {
             color="primary"
             fontWeight="bold"
             mb={2}
-            sx={{ width: '50%', justifyContent: 'center', textAlign: 'center', mt: '50px' }}
+            sx={{
+              width: '50%',
+              justifyContent: 'center',
+              textAlign: 'center',
+              mt: '50px',
+              mb: '75px',
+            }}
           >
             Search harmonized data across multiple genomic knowledgebases.
           </Typography>
@@ -61,17 +67,29 @@ const HomePage = () => {
               <SearchIcon />
               Search
             </Button>
-            <Box id="example-searches" display="flex" gap={1}>
+            <Box id="example-searches" display="flex" mt={1} gap={1}>
               <Typography>Examples: </Typography>
-              <Link href="/search?gene=BRAF" rel="noreferrer">
-                <span>BRAF</span>
-              </Link>
-              <Link href="/search?gene=ncbigene:5290" rel="noreferrer">
-                <span>ncbigene:5290</span>
-              </Link>
-              <Link href="/search?gene=hgnc:427" rel="noreferrer">
-                <span>hgnc:427</span>
-              </Link>
+              {searchType === 'gene' && (
+                <Box id="gene-example-searches" gap={1} display="flex">
+                  <Link href="/search?gene=BRAF" rel="noreferrer">
+                    <span>BRAF</span>
+                  </Link>
+                  <Link href="/search?gene=hgnc:427" rel="noreferrer">
+                    <span>hgnc:427</span>
+                  </Link>
+                  <Link href="/search?gene=ncbigene:5290" rel="noreferrer">
+                    <span>ncbigene:5290</span>
+                  </Link>
+                </Box>
+              )}
+              {searchType === 'variation' && (
+                <Box id="gene-example-searches" gap={1} display="flex">
+                  <Link href="/search?variation=BRAF%20V600E" rel="noreferrer">
+                    <span>BRAF V600E</span>
+                  </Link>
+                  {/* TODO: other types of variant searches? */}
+                </Box>
+              )}
             </Box>
           </Box>
         </Box>

--- a/client/src/pages/Results/ResultPage.tsx
+++ b/client/src/pages/Results/ResultPage.tsx
@@ -26,6 +26,7 @@ import {
   TAB_LABELS,
   getGeneNameFromProposition,
   getVariantNameFromProposition,
+  getEntityMetadataFromProposition,
 } from '../../utils'
 
 type SearchType = 'gene' | 'variation'
@@ -73,27 +74,8 @@ const ResultPage = () => {
       results.prognostic[0]?.grouped_evidence?.[0]?.proposition ??
       results.diagnostic[0]?.grouped_evidence?.[0]?.proposition
 
-    const exts = hasGeneContextQualifier(firstWithQualifier)
-      ? (firstWithQualifier.geneContextQualifier?.extensions ?? [])
-      : []
-
-    const descriptionExt = exts.find((e) => e.name === 'description')
-    const aliasesExt = exts.find((e) => e.name === 'aliases')
-
-    let displayName = searchQuery
-
-    if (typeFromUrl === 'gene') {
-      displayName = getGeneNameFromProposition(firstWithQualifier)
-    } else if (typeFromUrl === 'variation') {
-      displayName = getVariantNameFromProposition(firstWithQualifier)
-    }
-
-    return {
-      description: (descriptionExt?.value as string) ?? null,
-      aliases: (aliasesExt?.value as string[]) ?? [],
-      displayName,
-    }
-  }, [results.diagnostic, results.prognostic, results.therapeutic, searchQuery, typeFromUrl])
+    return getEntityMetadataFromProposition(firstWithQualifier, typeFromUrl as 'gene' | 'variation')
+  }, [results.diagnostic, results.prognostic, results.therapeutic, typeFromUrl])
 
   const selectedFilters = {
     variants: selectedVariants,

--- a/client/src/pages/Results/ResultPage.tsx
+++ b/client/src/pages/Results/ResultPage.tsx
@@ -17,15 +17,12 @@ import ResultTable from '../../components/ResultTable/ResultTable'
 import FilterSection from '../../components/FilterSection/FilterSection'
 import {
   NormalizedResult,
-  hasGeneContextQualifier,
   buildCountMap,
   evidenceOrder,
   normalizeResults,
   applyFilters,
   buildFilterOptions,
   TAB_LABELS,
-  getGeneNameFromProposition,
-  getVariantNameFromProposition,
   getEntityMetadataFromProposition,
 } from '../../utils'
 

--- a/client/src/pages/Results/ResultPage.tsx
+++ b/client/src/pages/Results/ResultPage.tsx
@@ -24,6 +24,8 @@ import {
   applyFilters,
   buildFilterOptions,
   TAB_LABELS,
+  getGeneNameFromProposition,
+  getVariantNameFromProposition,
 } from '../../utils'
 
 type SearchType = 'gene' | 'variation'
@@ -35,7 +37,7 @@ type EvidenceBuckets = {
   therapeutic: NormalizedResult[]
 }
 
-const GeneResult = () => {
+const ResultPage = () => {
   const [params] = useSearchParams()
 
   const [results, setResults] = React.useState<EvidenceBuckets>({
@@ -65,7 +67,7 @@ const GeneResult = () => {
   const [selectedSignificance, setSelectedSignificance] = useState<string[]>([])
   const [selectedSources, setSelectedSources] = useState<string[]>([])
 
-  const { description, aliases } = useMemo(() => {
+  const { description, aliases, displayName } = useMemo(() => {
     const firstWithQualifier =
       results.therapeutic[0]?.grouped_evidence?.[0]?.proposition ??
       results.prognostic[0]?.grouped_evidence?.[0]?.proposition ??
@@ -75,14 +77,24 @@ const GeneResult = () => {
       ? (firstWithQualifier.geneContextQualifier?.extensions ?? [])
       : []
 
+    console.log(firstWithQualifier)
     const descriptionExt = exts.find((e) => e.name === 'description')
     const aliasesExt = exts.find((e) => e.name === 'aliases')
+
+    let displayName = searchQuery
+
+    if (typeFromUrl === 'gene') {
+      displayName = getGeneNameFromProposition(firstWithQualifier)
+    } else if (typeFromUrl === 'variation') {
+      displayName = getVariantNameFromProposition(firstWithQualifier)
+    }
 
     return {
       description: (descriptionExt?.value as string) ?? null,
       aliases: (aliasesExt?.value as string[]) ?? [],
+      displayName,
     }
-  }, [results])
+  }, [results.diagnostic, results.prognostic, results.therapeutic, searchQuery, typeFromUrl])
 
   const selectedFilters = {
     variants: selectedVariants,
@@ -273,7 +285,7 @@ const GeneResult = () => {
               display={description || aliases.length ? 'block' : 'none'}
             >
               <Typography variant="h4" mb={2} fontWeight="bold">
-                {searchQuery}
+                {displayName}
               </Typography>
               <Typography
                 variant="h6"
@@ -399,4 +411,4 @@ const GeneResult = () => {
   )
 }
 
-export default GeneResult
+export default ResultPage

--- a/client/src/pages/Results/ResultPage.tsx
+++ b/client/src/pages/Results/ResultPage.tsx
@@ -77,7 +77,6 @@ const ResultPage = () => {
       ? (firstWithQualifier.geneContextQualifier?.extensions ?? [])
       : []
 
-    console.log(firstWithQualifier)
     const descriptionExt = exts.find((e) => e.name === 'description')
     const aliasesExt = exts.find((e) => e.name === 'aliases')
 

--- a/client/src/utils/propositions.ts
+++ b/client/src/utils/propositions.ts
@@ -167,3 +167,68 @@ export function getDiseaseFromProposition(
       return ['N/A']
   }
 }
+
+/**
+ * Extracts associated variant name from a proposition.
+ *
+ * @param prop - A variant proposition of various supported types
+ * @returns String variant name, or "" if not available
+ */
+export function getVariantNameFromProposition(
+  prop:
+    | VariantTherapeuticResponseProposition
+    | VariantDiagnosticProposition
+    | VariantPrognosticProposition
+    | VariantOncogenicityProposition
+    | VariantPathogenicityProposition
+    | ExperimentalVariantFunctionalImpactProposition,
+): string {
+  if (!prop) return ''
+
+  const subjectVariant = prop.subjectVariant
+
+  if (typeof subjectVariant === 'string') {
+    return subjectVariant
+  } else if (subjectVariant && 'name' in subjectVariant) {
+    return subjectVariant.name ?? ''
+  }
+  return ''
+}
+
+/**
+ * Extracts associated gene name from a proposition.
+ *
+ * @param prop - A variant proposition of various supported types
+ * @returns String gene name, or "" if not available
+ */
+export function getGeneNameFromProposition(
+  prop:
+    | VariantTherapeuticResponseProposition
+    | VariantDiagnosticProposition
+    | VariantPrognosticProposition
+    | VariantOncogenicityProposition
+    | VariantPathogenicityProposition
+    | ExperimentalVariantFunctionalImpactProposition
+    | undefined,
+): string {
+  if (!prop) return ''
+
+  if (prop.type === 'ExperimentalVariantFunctionalImpactProposition') {
+    return typeof prop.objectSequenceFeature === 'string'
+      ? prop.objectSequenceFeature
+      : (prop.objectSequenceFeature?.name ?? '')
+  }
+
+  if (hasGeneContextQualifier(prop)) {
+    const geneContextQualifier = prop.geneContextQualifier
+    if (geneContextQualifier) {
+      if (typeof geneContextQualifier === 'string') {
+        return geneContextQualifier
+      } else if ('name' in geneContextQualifier) {
+        return geneContextQualifier.name ?? ''
+      }
+    }
+  }
+
+  return ''
+}

--- a/client/src/utils/results.ts
+++ b/client/src/utils/results.ts
@@ -14,7 +14,11 @@
  */
 
 import { Statement } from '../models/domain'
-import { getDiseaseFromProposition, getTherapyFromProposition } from './propositions'
+import {
+  getDiseaseFromProposition,
+  getTherapyFromProposition,
+  getVariantNameFromProposition,
+} from './propositions'
 import { getSources } from './sources'
 
 export const TAB_LABELS: Record<'therapeutic' | 'diagnostic' | 'prognostic', string> = {
@@ -132,11 +136,7 @@ export const normalizeResults = (data: Record<string, Statement[]>): NormalizedR
     }, 'N/A')
     return [
       {
-        variant_name:
-          typeof first?.proposition?.subjectVariant === 'string'
-            ? first.proposition.subjectVariant
-            : (first?.proposition?.subjectVariant?.name ?? 'Unknown'),
-
+        variant_name: getVariantNameFromProposition(first?.proposition),
         evidence_level: highestEvidenceLevel,
         disease: getDiseaseFromProposition(first?.proposition),
         therapy: getTherapyFromProposition(first?.proposition),


### PR DESCRIPTION
ignore the branch name - I was originally using this for the search examples but then did a lot of refactoring that I realized should probably be in a separate PR. It's easiest to move the search examples to a new PR, so this one will remain for the refactor portion