### PR TITLE
feat: add footer and news section

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -3,16 +3,19 @@ import Home from './pages/Home'
 import { ThemeProvider } from '@mui/material'
 import theme from './theme'
 import ResultPage from './pages/Results/ResultPage'
+import Layout from './Layout'
 
 function App() {
   return (
     <ThemeProvider theme={theme}>
       <Router>
         <Routes>
+          <Route element={<Layout />}>
           <Route path="/" element={<Home />} />
           <Route path="/search" element={<ResultPage />} />
           {/* Fallback for invalid routes */}
           <Route path="*" element={<Home />} />
+          </Route>
         </Routes>
       </Router>
     </ThemeProvider>

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -11,10 +11,10 @@ function App() {
       <Router>
         <Routes>
           <Route element={<Layout />}>
-          <Route path="/" element={<Home />} />
-          <Route path="/search" element={<ResultPage />} />
-          {/* Fallback for invalid routes */}
-          <Route path="*" element={<Home />} />
+            <Route path="/" element={<Home />} />
+            <Route path="/search" element={<ResultPage />} />
+            {/* Fallback for invalid routes */}
+            <Route path="*" element={<Home />} />
           </Route>
         </Routes>
       </Router>

--- a/client/src/Layout.tsx
+++ b/client/src/Layout.tsx
@@ -1,12 +1,12 @@
 // Layout component for providing the header and footer and a full-height container for every page
-import { Box } from "@mui/material";
-import Header from "./components/Header";
-import Footer from "./components/Footer";
-import { Outlet } from "react-router-dom";
+import { Box } from '@mui/material'
+import Header from './components/Header'
+import Footer from './components/Footer'
+import { Outlet } from 'react-router-dom'
 
 export default function Layout() {
   return (
-    <Box sx={{ minHeight: "100vh", display: "flex", flexDirection: "column" }}>
+    <Box sx={{ minHeight: '100vh', display: 'flex', flexDirection: 'column' }}>
       <Header />
 
       <Box component="main" sx={{ flexGrow: 1 }}>
@@ -15,5 +15,5 @@ export default function Layout() {
 
       <Footer />
     </Box>
-  );
+  )
 }

--- a/client/src/Layout.tsx
+++ b/client/src/Layout.tsx
@@ -1,0 +1,19 @@
+// Layout component for providing the header and footer and a full-height container for every page
+import { Box } from "@mui/material";
+import Header from "./components/Header";
+import Footer from "./components/Footer";
+import { Outlet } from "react-router-dom";
+
+export default function Layout() {
+  return (
+    <Box sx={{ minHeight: "100vh", display: "flex", flexDirection: "column" }}>
+      <Header />
+
+      <Box component="main" sx={{ flexGrow: 1 }}>
+        <Outlet />
+      </Box>
+
+      <Footer />
+    </Box>
+  );
+}

--- a/client/src/components/Footer.tsx
+++ b/client/src/components/Footer.tsx
@@ -1,0 +1,68 @@
+import { useEffect, useState } from 'react'
+import { Box, IconButton, Toolbar, Typography } from '@mui/material'
+import GitHubIcon from '@mui/icons-material/GitHub'
+import theme from '../theme'
+
+const Footer = () => {
+  const [version, setVersion] = useState('')
+  const [environment, setEnvironment] = useState('')
+
+  useEffect(() => {
+    const run = async () => {
+      const url = '/api/service-info'
+      const res = await fetch(url, {
+        headers: { 'Content-Type': 'application/json' },
+      })
+      if (!res.ok) throw new Error(`Service info API request failed: ${res.status}`)
+      const data = await res.json()
+      setVersion(data.version)
+      setEnvironment(data.environment)
+    }
+    run()
+  }, [])
+
+  return (
+    <Box
+      component="footer"
+      sx={{
+        py: 2,
+        textAlign: 'center',
+        width: '100%',
+        bgcolor: theme.palette.footer.main,
+      }}
+    >
+      <Toolbar sx={{ display: 'flex', justifyContent: 'space-between' }}>
+        <Box display="flex" alignItems="center" gap={2}>
+          {version && (
+            <Typography variant="body2" color="white" sx={{ opacity: 0.8 }}>
+              {version ? `version ${version}` : 'version ?'}
+              {environment && environment != 'prod' ? ` [${environment}]` : ''}
+            </Typography>
+          )}
+        </Box>
+
+        <IconButton
+          component="a"
+          href="https://github.com/cancervariants/metakb"
+          target="_blank"
+          rel="noopener noreferrer"
+          color="secondary"
+          disableRipple
+          sx={{
+            '&:hover': {
+              color: 'white',
+            },
+          }}
+        >
+          {' '}
+          <Box display="flex" alignItems="center" gap={1}>
+            <GitHubIcon fontSize="large" />
+            <Typography fontWeight="bold">Visit us on GitHub!</Typography>
+          </Box>
+        </IconButton>
+      </Toolbar>
+    </Box>
+  )
+}
+
+export default Footer

--- a/client/src/components/Header.tsx
+++ b/client/src/components/Header.tsx
@@ -1,26 +1,7 @@
-import { useEffect, useState } from 'react'
-import { AppBar, Box, IconButton, Toolbar, Typography } from '@mui/material'
+import { AppBar, Box, Toolbar, Typography } from '@mui/material'
 import { Link } from 'react-router-dom'
-import GitHubIcon from '@mui/icons-material/GitHub'
 
 const Header = () => {
-  const [version, setVersion] = useState('')
-  const [environment, setEnvironment] = useState('')
-
-  useEffect(() => {
-    const run = async () => {
-      const url = '/api/service-info'
-      const res = await fetch(url, {
-        headers: { 'Content-Type': 'application/json' },
-      })
-      if (!res.ok) throw new Error(`Service info API request failed: ${res.status}`)
-      const data = await res.json()
-      setVersion(data.version)
-      setEnvironment(data.environment)
-    }
-    run()
-  }, [])
-
   return (
     <AppBar position="static" color="header" sx={{ padding: 2 }}>
       <Toolbar sx={{ display: 'flex', justifyContent: 'space-between' }}>
@@ -30,27 +11,7 @@ const Header = () => {
               MetaKB Jr.
             </Typography>
           </Link>
-          {version && (
-            <Typography variant="body2" color="white" sx={{ opacity: 0.8 }}>
-              {version ? `version ${version}` : 'version ?'}
-              {environment && environment != 'prod' ? ` [${environment}]` : ''}
-            </Typography>
-          )}
         </Box>
-
-        <IconButton
-          component="a"
-          href="https://github.com/cancervariants/metakb"
-          target="_blank"
-          rel="noopener noreferrer"
-          color="inherit"
-        >
-          {' '}
-          <Box display="flex" alignItems="center" gap={1}>
-            <GitHubIcon fontSize="large" />
-            <Typography>Visit us on GitHub!</Typography>
-          </Box>
-        </IconButton>
       </Toolbar>
     </AppBar>
   )

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -15,7 +15,8 @@
 html,
 body,
 #root {
-  height: 100%;
+  margin: 0;
+  padding: 0;
   background-color: lightgrey;
   overflow: scroll;
 }

--- a/client/src/pages/Home.tsx
+++ b/client/src/pages/Home.tsx
@@ -1,9 +1,12 @@
 import * as React from 'react'
 import Header from '../components/Header'
 import { Box, Button, Link, MenuItem, Select, TextField, Typography } from '@mui/material'
+import RocketLaunchIcon from '@mui/icons-material/RocketLaunch'
 import SearchIcon from '@mui/icons-material/Search'
 import { useNavigate } from 'react-router-dom'
 import { useEffect, useState } from 'react'
+import Footer from '../components/Footer'
+import AutoStoriesIcon from '@mui/icons-material/AutoStories'
 
 const HomePage = () => {
   const navigate = useNavigate()
@@ -50,9 +53,9 @@ const HomePage = () => {
   }, [])
 
   return (
-    <>
+    <Box sx={{ display: 'flex', flexDirection: 'column', minHeight: '100vh' }}>
       <Header />
-      <main>
+      <Box component="main" sx={{ flexGrow: 1, display: 'flex', flexDirection: 'column' }}>
         <Box
           id="main-page-container"
           m={5}
@@ -68,7 +71,7 @@ const HomePage = () => {
             variant="h5"
             color="primary"
             fontWeight="bold"
-            mb={2}
+            mb={4}
             sx={{
               width: '50%',
               justifyContent: 'center',
@@ -87,7 +90,7 @@ const HomePage = () => {
               alignItems="center"
               flexWrap="wrap"
               gap={6}
-              mb={6}
+              mb={10}
             >
               <Box textAlign="center">
                 <Typography variant="h4" color="primary" fontWeight="bold">
@@ -128,7 +131,7 @@ const HomePage = () => {
             </Box>
           )}
 
-          <Box id="search-container" mb={50}>
+          <Box id="search-container" mb={10}>
             <Select
               value={searchType}
               onChange={(e) => setSearchType(e.target.value)}
@@ -173,9 +176,30 @@ const HomePage = () => {
               )}
             </Box>
           </Box>
+          <Box id="latest-updates-section" my={8} width="100%" maxWidth={800}>
+            <Typography variant="h6" color="primary" mb={2}>
+              Latest Updates
+            </Typography>
+            <Box sx={{ bgcolor: 'grey.100', borderRadius: 1, p: 2 }}>
+              <Box display="flex" alignItems="center" mb={1}>
+                <RocketLaunchIcon color="secondary" sx={{ mr: 1 }} />
+                <Typography variant="body2" color="text.secondary">
+                  Version 2.0 now in early development — improved harmonization and search accuracy.
+                </Typography>
+              </Box>
+
+              <Box display="flex" alignItems="center">
+                <AutoStoriesIcon color="primary" sx={{ mr: 1 }} />
+                <Typography variant="body2" color="text.secondary">
+                  More data sources coming soon!
+                </Typography>
+              </Box>
+            </Box>
+          </Box>
         </Box>
-      </main>
-    </>
+      </Box>
+      <Footer />
+    </Box>
   )
 }
 

--- a/client/src/pages/Home.tsx
+++ b/client/src/pages/Home.tsx
@@ -1,11 +1,9 @@
 import * as React from 'react'
-import Header from '../components/Header'
 import { Box, Button, Link, MenuItem, Select, TextField, Typography } from '@mui/material'
 import RocketLaunchIcon from '@mui/icons-material/RocketLaunch'
 import SearchIcon from '@mui/icons-material/Search'
 import { useNavigate } from 'react-router-dom'
 import { useEffect, useState } from 'react'
-import Footer from '../components/Footer'
 import AutoStoriesIcon from '@mui/icons-material/AutoStories'
 
 const HomePage = () => {
@@ -53,9 +51,8 @@ const HomePage = () => {
   }, [])
 
   return (
-    <Box sx={{ display: 'flex', flexDirection: 'column', minHeight: '100vh' }}>
-      <Header />
-      <Box component="main" sx={{ flexGrow: 1, display: 'flex', flexDirection: 'column' }}>
+    <>
+      <Box component="main">
         <Box
           id="main-page-container"
           m={5}
@@ -199,8 +196,7 @@ const HomePage = () => {
           </Box>
         </Box>
       </Box>
-      <Footer />
-    </Box>
+    </>
   )
 }
 

--- a/client/src/pages/Home.tsx
+++ b/client/src/pages/Home.tsx
@@ -184,7 +184,8 @@ const HomePage = () => {
               <Box display="flex" alignItems="center" mb={1}>
                 <RocketLaunchIcon color="secondary" sx={{ mr: 1 }} />
                 <Typography variant="body2" color="text.secondary">
-                  Version 2.0 now in early development — improved harmonization and search accuracy.
+                  Version 2.0 is now in early development, bringing a refined knowledge model and
+                  higher-quality harmonized data.
                 </Typography>
               </Box>
 

--- a/client/src/pages/Results/ResultPage.tsx
+++ b/client/src/pages/Results/ResultPage.tsx
@@ -26,6 +26,7 @@ import {
   getEntityMetadataFromProposition,
 } from '../../utils'
 import { EvidenceLegend } from '../../components/ResultTable/EvidenceLegend'
+import Footer from '../../components/Footer'
 
 type SearchType = 'gene' | 'variation'
 const API_BASE = '/api/search/statements'
@@ -250,9 +251,9 @@ const ResultPage = () => {
   const hasFilteredResults = filteredResults.length > 0
 
   return (
-    <>
+    <Box sx={{ minHeight: '100vh', display: 'flex', flexDirection: 'column' }}>
       <Header />
-      <Box id="result-page-container" m={5}>
+      <Box id="result-page-container" m={5} sx={{ flexGrow: 1 }}>
         {loading && <CircularProgress />}
         {error && <Alert severity="error">{error}</Alert>}
         {!loading && !error && (
@@ -389,7 +390,8 @@ const ResultPage = () => {
           </Box>
         )}
       </Box>
-    </>
+      <Footer />
+    </Box>
   )
 }
 

--- a/client/src/pages/Results/ResultPage.tsx
+++ b/client/src/pages/Results/ResultPage.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react'
 import { useEffect, useMemo, useState } from 'react'
-import Header from '../../components/Header'
 import {
   Alert,
   Box,
@@ -26,7 +25,6 @@ import {
   getEntityMetadataFromProposition,
 } from '../../utils'
 import { EvidenceLegend } from '../../components/ResultTable/EvidenceLegend'
-import Footer from '../../components/Footer'
 
 type SearchType = 'gene' | 'variation'
 const API_BASE = '/api/search/statements'
@@ -251,9 +249,8 @@ const ResultPage = () => {
   const hasFilteredResults = filteredResults.length > 0
 
   return (
-    <Box sx={{ minHeight: '100vh', display: 'flex', flexDirection: 'column' }}>
-      <Header />
-      <Box id="result-page-container" m={5} sx={{ flexGrow: 1 }}>
+    <>
+      <Box id="result-page-container" m={5}>
         {loading && <CircularProgress />}
         {error && <Alert severity="error">{error}</Alert>}
         {!loading && !error && (
@@ -390,8 +387,7 @@ const ResultPage = () => {
           </Box>
         )}
       </Box>
-      <Footer />
-    </Box>
+    </>
   )
 }
 

--- a/client/src/theme.ts
+++ b/client/src/theme.ts
@@ -4,10 +4,12 @@ import { PaletteColorOptions, PaletteColor } from '@mui/material/styles'
 declare module '@mui/material/styles' {
   interface Palette {
     header: PaletteColor
+    footer: PaletteColor
     evidence: Record<'A' | 'B' | 'C' | 'D' | 'E', string>
   }
   interface PaletteOptions {
     header?: PaletteColorOptions
+    footer?: PaletteColorOptions
     evidence?: Partial<Record<'A' | 'B' | 'C' | 'D' | 'E', string>>
   }
 }
@@ -25,6 +27,10 @@ export const themeOptions: ThemeOptions = {
     secondary: { main: '#A1D044' },
     header: {
       main: '#18252B',
+      contrastText: '#FFFFFF',
+    },
+    footer: {
+      main: '#7E7E7E',
       contrastText: '#FFFFFF',
     },
     evidence: {


### PR DESCRIPTION

<img width="1185" height="1257" alt="Screenshot 2025-11-13 at 4 53 25 PM" src="https://github.com/user-attachments/assets/c865c9ba-7a14-4b78-aeab-8a319ab09cb0" />


- Added the footer
- Moved the GH link and version to the footer
- Did some styling adjustments
- the page looked really boring and bland even with the footer so I added a lil news section for now to try to break up the monotony of the page as it currently is (lmk if I should do this in a different PR or something)

