### PR TITLE
feat: add '<gene> mutation' catvars from MOA

### DIFF
--- a/server/src/metakb/services/manage_data.py
+++ b/server/src/metakb/services/manage_data.py
@@ -98,20 +98,24 @@ def is_loadable_statement(statement: Statement) -> bool:
             proposition.subjectVariant,
         )
         success = False
-    if len(proposition.subjectVariant.constraints) != 1:
-        _logger.info(
-            "%s could not be loaded because it contains more than 1 constraint: %s",
-            statement.id,
-            proposition.subjectVariant.constraints,
-        )
-        success = False
-    if proposition.subjectVariant.constraints[0].type != "DefiningAlleleConstraint":
-        _logger.info(
-            "%s could not be loaded because it doesn't use a DefiningAlleleConstraint: %s",
-            statement.id,
-            proposition.subjectVariant.constraints,
-        )
-        success = False
+    else:
+        if len(proposition.subjectVariant.constraints) != 1:
+            _logger.info(
+                "%s could not be loaded because it contains more than 1 constraint: %s",
+                statement.id,
+                proposition.subjectVariant.constraints,
+            )
+            success = False
+        if (
+            proposition.subjectVariant.constraints[0].root.type
+            != "DefiningAlleleConstraint"
+        ):
+            _logger.info(
+                "%s could not be loaded because it doesn't use a DefiningAlleleConstraint: %s",
+                statement.id,
+                proposition.subjectVariant.constraints,
+            )
+            success = False
     if isinstance(proposition, VariantTherapeuticResponseProposition):
         if not _is_loadable_condition(
             proposition.conditionQualifier.root, statement.id

--- a/server/src/metakb/services/manage_data.py
+++ b/server/src/metakb/services/manage_data.py
@@ -98,6 +98,20 @@ def is_loadable_statement(statement: Statement) -> bool:
             proposition.subjectVariant,
         )
         success = False
+    if len(proposition.subjectVariant.constraints) != 1:
+        _logger.info(
+            "%s could not be loaded because it contains more than 1 constraint: %s",
+            statement.id,
+            proposition.subjectVariant.constraints,
+        )
+        success = False
+    if proposition.subjectVariant.constraints[0].type != "DefiningAlleleConstraint":
+        _logger.info(
+            "%s could not be loaded because it doesn't use a DefiningAlleleConstraint: %s",
+            statement.id,
+            proposition.subjectVariant.constraints,
+        )
+        success = False
     if isinstance(proposition, VariantTherapeuticResponseProposition):
         if not _is_loadable_condition(
             proposition.conditionQualifier.root, statement.id

--- a/server/src/metakb/transformers/moa.py
+++ b/server/src/metakb/transformers/moa.py
@@ -5,7 +5,11 @@ import logging
 from pathlib import Path
 from typing import ClassVar
 
-from ga4gh.cat_vrs.models import CategoricalVariant, DefiningAlleleConstraint
+from ga4gh.cat_vrs.models import (
+    CategoricalVariant,
+    DefiningAlleleConstraint,
+    FeatureContextConstraint,
+)
 from ga4gh.core import sha512t24u
 from ga4gh.core.models import (
     Coding,
@@ -39,7 +43,7 @@ from metakb.transformers.base import (
     _TransformedRecordsCache,
 )
 
-logger = logging.getLogger(__name__)
+_logger = logging.getLogger(__name__)
 
 
 class _MoaTransformedCache(_TransformedRecordsCache):
@@ -111,7 +115,7 @@ class MoaTransformer(Transformer):
         # Check cache for variation record (which contains gene information)
         variation_gene_map = self._cache.variations.get(variant_id)
         if not variation_gene_map:
-            logger.debug(
+            _logger.debug(
                 "%s has no variation for variant_id %s", assertion_id, variant_id
             )
             return
@@ -136,7 +140,7 @@ class MoaTransformer(Transformer):
         # Add disease
         moa_disease = self._add_disease(assertion["disease"])
         if not moa_disease:
-            logger.debug(
+            _logger.debug(
                 "%s has no disease for disease %s", assertion_id, assertion["disease"]
             )
             return
@@ -169,7 +173,7 @@ class MoaTransformer(Transformer):
             prop_params["objectTherapeutic"] = self._get_therapy_or_group(assertion)
 
             if not prop_params["objectTherapeutic"]:
-                logger.debug(
+                _logger.debug(
                     "%s has no therapy for therapy_name %s",
                     assertion_id,
                     assertion["therapy"]["name"],
@@ -233,8 +237,47 @@ class MoaTransformer(Transformer):
             constraints = None
             extensions = []
 
-            if "rearrangement_type" in variant or not protein_change or not gene:
-                logger.debug(
+            if (
+                variant["feature_type"] == "somatic_variant"
+                and variant["alternate_allele"] is None
+                and feature == gene
+                and protein_change is None
+                # no slam-dunk catvar solution exists for defining specific exons as features --
+                # see https://github.com/ga4gh/cat-vrs/discussions/161
+                and variant["exon"] is None
+            ):
+                gene_norm_resp, normalized_gene_id = (
+                    self.vicc_normalizers.normalize_gene(feature)
+                )
+                if not normalized_gene_id:
+                    _logger.debug("Unable to normalize feature term: %s", feature)
+                    extensions.append(self._get_vicc_normalizer_failure_ext())
+                else:
+                    mappings = []
+                    extensions = []
+                    if normalized_gene_id:
+                        mappings.extend(
+                            self._get_vicc_normalizer_mappings(
+                                normalized_gene_id, gene_norm_resp
+                            )
+                        )
+                        id_ = f"moa.{gene_norm_resp.gene.id}"
+                    else:
+                        id_ = f"moa.gene:{_sanitize_name(feature)}"
+                        extensions.append(self._get_vicc_normalizer_failure_ext())
+
+                    gene_concept = MappableConcept(
+                        id=id_,
+                        conceptType="Gene",
+                        name=gene,
+                        mappings=mappings or None,
+                        extensions=extensions or None,
+                    )
+                    constraints = [
+                        FeatureContextConstraint(featureContext=gene_concept)
+                    ]
+            elif "rearrangement_type" in variant or not protein_change or not gene:
+                _logger.debug(
                     "Variation Normalizer does not support %s: %s",
                     moa_variant_id,
                     feature,
@@ -249,7 +292,7 @@ class MoaTransformer(Transformer):
                 vrs_variation = await self.vicc_normalizers.normalize_variation(query)
 
                 if not vrs_variation:
-                    logger.debug(
+                    _logger.debug(
                         "Variation Normalizer unable to normalize: moa.variant: %s using query: %s",
                         variant_id,
                         query,
@@ -355,12 +398,12 @@ class MoaTransformer(Transformer):
                 genomic_params["name"] = gnomad_vcf
                 members = [Variation(**genomic_params)]
             else:
-                logger.debug(
+                _logger.debug(
                     "Variation Normalizer unable to normalize genomic representation: %s",
                     gnomad_vcf,
                 )
         else:
-            logger.debug(
+            _logger.debug(
                 "Not enough enough information provided to create genomic representation: %s",
                 moa_rep_coord,
             )
@@ -432,7 +475,7 @@ class MoaTransformer(Transformer):
         therapy = assertion["therapy"]
         therapy_name = therapy["name"]
         if not therapy_name:
-            logger.debug("%s has no therapy_name", assertion["id"])
+            _logger.debug("%s has no therapy_name", assertion["id"])
             return None
 
         therapy_type = therapy["type"]
@@ -503,7 +546,7 @@ class MoaTransformer(Transformer):
         :param is_disease: ``True`` if ``cached_obj`` is a disease. ``False`` if
             ``cached_obj`` is a therapy
         """
-        logger.debug(
+        _logger.debug(
             "MOA %s and %s resolve to same concept %s",
             moa_concept_label,
             cached_label,
@@ -585,7 +628,7 @@ class MoaTransformer(Transformer):
         ) = self.vicc_normalizers.normalize_therapy(name)
 
         if not normalized_therapeutic_id:
-            logger.debug("Therapy Normalizer unable to normalize: %s", therapy)
+            _logger.debug("Therapy Normalizer unable to normalize: %s", therapy)
             extensions.append(self._get_vicc_normalizer_failure_ext())
             id_ = therapy_id
         else:
@@ -709,7 +752,7 @@ class MoaTransformer(Transformer):
                 break
 
         if not normalized_disease_id:
-            logger.debug("Disease Normalizer unable to normalize: %s", queries)
+            _logger.debug("Disease Normalizer unable to normalize: %s", queries)
             extensions.append(self._get_vicc_normalizer_failure_ext())
             id_ = f"moa.disease:{_sanitize_name(disease_name)}"
         else:

--- a/server/src/metakb/transformers/moa.py
+++ b/server/src/metakb/transformers/moa.py
@@ -249,6 +249,7 @@ class MoaTransformer(Transformer):
                 gene_norm_resp, normalized_gene_id = (
                     self.vicc_normalizers.normalize_gene(feature)
                 )
+                feature = f"{feature} Mutation"
                 if not normalized_gene_id:
                     _logger.debug("Unable to normalize feature term: %s", feature)
                     extensions.append(self._get_vicc_normalizer_failure_ext())

--- a/server/tests/data/harvesters/moa/assertions.json
+++ b/server/tests/data/harvesters/moa/assertions.json
@@ -1,108 +1,164 @@
 [
-	{
-		"assertion_id": 163,
-		"context": "",
-		"created_on": "02/07/25",
-		"deprecated": false,
-		"description": "The combination of ipilimumab and vemurafenib in a sequencing strategy showed limited efficacy in a phase II study.",
-		"disease": "Melanoma",
-		"favorable_prognosis": "",
-		"features": [
-			{
-				"attributes": [
-					{
-						"alternate_allele": "T",
-						"cdna_change": "c.1799T>A",
-						"chromosome": "7",
-						"end_position": "140453136",
-						"exon": "15",
-						"feature_type": "somatic_variant",
-						"gene": "BRAF",
-						"protein_change": "p.V600E",
-						"reference_allele": "A",
-						"rsid": "rs113488022",
-						"start_position": "140453136",
-						"variant_annotation": "Missense"
-					}
-				],
-				"feature_id": 163,
-				"feature_type": "somatic_variant"
-			}
-		],
-		"last_updated": "2019-06-13",
-		"oncotree_code": "MEL",
-		"oncotree_term": "Melanoma",
-		"predictive_implication": "Clinical trial",
-		"sources": [
-			{
-				"citation": "Amin A, Lawson DH, Salama AK, et al. Phase II study of vemurafenib followed by ipilimumab in patients with previously untreated BRAF-mutated metastatic melanoma. J Immunother Cancer. 2016;4:44.",
-				"doi": "10.1186/s40425-016-0148-7",
-				"nct": "NCT01673854",
-				"pmid": 27532019,
-				"source_id": 69,
-				"source_type": "Journal",
-				"url": "https://doi.org/10.1186/s40425-016-0148-7"
-			}
-		],
-		"submitted_by": "breardon@broadinstitute.org",
-		"therapy_name": "Ipilimumab + Vemurafenib",
-		"therapy_resistance": "",
-		"therapy_sensitivity": 1,
-		"therapy_strategy": "CTLA-4 inhibition + B-RAF inhibition",
-		"therapy_type": "Combination therapy",
-		"validated": true
-	},
-	{
-		"assertion_id": 164,
-		"context": "Resistance to BRAFi monotherapy",
-		"created_on": "02/07/25",
-		"deprecated": false,
-		"description": "Administration of bevacizumab in a dabrafenib-resistant melanoma cancer cell line (A375R) counteracted the tumor growth stimulating effect of administering dabrafenib post-resistance. This study suggests that a regime which combines BRAFi with bevacizumab or inhibitors of PI3K/Akt/mTOR may be more effective than BRAFi monotherapy in the setting of resistance.",
-		"disease": "Melanoma",
-		"favorable_prognosis": "",
-		"features": [
-			{
-				"attributes": [
-					{
-						"alternate_allele": "T",
-						"cdna_change": "c.1799T>A",
-						"chromosome": "7",
-						"end_position": "140453136",
-						"exon": "15",
-						"feature_type": "somatic_variant",
-						"gene": "BRAF",
-						"protein_change": "p.V600E",
-						"reference_allele": "A",
-						"rsid": "rs113488022",
-						"start_position": "140453136",
-						"variant_annotation": "Missense"
-					}
-				],
-				"feature_id": 164,
-				"feature_type": "somatic_variant"
-			}
-		],
-		"last_updated": "2019-06-13",
-		"oncotree_code": "MEL",
-		"oncotree_term": "Melanoma",
-		"predictive_implication": "Preclinical",
-		"sources": [
-			{
-				"citation": "Caporali S, Alvino E, Lacal PM, et al. Targeting the PI3K/AKT/mTOR pathway overcomes the stimulating effect of dabrafenib on the invasive behavior of melanoma cells with acquired resistance to the BRAF inhibitor. Int J Oncol. 2016;49(3):1164-74.",
-				"doi": "10.3892/ijo.2016.3594",
-				"nct": "",
-				"pmid": 27572607,
-				"source_id": 70,
-				"source_type": "Journal",
-				"url": "https://doi.org/10.3892/ijo.2016.3594"
-			}
-		],
-		"submitted_by": "breardon@broadinstitute.org",
-		"therapy_name": "Dabrafenib + Bevacizumab",
-		"therapy_resistance": "",
-		"therapy_sensitivity": 1,
-		"therapy_strategy": "B-RAF inhibition + VEGF/VEGFR inhibition",
-		"therapy_type": "Targeted therapy",
-		"validated": true
-	}
+  {
+    "assertion_id": 163,
+    "context": "",
+    "created_on": "02/07/25",
+    "deprecated": false,
+    "description": "The combination of ipilimumab and vemurafenib in a sequencing strategy showed limited efficacy in a phase II study.",
+    "disease": "Melanoma",
+    "favorable_prognosis": "",
+    "features": [
+      {
+        "attributes": [
+          {
+            "alternate_allele": "T",
+            "cdna_change": "c.1799T>A",
+            "chromosome": "7",
+            "end_position": "140453136",
+            "exon": "15",
+            "feature_type": "somatic_variant",
+            "gene": "BRAF",
+            "protein_change": "p.V600E",
+            "reference_allele": "A",
+            "rsid": "rs113488022",
+            "start_position": "140453136",
+            "variant_annotation": "Missense"
+          }
+        ],
+        "feature_id": 163,
+        "feature_type": "somatic_variant"
+      }
+    ],
+    "last_updated": "2019-06-13",
+    "oncotree_code": "MEL",
+    "oncotree_term": "Melanoma",
+    "predictive_implication": "Clinical trial",
+    "sources": [
+      {
+        "citation": "Amin A, Lawson DH, Salama AK, et al. Phase II study of vemurafenib followed by ipilimumab in patients with previously untreated BRAF-mutated metastatic melanoma. J Immunother Cancer. 2016;4:44.",
+        "doi": "10.1186/s40425-016-0148-7",
+        "nct": "NCT01673854",
+        "pmid": 27532019,
+        "source_id": 69,
+        "source_type": "Journal",
+        "url": "https://doi.org/10.1186/s40425-016-0148-7"
+      }
+    ],
+    "submitted_by": "breardon@broadinstitute.org",
+    "therapy_name": "Ipilimumab + Vemurafenib",
+    "therapy_resistance": "",
+    "therapy_sensitivity": 1,
+    "therapy_strategy": "CTLA-4 inhibition + B-RAF inhibition",
+    "therapy_type": "Combination therapy",
+    "validated": true
+  },
+  {
+    "assertion_id": 164,
+    "context": "Resistance to BRAFi monotherapy",
+    "created_on": "02/07/25",
+    "deprecated": false,
+    "description": "Administration of bevacizumab in a dabrafenib-resistant melanoma cancer cell line (A375R) counteracted the tumor growth stimulating effect of administering dabrafenib post-resistance. This study suggests that a regime which combines BRAFi with bevacizumab or inhibitors of PI3K/Akt/mTOR may be more effective than BRAFi monotherapy in the setting of resistance.",
+    "disease": "Melanoma",
+    "favorable_prognosis": "",
+    "features": [
+      {
+        "attributes": [
+          {
+            "alternate_allele": "T",
+            "cdna_change": "c.1799T>A",
+            "chromosome": "7",
+            "end_position": "140453136",
+            "exon": "15",
+            "feature_type": "somatic_variant",
+            "gene": "BRAF",
+            "protein_change": "p.V600E",
+            "reference_allele": "A",
+            "rsid": "rs113488022",
+            "start_position": "140453136",
+            "variant_annotation": "Missense"
+          }
+        ],
+        "feature_id": 164,
+        "feature_type": "somatic_variant"
+      }
+    ],
+    "last_updated": "2019-06-13",
+    "oncotree_code": "MEL",
+    "oncotree_term": "Melanoma",
+    "predictive_implication": "Preclinical",
+    "sources": [
+      {
+        "citation": "Caporali S, Alvino E, Lacal PM, et al. Targeting the PI3K/AKT/mTOR pathway overcomes the stimulating effect of dabrafenib on the invasive behavior of melanoma cells with acquired resistance to the BRAF inhibitor. Int J Oncol. 2016;49(3):1164-74.",
+        "doi": "10.3892/ijo.2016.3594",
+        "nct": "",
+        "pmid": 27572607,
+        "source_id": 70,
+        "source_type": "Journal",
+        "url": "https://doi.org/10.3892/ijo.2016.3594"
+      }
+    ],
+    "submitted_by": "breardon@broadinstitute.org",
+    "therapy_name": "Dabrafenib + Bevacizumab",
+    "therapy_resistance": "",
+    "therapy_sensitivity": 1,
+    "therapy_strategy": "B-RAF inhibition + VEGF/VEGFR inhibition",
+    "therapy_type": "Targeted therapy",
+    "validated": true
+  },
+  {
+    "assertion_id": 120,
+    "id": 120,
+    "context": "",
+    "deprecated": false,
+    "description": "ARID1A mutations were associated with poorer prognosis in a study of 109 microdissected pancreatic adenocarcinoma tumors.",
+    "disease": "Pancreatic Adenocarcinoma",
+    "oncotree_code": "PAAD",
+    "oncotree_term": "Pancreatic Adenocarcinoma",
+    "therapy_name": "",
+    "therapy_type": "",
+    "therapy_strategy": "",
+    "therapy_resistance": "",
+    "therapy_sensitivity": "",
+    "predictive_implication": "Clinical evidence",
+    "favorable_prognosis": 0,
+    "created_on": "10/02/25",
+    "last_updated": "2017-11-03",
+    "submitted_by": "breardon@broadinstitute.org",
+    "validated": true,
+    "sources": [
+      {
+        "source_id": 54,
+        "source_type": "Journal",
+        "doi": "10.1038/ncomms7744",
+        "nct": "",
+        "pmid": 25855536,
+        "url": "https://doi.org/10.1038/ncomms7744",
+        "citation": "Witkiewicz AK, Mcmillan EA, Balaji U, et al. Whole-exome sequencing of pancreatic cancer defines genetic diversity and therapeutic targets. Nat Commun. 2015;6:6744."
+      }
+    ],
+    "features": [
+      {
+        "attributes": [
+          {
+            "alternate_allele": null,
+            "cdna_change": null,
+            "chromosome": null,
+            "end_position": null,
+            "exon": null,
+            "gene": "ARID1A",
+            "protein_change": null,
+            "reference_allele": null,
+            "rsid": null,
+            "start_position": null,
+            "variant_annotation": null,
+            "feature": "ARID1A",
+
+            "feature_type": "somatic_variant"
+          }
+        ],
+        "feature_id": 145,
+        "feature_type": "somatic_variant"
+      }
+    ]
+  }
 ]

--- a/server/tests/data/harvesters/moa/variants.json
+++ b/server/tests/data/harvesters/moa/variants.json
@@ -1,22 +1,44 @@
 [
-	{
-		"attributes": [
-			{
-				"alternate_allele": "T",
-				"cdna_change": "c.1799T>A",
-				"chromosome": "7",
-				"end_position": "140453136",
-				"exon": "15",
-				"feature_type": "somatic_variant",
-				"gene": "BRAF",
-				"protein_change": "p.V600E",
-				"reference_allele": "A",
-				"rsid": "rs113488022",
-				"start_position": "140453136",
-				"variant_annotation": "Missense"
-			}
-		],
-		"feature_id": 145,
-		"feature_type": "somatic_variant"
-	}
+  {
+    "attributes": [
+      {
+        "alternate_allele": "T",
+        "cdna_change": "c.1799T>A",
+        "chromosome": "7",
+        "end_position": "140453136",
+        "exon": "15",
+        "feature_type": "somatic_variant",
+        "gene": "BRAF",
+        "protein_change": "p.V600E",
+        "reference_allele": "A",
+        "rsid": "rs113488022",
+        "start_position": "140453136",
+        "variant_annotation": "Missense"
+      }
+    ],
+    "feature_id": 144,
+    "feature_type": "somatic_variant"
+  },
+  {
+    "attributes": [
+      {
+        "alternate_allele": null,
+        "cdna_change": null,
+        "chromosome": null,
+        "end_position": null,
+        "exon": null,
+        "gene": "ARID1A",
+        "protein_change": null,
+        "reference_allele": null,
+        "rsid": null,
+        "start_position": null,
+        "variant_annotation": null,
+        "feature": "ARID1A",
+
+        "feature_type": "somatic_variant"
+      }
+    ],
+    "feature_id": 120,
+    "feature_type": "somatic_variant"
+  }
 ]

--- a/server/tests/data/transformers/prognostic/moa_harvester.json
+++ b/server/tests/data/transformers/prognostic/moa_harvester.json
@@ -1,89 +1,130 @@
 {
-	"assertions": [
-		{
-			"id": 141,
-			"context": "",
-			"deprecated": false,
-			"description": "More frequent in Chronic Myelomonocytic Leukemia.",
-			"disease": {
-				"name": "Myelodysplasia",
-				"oncotree_code": "MDS",
-				"oncotree_term": "Myelodysplasia"
-			},
-			"therapy": {
-				"name": "",
-				"type": "",
-				"strategy": "",
-				"resistance": "",
-				"sensitivity": ""
-			},
-			"predictive_implication": "Clinical evidence",
-			"favorable_prognosis": 0,
-			"created_on": "12/05/24",
-			"last_updated": "2019-06-13",
-			"submitted_by": "breardon@broadinstitute.org",
-			"validated": true,
-			"source_id": 60,
-			"variant": {
-				"id": 141,
-				"alternate_allele": "C",
-				"cdna_change": "c.4376A>G",
-				"chromosome": "X",
-				"end_position": "39921444",
-				"exon": "10",
-				"feature_type": "somatic_variant",
-				"gene": "BCOR",
-				"protein_change": "p.N1425S",
-				"reference_allele": "T",
-				"rsid": null,
-				"start_position": "39921444",
-				"variant_annotation": "Missense",
-				"feature": "BCOR p.N1425S (Missense)"
-			}
-		},
-		{
-			"id": 532,
-			"context": "",
-			"deprecated": false,
-			"description": "The National Comprehensive Cancer Network\u00ae (NCCN\u00ae) highlights SF3B1 E622, Y623, R625, N626, H662, T663, K666, K700E, I704, G740, G742, and D781 missense variants as being associated with a favorable prognosis in patients with myelodysplastic syndromes.",
-			"disease": {
-				"name": "Myelodysplasia",
-				"oncotree_code": "MDS",
-				"oncotree_term": "Myelodysplasia"
-			},
-			"therapy": {
-				"name": "",
-				"type": "",
-				"strategy": "",
-				"resistance": "",
-				"sensitivity": ""
-			},
-			"predictive_implication": "Guideline",
-			"favorable_prognosis": 1,
-			"created_on": "12/05/24",
-			"last_updated": "2023-11-02",
-			"submitted_by": "breardon@broadinstitute.org",
-			"validated": true,
-			"source_id": 33,
-			"variant": {
-				"id": 532,
-				"alternate_allele": "G",
-				"cdna_change": "c.1866G>C",
-				"chromosome": "2",
-				"end_position": "198267491",
-				"exon": "14",
-				"feature_type": "somatic_variant",
-				"gene": "SF3B1",
-				"protein_change": "p.E622D",
-				"reference_allele": "C",
-				"rsid": "rs763149798",
-				"start_position": "198267491",
-				"variant_annotation": "Missense",
-				"feature": "SF3B1 p.E622D (Missense)"
-			}
-		}
-	],
-	"sources": [
+  "assertions": [
+    {
+      "id": 141,
+      "context": "",
+      "deprecated": false,
+      "description": "More frequent in Chronic Myelomonocytic Leukemia.",
+      "disease": {
+        "name": "Myelodysplasia",
+        "oncotree_code": "MDS",
+        "oncotree_term": "Myelodysplasia"
+      },
+      "therapy": {
+        "name": "",
+        "type": "",
+        "strategy": "",
+        "resistance": "",
+        "sensitivity": ""
+      },
+      "predictive_implication": "Clinical evidence",
+      "favorable_prognosis": 0,
+      "created_on": "12/05/24",
+      "last_updated": "2019-06-13",
+      "submitted_by": "breardon@broadinstitute.org",
+      "validated": true,
+      "source_id": 60,
+      "variant": {
+        "id": 141,
+        "alternate_allele": "C",
+        "cdna_change": "c.4376A>G",
+        "chromosome": "X",
+        "end_position": "39921444",
+        "exon": "10",
+        "feature_type": "somatic_variant",
+        "gene": "BCOR",
+        "protein_change": "p.N1425S",
+        "reference_allele": "T",
+        "rsid": null,
+        "start_position": "39921444",
+        "variant_annotation": "Missense",
+        "feature": "BCOR p.N1425S (Missense)"
+      }
+    },
+    {
+      "id": 532,
+      "context": "",
+      "deprecated": false,
+      "description": "The National Comprehensive Cancer Network\u00ae (NCCN\u00ae) highlights SF3B1 E622, Y623, R625, N626, H662, T663, K666, K700E, I704, G740, G742, and D781 missense variants as being associated with a favorable prognosis in patients with myelodysplastic syndromes.",
+      "disease": {
+        "name": "Myelodysplasia",
+        "oncotree_code": "MDS",
+        "oncotree_term": "Myelodysplasia"
+      },
+      "therapy": {
+        "name": "",
+        "type": "",
+        "strategy": "",
+        "resistance": "",
+        "sensitivity": ""
+      },
+      "predictive_implication": "Guideline",
+      "favorable_prognosis": 1,
+      "created_on": "12/05/24",
+      "last_updated": "2023-11-02",
+      "submitted_by": "breardon@broadinstitute.org",
+      "validated": true,
+      "source_id": 33,
+      "variant": {
+        "id": 532,
+        "alternate_allele": "G",
+        "cdna_change": "c.1866G>C",
+        "chromosome": "2",
+        "end_position": "198267491",
+        "exon": "14",
+        "feature_type": "somatic_variant",
+        "gene": "SF3B1",
+        "protein_change": "p.E622D",
+        "reference_allele": "C",
+        "rsid": "rs763149798",
+        "start_position": "198267491",
+        "variant_annotation": "Missense",
+        "feature": "SF3B1 p.E622D (Missense)"
+      }
+    },
+    {
+      "id": 120,
+      "context": "",
+      "deprecated": false,
+      "description": "ARID1A mutations were associated with poorer prognosis in a study of 109 microdissected pancreatic adenocarcinoma tumors.",
+      "disease": {
+        "name": "Pancreatic Adenocarcinoma",
+        "oncotree_code": "PAAD",
+        "oncotree_term": "Pancreatic Adenocarcinoma"
+      },
+      "therapy": {
+        "name": "",
+        "type": "",
+        "strategy": "",
+        "resistance": "",
+        "sensitivity": ""
+      },
+      "predictive_implication": "Clinical evidence",
+      "favorable_prognosis": 0,
+      "created_on": "10/02/25",
+      "last_updated": "2017-11-03",
+      "submitted_by": "breardon@broadinstitute.org",
+      "validated": true,
+      "source_id": 54,
+      "variant": {
+        "id": 120,
+        "alternate_allele": null,
+        "cdna_change": null,
+        "chromosome": null,
+        "end_position": null,
+        "exon": null,
+        "feature_type": "somatic_variant",
+        "gene": "ARID1A",
+        "protein_change": null,
+        "reference_allele": null,
+        "rsid": null,
+        "start_position": null,
+        "variant_annotation": null,
+        "feature": "ARID1A"
+      }
+    }
+  ],
+  "sources": [
     {
       "id": 33,
       "type": "Guideline",
@@ -101,26 +142,35 @@
       "pmid": 20453058,
       "url": "https://doi.org/10.1158/1078-0432.CCR-09-2828",
       "citation": "O'Brien C, Wallin JJ, Sampath D, et al. Predictive biomarkers of sensitivity to the phosphatidylinositol 3' kinase inhibitor GDC-0941 in breast cancer preclinical models. Clin Cancer Res. 2010;16(14):3670-83."
+    },
+    {
+      "id": 54,
+      "type": "Journal",
+      "doi": "10.1038/ncomms7744",
+      "nct": "",
+      "pmid": 25855536,
+      "url": "https://doi.org/10.1038/ncomms7744",
+      "citation": "Witkiewicz AK, Mcmillan EA, Balaji U, et al. Whole-exome sequencing of pancreatic cancer defines genetic diversity and therapeutic targets. Nat Commun. 2015;6:6744."
     }
-	],
-	"variants": [
-		{
-			"id": 141,
-			"alternate_allele": "C",
-			"cdna_change": "c.4376A>G",
-			"chromosome": "X",
-			"end_position": "39921444",
-			"exon": "10",
-			"feature_type": "somatic_variant",
-			"gene": "BCOR",
-			"protein_change": "p.N1425S",
-			"reference_allele": "T",
-			"rsid": null,
-			"start_position": "39921444",
-			"variant_annotation": "Missense",
-			"feature": "BCOR p.N1425S (Missense)"
-		},
-		{
+  ],
+  "variants": [
+    {
+      "id": 141,
+      "alternate_allele": "C",
+      "cdna_change": "c.4376A>G",
+      "chromosome": "X",
+      "end_position": "39921444",
+      "exon": "10",
+      "feature_type": "somatic_variant",
+      "gene": "BCOR",
+      "protein_change": "p.N1425S",
+      "reference_allele": "T",
+      "rsid": null,
+      "start_position": "39921444",
+      "variant_annotation": "Missense",
+      "feature": "BCOR p.N1425S (Missense)"
+    },
+    {
       "id": 532,
       "alternate_allele": "G",
       "cdna_change": "c.1866G>C",
@@ -135,10 +185,23 @@
       "start_position": "198267491",
       "variant_annotation": "Missense",
       "feature": "SF3B1 p.E622D (Missense)"
+    },
+    {
+      "id": 120,
+      "alternate_allele": null,
+      "cdna_change": null,
+      "chromosome": null,
+      "end_position": null,
+      "exon": null,
+      "feature_type": "somatic_variant",
+      "gene": "ARID1A",
+      "protein_change": null,
+      "reference_allele": null,
+      "rsid": null,
+      "start_position": null,
+      "variant_annotation": null,
+      "feature": "ARID1A"
     }
-	],
-	"genes": [
-		"BCOR",
-		"SF3B1"
-	]
+  ],
+  "genes": ["BCOR", "SF3B1", "ARID1A"]
 }

--- a/server/tests/data/transformers/therapeutic/moa_harvester.json
+++ b/server/tests/data/transformers/therapeutic/moa_harvester.json
@@ -1,98 +1,139 @@
 {
-	"assertions": [
-		{
-			"id": 66,
-			"context": "",
-			"deprecated": false,
-			"description": "T315I mutant ABL1 in p210 BCR-ABL cells resulted in retained high levels of phosphotyrosine at increasing concentrations of inhibitor STI-571, whereas wildtype appropriately received inhibition.",
-			"disease": {
-				"name": "Chronic Myelogenous Leukemia",
-				"oncotree_code": "CML",
-				"oncotree_term": "Chronic Myelogenous Leukemia"
-			},
-			"therapy": {
-				"name": "Imatinib",
-				"type": "Targeted therapy",
-				"strategy": "BCR-ABL inhibition",
-				"resistance": 1,
-				"sensitivity": ""
-			},
-			"predictive_implication": "Preclinical",
-			"favorable_prognosis": "",
-			"created_on": "12/05/24",
-			"last_updated": "2023-11-30",
-			"submitted_by": "breardon@broadinstitute.org",
-			"validated": true,
-			"source_id": 45,
-			"variant": {
-				"id": 66,
-				"alternate_allele": "T",
-				"cdna_change": "c.944C>T",
-				"chromosome": "9",
-				"end_position": "133748283",
-				"exon": "5",
-				"feature_type": "somatic_variant",
-				"gene": "ABL1",
-				"protein_change": "p.T315I",
-				"reference_allele": "C",
-				"rsid": "rs121913459",
-				"start_position": "133748283",
-				"variant_annotation": "Missense",
-				"feature": "ABL1 p.T315I (Missense)"
-			}
-		},
-		{
-			"id": 154,
-			"context": "Metastatic, after prior therapy",
-			"deprecated": false,
-			"description": "The U.S. Food and Drug Administration (FDA) granted regular approval to encorafenib in combination with cetuximab for the treatment of adult patients with metastatic colorectal cancer (CRC) with BRAF V600E mutation, as detected by an FDA-approved test, after prior therapy.",
-			"disease": {
-				"name": "Colorectal Adenocarcinoma",
-				"oncotree_code": "COADREAD",
-				"oncotree_term": "Colorectal Adenocarcinoma"
-			},
-			"therapy": {
-				"name": "Cetuximab + Encorafenib",
-				"type": "Targeted therapy",
-				"strategy": "EGFR inhibition + B-RAF inhibition",
-				"resistance": "",
-				"sensitivity": 1
-			},
-			"predictive_implication": "FDA-Approved",
-			"favorable_prognosis": "",
-			"created_on": "12/05/24",
-			"last_updated": "2020-10-15",
-			"submitted_by": "breardon@broadinstitute.org",
-			"validated": true,
-			"source_id": 64,
-			"variant": {
-				"id": 144,
-				"alternate_allele": "T",
-				"cdna_change": "c.1799T>A",
-				"chromosome": "7",
-				"end_position": "140453136",
-				"exon": "15",
-				"feature_type": "somatic_variant",
-				"gene": "BRAF",
-				"protein_change": "p.V600E",
-				"reference_allele": "A",
-				"rsid": "rs113488022",
-				"start_position": "140453136",
-				"variant_annotation": "Missense",
-				"feature": "BRAF p.V600E (Missense)"
-			}
-		}
-	],
-	"sources": [
-		{
-			"id": 45,
-			"type": "Journal",
-			"doi": "10.1126/science.1062538",
-			"nct": "",
-			"pmid": 11423618,
-			"url": "https://doi.org/10.1126/science.1062538",
-			"citation": "Gorre, Mercedes E., et al. Clinical resistance to STI-571 cancer therapy caused by BCR-ABL gene mutation or amplification. Science 293.5531 (2001): 876-880."
-		},
+  "assertions": [
+    {
+      "id": 66,
+      "context": "",
+      "deprecated": false,
+      "description": "T315I mutant ABL1 in p210 BCR-ABL cells resulted in retained high levels of phosphotyrosine at increasing concentrations of inhibitor STI-571, whereas wildtype appropriately received inhibition.",
+      "disease": {
+        "name": "Chronic Myelogenous Leukemia",
+        "oncotree_code": "CML",
+        "oncotree_term": "Chronic Myelogenous Leukemia"
+      },
+      "therapy": {
+        "name": "Imatinib",
+        "type": "Targeted therapy",
+        "strategy": "BCR-ABL inhibition",
+        "resistance": 1,
+        "sensitivity": ""
+      },
+      "predictive_implication": "Preclinical",
+      "favorable_prognosis": "",
+      "created_on": "12/05/24",
+      "last_updated": "2023-11-30",
+      "submitted_by": "breardon@broadinstitute.org",
+      "validated": true,
+      "source_id": 45,
+      "variant": {
+        "id": 66,
+        "alternate_allele": "T",
+        "cdna_change": "c.944C>T",
+        "chromosome": "9",
+        "end_position": "133748283",
+        "exon": "5",
+        "feature_type": "somatic_variant",
+        "gene": "ABL1",
+        "protein_change": "p.T315I",
+        "reference_allele": "C",
+        "rsid": "rs121913459",
+        "start_position": "133748283",
+        "variant_annotation": "Missense",
+        "feature": "ABL1 p.T315I (Missense)"
+      }
+    },
+    {
+      "id": 154,
+      "context": "Metastatic, after prior therapy",
+      "deprecated": false,
+      "description": "The U.S. Food and Drug Administration (FDA) granted regular approval to encorafenib in combination with cetuximab for the treatment of adult patients with metastatic colorectal cancer (CRC) with BRAF V600E mutation, as detected by an FDA-approved test, after prior therapy.",
+      "disease": {
+        "name": "Colorectal Adenocarcinoma",
+        "oncotree_code": "COADREAD",
+        "oncotree_term": "Colorectal Adenocarcinoma"
+      },
+      "therapy": {
+        "name": "Cetuximab + Encorafenib",
+        "type": "Targeted therapy",
+        "strategy": "EGFR inhibition + B-RAF inhibition",
+        "resistance": "",
+        "sensitivity": 1
+      },
+      "predictive_implication": "FDA-Approved",
+      "favorable_prognosis": "",
+      "created_on": "12/05/24",
+      "last_updated": "2020-10-15",
+      "submitted_by": "breardon@broadinstitute.org",
+      "validated": true,
+      "source_id": 64,
+      "variant": {
+        "id": 144,
+        "alternate_allele": "T",
+        "cdna_change": "c.1799T>A",
+        "chromosome": "7",
+        "end_position": "140453136",
+        "exon": "15",
+        "feature_type": "somatic_variant",
+        "gene": "BRAF",
+        "protein_change": "p.V600E",
+        "reference_allele": "A",
+        "rsid": "rs113488022",
+        "start_position": "140453136",
+        "variant_annotation": "Missense",
+        "feature": "BRAF p.V600E (Missense)"
+      }
+    },
+    {
+      "id": 135,
+      "context": "Primary",
+      "deprecated": false,
+      "description": "Somatic homologous recombination mutations were predictive of platinum sensitivity compared with cases without homologous recombination mutations in Ovarian, Fallopian Tube, and Peritoneal Carcinomas.",
+      "disease": {
+        "name": "Peritoneal Mesothelioma",
+        "oncotree_code": "PEMESO",
+        "oncotree_term": "Peritoneal Mesothelioma"
+      },
+      "therapy": {
+        "name": "Platinum Compound",
+        "type": "Chemotherapy",
+        "strategy": "Platinum-based chemotherapy",
+        "resistance": "",
+        "sensitivity": 1
+      },
+      "predictive_implication": "Inferential",
+      "favorable_prognosis": "",
+      "created_on": "10/02/25",
+      "last_updated": "2025-02-13",
+      "submitted_by": "breardon@broadinstitute.org",
+      "validated": true,
+      "source_id": 59,
+      "variant": {
+        "id": 131,
+        "alternate_allele": null,
+        "cdna_change": null,
+        "chromosome": null,
+        "end_position": null,
+        "exon": null,
+        "feature_type": "somatic_variant",
+        "gene": "BARD1",
+        "protein_change": null,
+        "reference_allele": null,
+        "rsid": null,
+        "start_position": null,
+        "variant_annotation": null,
+        "feature": "BARD1"
+      }
+    }
+  ],
+  "sources": [
+    {
+      "id": 45,
+      "type": "Journal",
+      "doi": "10.1126/science.1062538",
+      "nct": "",
+      "pmid": 11423618,
+      "url": "https://doi.org/10.1126/science.1062538",
+      "citation": "Gorre, Mercedes E., et al. Clinical resistance to STI-571 cancer therapy caused by BCR-ABL gene mutation or amplification. Science 293.5531 (2001): 876-880."
+    },
     {
       "id": 64,
       "type": "FDA",
@@ -101,26 +142,35 @@
       "pmid": "",
       "url": "https://www.accessdata.fda.gov/drugsatfda_docs/label/2020/210496s006lbl.pdf",
       "citation": "Array BioPharma Inc. Braftovi (encorafenib) [package insert]. U.S. Food and Drug Administration website. www.accessdata.fda.gov/drugsatfda_docs/label/2020/210496s006lbl.pdf. Revised April 2020. Accessed October 15, 2020."
+    },
+    {
+      "id": 59,
+      "type": "Journal",
+      "doi": "10.1158/1078-0432.CCR-13-2287",
+      "nct": "",
+      "pmid": 24240112,
+      "url": "https://doi.org/10.1158/1078-0432.CCR-13-2287",
+      "citation": "Pennington KP, Walsh T, Harrell MI, et al. Germline and somatic mutations in homologous recombination genes predict platinum response and survival in ovarian, fallopian tube, and peritoneal carcinomas. Clin Cancer Res. 2014;20(3):764-75."
     }
-	],
-	"variants": [
-		{
-			"id": 66,
-			"alternate_allele": "T",
-			"cdna_change": "c.944C>T",
-			"chromosome": "9",
-			"end_position": "133748283",
-			"exon": "5",
-			"feature_type": "somatic_variant",
-			"gene": "ABL1",
-			"protein_change": "p.T315I",
-			"reference_allele": "C",
-			"rsid": "rs121913459",
-			"start_position": "133748283",
-			"variant_annotation": "Missense",
-			"feature": "ABL1 p.T315I (Missense)"
-		},
-		{
+  ],
+  "variants": [
+    {
+      "id": 66,
+      "alternate_allele": "T",
+      "cdna_change": "c.944C>T",
+      "chromosome": "9",
+      "end_position": "133748283",
+      "exon": "5",
+      "feature_type": "somatic_variant",
+      "gene": "ABL1",
+      "protein_change": "p.T315I",
+      "reference_allele": "C",
+      "rsid": "rs121913459",
+      "start_position": "133748283",
+      "variant_annotation": "Missense",
+      "feature": "ABL1 p.T315I (Missense)"
+    },
+    {
       "id": 144,
       "alternate_allele": "T",
       "cdna_change": "c.1799T>A",
@@ -135,10 +185,23 @@
       "start_position": "140453136",
       "variant_annotation": "Missense",
       "feature": "BRAF p.V600E (Missense)"
+    },
+    {
+      "id": 131,
+      "alternate_allele": null,
+      "cdna_change": null,
+      "chromosome": null,
+      "end_position": null,
+      "exon": null,
+      "feature_type": "somatic_variant",
+      "gene": "BARD1",
+      "protein_change": null,
+      "reference_allele": null,
+      "rsid": null,
+      "start_position": null,
+      "variant_annotation": null,
+      "feature": "BARD1"
     }
-	],
-	"genes": [
-		"ABL1",
-		"BRAF"
-	]
+  ],
+  "genes": ["ABL1", "BRAF", "BARD1"]
 }

--- a/server/tests/unit/harvesters/moa/test_moa_assertions.py
+++ b/server/tests/unit/harvesters/moa/test_moa_assertions.py
@@ -10,9 +10,9 @@ from metakb.harvesters.moa import MoaHarvester
 from metakb.schemas.app import SourceName
 
 
-@pytest.fixture(scope="module")
+@pytest.fixture(scope="session")
 def assertion164():
-    """Create a fixture for assertion #165."""
+    """Create a fixture for assertion #164."""
     return {
         "id": 164,
         "context": "Resistance to BRAFi monotherapy",
@@ -38,7 +38,7 @@ def assertion164():
         "validated": True,
         "source_id": 70,
         "variant": {
-            "id": 145,
+            "id": 144,
             "alternate_allele": "T",
             "cdna_change": "c.1799T>A",
             "chromosome": "7",
@@ -52,6 +52,51 @@ def assertion164():
             "start_position": "140453136",
             "variant_annotation": "Missense",
             "feature": "BRAF p.V600E (Missense)",
+        },
+    }
+
+
+@pytest.fixture(scope="session")
+def assertion120():
+    return {
+        "id": 120,
+        "context": "",
+        "deprecated": False,
+        "description": "ARID1A mutations were associated with poorer prognosis in a study of 109 microdissected pancreatic adenocarcinoma tumors.",
+        "disease": {
+            "name": "Pancreatic Adenocarcinoma",
+            "oncotree_code": "PAAD",
+            "oncotree_term": "Pancreatic Adenocarcinoma",
+        },
+        "therapy": {
+            "name": "",
+            "type": "",
+            "strategy": "",
+            "resistance": "",
+            "sensitivity": "",
+        },
+        "predictive_implication": "Clinical evidence",
+        "favorable_prognosis": 0,
+        "created_on": "10/02/25",
+        "last_updated": "2017-11-03",
+        "submitted_by": "breardon@broadinstitute.org",
+        "validated": True,
+        "source_id": 54,
+        "variant": {
+            "id": 120,
+            "alternate_allele": None,
+            "cdna_change": None,
+            "chromosome": None,
+            "end_position": None,
+            "exon": None,
+            "feature_type": "somatic_variant",
+            "gene": "ARID1A",
+            "protein_change": None,
+            "reference_allele": None,
+            "rsid": None,
+            "start_position": None,
+            "variant_annotation": None,
+            "feature": "ARID1A",
         },
     }
 
@@ -79,3 +124,28 @@ def test_assertion_164(test_get_all_assertions, test_get_all_variants, assertion
             actual = a
             break
     assert actual == assertion164
+
+
+@patch.object(MoaHarvester, "_get_all_variants")
+@patch.object(MoaHarvester, "_get_all_assertions")
+def test_assertion_120(test_get_all_assertions, test_get_all_variants, assertion120):
+    """Test moa harvester works correctly for assertions."""
+    moa_harvester_test_dir = TEST_HARVESTERS_DIR / SourceName.MOA.value
+    with (moa_harvester_test_dir / "assertions.json").open() as f:
+        data = json.load(f)
+    test_get_all_assertions.return_value = data
+
+    with (moa_harvester_test_dir / "variants.json").open() as f:
+        data = json.load(f)
+    test_get_all_variants.return_value = data
+
+    assertion_resp = MoaHarvester()._get_all_assertions()
+    _, variants_list = MoaHarvester().harvest_variants()
+    assertions = MoaHarvester().harvest_assertions(assertion_resp, variants_list)
+
+    actual = None
+    for a in assertions:
+        if a["id"] == assertion120["id"]:
+            actual = a
+            break
+    assert actual == assertion120

--- a/server/tests/unit/transformers/test_moa_transformer_prognostic.py
+++ b/server/tests/unit/transformers/test_moa_transformer_prognostic.py
@@ -447,7 +447,7 @@ def moa_aid120_study_stmt():
             "subjectVariant": {
                 "id": "moa.variant:120",
                 "type": "CategoricalVariant",
-                "name": "ARID1A",
+                "name": "ARID1A Mutation",
                 "extensions": [],
                 "constraints": [
                     {

--- a/server/tests/unit/transformers/test_moa_transformer_prognostic.py
+++ b/server/tests/unit/transformers/test_moa_transformer_prognostic.py
@@ -413,10 +413,205 @@ def moa_aid532_study_stmt(
     }
 
 
+@pytest.fixture(scope="session")
+def moa_aid120_study_stmt():
+    return {
+        "id": "moa.assertion:120",
+        "type": "Statement",
+        "description": "ARID1A mutations were associated with poorer prognosis in a study of 109 microdissected pancreatic adenocarcinoma tumors.",
+        "specifiedBy": {
+            "id": "moa.method:2021",
+            "type": "Method",
+            "name": "MOAlmanac (2021)",
+            "reportedIn": {
+                "type": "Document",
+                "name": "Reardon, B., Moore, N.D., Moore, N.S. et al.",
+                "title": "Integrating molecular profiles into clinical frameworks through the Molecular Oncology Almanac to prospectively guide precision oncology",
+                "doi": "10.1038/s43018-021-00243-3",
+                "pmid": 35121878,
+            },
+        },
+        "reportedIn": [
+            {
+                "id": "moa.source:54",
+                "type": "Document",
+                "extensions": [{"name": "source_type", "value": "Journal"}],
+                "title": "Witkiewicz AK, Mcmillan EA, Balaji U, et al. Whole-exome sequencing of pancreatic cancer defines genetic diversity and therapeutic targets. Nat Commun. 2015;6:6744.",
+                "urls": ["https://doi.org/10.1038/ncomms7744"],
+                "doi": "10.1038/ncomms7744",
+                "pmid": 25855536,
+            }
+        ],
+        "proposition": {
+            "type": "VariantPrognosticProposition",
+            "subjectVariant": {
+                "id": "moa.variant:120",
+                "type": "CategoricalVariant",
+                "name": "ARID1A",
+                "extensions": [],
+                "constraints": [
+                    {
+                        "type": "FeatureContextConstraint",
+                        "featureContext": {
+                            "id": "moa.normalize.gene.hgnc:11110",
+                            "conceptType": "Gene",
+                            "name": "ARID1A",
+                            "mappings": [
+                                {
+                                    "extensions": [
+                                        {
+                                            "name": "vicc_normalizer_priority",
+                                            "value": True,
+                                        }
+                                    ],
+                                    "coding": {
+                                        "id": "hgnc:11110",
+                                        "name": "ARID1A",
+                                        "system": "https://www.genenames.org/data/gene-symbol-report/#!/hgnc_id/",
+                                        "code": "HGNC:11110",
+                                    },
+                                    "relation": "exactMatch",
+                                },
+                                {
+                                    "extensions": [
+                                        {
+                                            "name": "vicc_normalizer_priority",
+                                            "value": False,
+                                        }
+                                    ],
+                                    "coding": {
+                                        "id": "ncbigene:8289",
+                                        "system": "https://www.ncbi.nlm.nih.gov/gene/",
+                                        "code": "8289",
+                                    },
+                                    "relation": "exactMatch",
+                                },
+                            ],
+                        },
+                    }
+                ],
+                "mappings": [
+                    {
+                        "coding": {
+                            "id": "moa.variant:120",
+                            "system": "https://moalmanac.org",
+                            "code": "120",
+                        },
+                        "relation": "exactMatch",
+                    }
+                ],
+            },
+            "geneContextQualifier": {
+                "id": "moa.normalize.gene.hgnc:11110",
+                "conceptType": "Gene",
+                "name": "ARID1A",
+                "mappings": [
+                    {
+                        "extensions": [
+                            {"name": "vicc_normalizer_priority", "value": True}
+                        ],
+                        "coding": {
+                            "id": "hgnc:11110",
+                            "name": "ARID1A",
+                            "system": "https://www.genenames.org/data/gene-symbol-report/#!/hgnc_id/",
+                            "code": "HGNC:11110",
+                        },
+                        "relation": "exactMatch",
+                    },
+                    {
+                        "extensions": [
+                            {"name": "vicc_normalizer_priority", "value": False}
+                        ],
+                        "coding": {
+                            "id": "ncbigene:8289",
+                            "system": "https://www.ncbi.nlm.nih.gov/gene/",
+                            "code": "8289",
+                        },
+                        "relation": "exactMatch",
+                    },
+                ],
+            },
+            "alleleOriginQualifier": {"name": "somatic"},
+            "predicate": "associatedWithWorseOutcomeFor",
+            "objectCondition": {
+                "id": "moa.normalize.disease.ncit:C8294",
+                "conceptType": "Disease",
+                "name": "Pancreatic Adenocarcinoma",
+                "mappings": [
+                    {
+                        "coding": {
+                            "id": "oncotree:PAAD",
+                            "name": "Pancreatic Adenocarcinoma",
+                            "system": "https://oncotree.mskcc.org/?version=oncotree_latest_stable&field=CODE&search=",
+                            "code": "PAAD",
+                        },
+                        "relation": "exactMatch",
+                    },
+                    {
+                        "extensions": [
+                            {"name": "vicc_normalizer_priority", "value": True}
+                        ],
+                        "coding": {
+                            "id": "ncit:C8294",
+                            "name": "Pancreatic Adenocarcinoma",
+                            "system": "https://ncit.nci.nih.gov/ncitbrowser/ConceptReport.jsp?dictionary=NCI_Thesaurus&code=",
+                            "code": "C8294",
+                        },
+                        "relation": "exactMatch",
+                    },
+                    {
+                        "extensions": [
+                            {"name": "vicc_normalizer_priority", "value": False}
+                        ],
+                        "coding": {
+                            "id": "DOID:4074",
+                            "system": "https://disease-ontology.org/?id=",
+                            "code": "DOID:4074",
+                        },
+                        "relation": "exactMatch",
+                    },
+                    {
+                        "extensions": [
+                            {"name": "vicc_normalizer_priority", "value": False}
+                        ],
+                        "coding": {
+                            "id": "MONDO_0006047",
+                            "system": "https://purl.obolibrary.org/obo/",
+                            "code": "MONDO:0006047",
+                        },
+                        "relation": "exactMatch",
+                    },
+                ],
+            },
+        },
+        "direction": "disputes",
+        "strength": {
+            "primaryCoding": {
+                "system": "https://moalmanac.org/about",
+                "code": "Clinical evidence",
+            },
+            "mappings": [
+                {
+                    "coding": {
+                        "name": "observational study evidence",
+                        "system": "https://go.osu.edu/evidence-codes",
+                        "code": "e000007",
+                    },
+                    "relation": "exactMatch",
+                }
+            ],
+        },
+    }
+
+
 @pytest.fixture(scope="module")
-def statements(moa_aid141_study_stmt, moa_aid532_study_stmt):
+def statements(
+    moa_aid141_study_stmt: dict,
+    moa_aid532_study_stmt: dict,
+    moa_aid120_study_stmt: dict,
+):
     """Create test fixture for MOA prognostic statements."""
-    return [moa_aid141_study_stmt, moa_aid532_study_stmt]
+    return [moa_aid141_study_stmt, moa_aid532_study_stmt, moa_aid120_study_stmt]
 
 
 def test_moa_cdm(data, statements, check_transformed_cdm):

--- a/server/tests/unit/transformers/test_moa_transformer_therapeutic.py
+++ b/server/tests/unit/transformers/test_moa_transformer_therapeutic.py
@@ -447,7 +447,7 @@ def moa_aid135_study_stmt():
             "subjectVariant": {
                 "id": "moa.variant:131",
                 "type": "CategoricalVariant",
-                "name": "BARD1",
+                "name": "BARD1 Mutation",
                 "extensions": [],
                 "constraints": [
                     {

--- a/server/tests/unit/transformers/test_moa_transformer_therapeutic.py
+++ b/server/tests/unit/transformers/test_moa_transformer_therapeutic.py
@@ -413,10 +413,211 @@ def moa_not_normalizable_stmt(
     }
 
 
+@pytest.fixture(scope="session")
+def moa_aid135_study_stmt():
+    return {
+        "id": "moa.assertion:135",
+        "type": "Statement",
+        "description": "Somatic homologous recombination mutations were predictive of platinum sensitivity compared with cases without homologous recombination mutations in Ovarian, Fallopian Tube, and Peritoneal Carcinomas.",
+        "specifiedBy": {
+            "id": "moa.method:2021",
+            "type": "Method",
+            "name": "MOAlmanac (2021)",
+            "reportedIn": {
+                "type": "Document",
+                "name": "Reardon, B., Moore, N.D., Moore, N.S. et al.",
+                "title": "Integrating molecular profiles into clinical frameworks through the Molecular Oncology Almanac to prospectively guide precision oncology",
+                "doi": "10.1038/s43018-021-00243-3",
+                "pmid": 35121878,
+            },
+        },
+        "reportedIn": [
+            {
+                "id": "moa.source:59",
+                "type": "Document",
+                "extensions": [{"name": "source_type", "value": "Journal"}],
+                "title": "Pennington KP, Walsh T, Harrell MI, et al. Germline and somatic mutations in homologous recombination genes predict platinum response and survival in ovarian, fallopian tube, and peritoneal carcinomas. Clin Cancer Res. 2014;20(3):764-75.",
+                "urls": ["https://doi.org/10.1158/1078-0432.CCR-13-2287"],
+                "doi": "10.1158/1078-0432.CCR-13-2287",
+                "pmid": 24240112,
+            }
+        ],
+        "proposition": {
+            "type": "VariantTherapeuticResponseProposition",
+            "subjectVariant": {
+                "id": "moa.variant:131",
+                "type": "CategoricalVariant",
+                "name": "BARD1",
+                "extensions": [],
+                "constraints": [
+                    {
+                        "type": "FeatureContextConstraint",
+                        "featureContext": {
+                            "id": "moa.normalize.gene.hgnc:952",
+                            "conceptType": "Gene",
+                            "name": "BARD1",
+                            "mappings": [
+                                {
+                                    "extensions": [
+                                        {
+                                            "name": "vicc_normalizer_priority",
+                                            "value": True,
+                                        }
+                                    ],
+                                    "coding": {
+                                        "id": "hgnc:952",
+                                        "name": "BARD1",
+                                        "system": "https://www.genenames.org/data/gene-symbol-report/#!/hgnc_id/",
+                                        "code": "HGNC:952",
+                                    },
+                                    "relation": "exactMatch",
+                                },
+                                {
+                                    "extensions": [
+                                        {
+                                            "name": "vicc_normalizer_priority",
+                                            "value": False,
+                                        }
+                                    ],
+                                    "coding": {
+                                        "id": "ncbigene:580",
+                                        "system": "https://www.ncbi.nlm.nih.gov/gene/",
+                                        "code": "580",
+                                    },
+                                    "relation": "exactMatch",
+                                },
+                            ],
+                        },
+                    }
+                ],
+                "mappings": [
+                    {
+                        "coding": {
+                            "id": "moa.variant:131",
+                            "system": "https://moalmanac.org",
+                            "code": "131",
+                        },
+                        "relation": "exactMatch",
+                    }
+                ],
+            },
+            "geneContextQualifier": {
+                "id": "moa.normalize.gene.hgnc:952",
+                "conceptType": "Gene",
+                "name": "BARD1",
+                "mappings": [
+                    {
+                        "extensions": [
+                            {"name": "vicc_normalizer_priority", "value": True}
+                        ],
+                        "coding": {
+                            "id": "hgnc:952",
+                            "name": "BARD1",
+                            "system": "https://www.genenames.org/data/gene-symbol-report/#!/hgnc_id/",
+                            "code": "HGNC:952",
+                        },
+                        "relation": "exactMatch",
+                    },
+                    {
+                        "extensions": [
+                            {"name": "vicc_normalizer_priority", "value": False}
+                        ],
+                        "coding": {
+                            "id": "ncbigene:580",
+                            "system": "https://www.ncbi.nlm.nih.gov/gene/",
+                            "code": "580",
+                        },
+                        "relation": "exactMatch",
+                    },
+                ],
+            },
+            "alleleOriginQualifier": {"name": "somatic"},
+            "predicate": "predictsSensitivityTo",
+            "objectTherapeutic": {
+                "id": "moa.normalize.therapy.ncit:C1450",
+                "conceptType": "Therapy",
+                "name": "Platinum Compound",
+                "mappings": [
+                    {
+                        "extensions": [
+                            {"name": "vicc_normalizer_priority", "value": True}
+                        ],
+                        "coding": {
+                            "id": "ncit:C1450",
+                            "name": "Platinum Compound",
+                            "system": "https://ncit.nci.nih.gov/ncitbrowser/ConceptReport.jsp?dictionary=NCI_Thesaurus&code=",
+                            "code": "C1450",
+                        },
+                        "relation": "exactMatch",
+                    }
+                ],
+            },
+            "conditionQualifier": {
+                "id": "moa.normalize.disease.ncit:C7633",
+                "conceptType": "Disease",
+                "name": "Peritoneal Mesothelioma",
+                "mappings": [
+                    {
+                        "coding": {
+                            "id": "oncotree:PEMESO",
+                            "name": "Peritoneal Mesothelioma",
+                            "system": "https://oncotree.mskcc.org/?version=oncotree_latest_stable&field=CODE&search=",
+                            "code": "PEMESO",
+                        },
+                        "relation": "exactMatch",
+                    },
+                    {
+                        "extensions": [
+                            {"name": "vicc_normalizer_priority", "value": True}
+                        ],
+                        "coding": {
+                            "id": "ncit:C7633",
+                            "name": "Peritoneal Mesothelial Neoplasm",
+                            "system": "https://ncit.nci.nih.gov/ncitbrowser/ConceptReport.jsp?dictionary=NCI_Thesaurus&code=",
+                            "code": "C7633",
+                        },
+                        "relation": "exactMatch",
+                    },
+                    {
+                        "extensions": [
+                            {"name": "vicc_normalizer_priority", "value": False}
+                        ],
+                        "coding": {
+                            "id": "MONDO_0006362",
+                            "system": "https://purl.obolibrary.org/obo/",
+                            "code": "MONDO:0006362",
+                        },
+                        "relation": "exactMatch",
+                    },
+                ],
+            },
+        },
+        "direction": "supports",
+        "strength": {
+            "primaryCoding": {
+                "system": "https://moalmanac.org/about",
+                "code": "Inferential evidence",
+            },
+            "mappings": [
+                {
+                    "coding": {
+                        "name": "inferential evidence",
+                        "system": "https://go.osu.edu/evidence-codes",
+                        "code": "e000010",
+                    },
+                    "relation": "exactMatch",
+                }
+            ],
+        },
+    }
+
+
 @pytest.fixture(scope="module")
-def statements(moa_aid66_study_stmt, moa_aid154_study_stmt):
+def statements(
+    moa_aid66_study_stmt: dict, moa_aid154_study_stmt: dict, moa_aid135_study_stmt: dict
+):
     """Create test fixture for MOA therapeutic statements."""
-    return [moa_aid66_study_stmt, moa_aid154_study_stmt]
+    return [moa_aid66_study_stmt, moa_aid154_study_stmt, moa_aid135_study_stmt]
 
 
 def test_moa_cdm(normalizable_data, statements, check_transformed_cdm):


### PR DESCRIPTION
* Identify MOA variants that can be represented with [FeatureContextConstraints](https://cat-vrs.ga4gh.org/en/latest/concepts/catvrs_model.html#featurecontextconstraint) and construct said constraints. I think this could account for up to 200 additional statements.
* Update DB ingest method to block upload of unsupported catvars on the DB side. Once this PR is approved, a subsequent ticket could handle ingest and retrieval of them.

MOA examples: https://moalmanac.org/assertion/559, https://moalmanac.org/assertion/521

See here for an example of CDM output:

https://gist.github.com/jsstevenson/5fc111fdff9e7a23efba18bf682341bc