### PR TITLE
refactor: break SequenceReference into its own DB node

### DIFF
--- a/server/src/metakb/repository/neo4j_models.py
+++ b/server/src/metakb/repository/neo4j_models.py
@@ -79,6 +79,21 @@ class BaseNode(BaseModel, abc.ABC):
         """Return corresponding GKS class."""
 
 
+class SequenceReferenceNode(BaseNode):
+    """Node model for a sequence reference"""
+
+    refget_accession: str
+
+    @classmethod
+    def from_gks(cls, sequence_reference: SequenceReference) -> Self:
+        """Create Node instance from GKS class."""
+        return cls(refget_accession=sequence_reference.refgetAccession)
+
+    def to_gks(self) -> SequenceReference:
+        """Return VRS SequenceReference"""
+        return SequenceReference(refgetAccession=self.refget_accession)
+
+
 class SequenceLocationNode(BaseNode):
     """Node model for SequenceLocation"""
 
@@ -87,7 +102,7 @@ class SequenceLocationNode(BaseNode):
     # will need to think about how to handle null case in the future
     start: int
     end: int
-    refget_accession: str
+    has_sequence_reference: SequenceReferenceNode
     sequence: str = ""
 
     @classmethod
@@ -97,7 +112,9 @@ class SequenceLocationNode(BaseNode):
             id=sequence_location.id,
             start=sequence_location.start,
             end=sequence_location.end,
-            refget_accession=sequence_location.sequenceReference.refgetAccession,
+            has_sequence_reference=SequenceReferenceNode.from_gks(
+                sequence_location.sequenceReference
+            ),
             sequence=sequence_location.sequence.root
             if sequence_location.sequence
             else "",
@@ -109,7 +126,7 @@ class SequenceLocationNode(BaseNode):
             id=self.id,
             start=self.start,
             end=self.end,
-            sequenceReference=SequenceReference(refgetAccession=self.refget_accession),
+            sequenceReference=self.has_sequence_reference.to_gks(),
             sequence=self.sequence if self.sequence else None,
         )
 

--- a/server/src/metakb/repository/neo4j_repository.py
+++ b/server/src/metakb/repository/neo4j_repository.py
@@ -348,7 +348,6 @@ class Neo4jRepository(AbstractRepository):
     ) -> AlleleNode:
         """Build a VRS Allele node from the raw Neo4j node results
 
-
         :param allele_record: Neo4j allele record
         :param sl_record: Neo4j sequence location record
         :param se_record: Neo4j sequence expression record

--- a/server/src/metakb/repository/queries/load_definingalleleconstraint_catvar.cypher
+++ b/server/src/metakb/repository/queries/load_definingalleleconstraint_catvar.cypher
@@ -1,3 +1,4 @@
+// ----- Declare base CV node + nodes related to constraint -----
 MERGE (cv:Variation:CategoricalVariant:ProteinSequenceConsequence {id: $cv.id})
   ON CREATE SET
     cv +=
@@ -22,20 +23,17 @@ MERGE
         expressions: $cv.has_constraint.has_defining_allele.expressions
       }
 MERGE (constr)-[:HAS_DEFINING_ALLELE]->(allele)
-MERGE
-  (sl:Location:SequenceLocation
-    {id: $cv.has_constraint.has_defining_allele.has_location.id})
-  ON CREATE SET
-    sl +=
-      {
-        digest: $cv.has_constraint.has_defining_allele.has_location.digest,
-        start: $cv.has_constraint.has_defining_allele.has_location.start,
-        end: $cv.has_constraint.has_defining_allele.has_location.end,
-        refget_accession:
-          $cv.has_constraint.has_defining_allele.has_location.refget_accession,
-        sequence: $cv.has_constraint.has_defining_allele.has_location.sequence
-      }
+WITH
+  cv,
+  constr,
+  allele,
+  $cv.has_constraint.has_defining_allele.has_location AS loc
+MERGE (sl:Location:SequenceLocation {id: loc.id})
+  ON CREATE SET sl += loc {.digest, .start, .end, .sequence}
 MERGE (allele)-[:HAS_LOCATION]->(sl)
+WITH cv, constr, allele, sl, loc, loc.has_sequence_reference AS loc_sr
+MERGE (sr:SequenceReference {refget_accession: loc_sr.refget_accession})
+MERGE (sl)-[:HAS_SEQUENCE_REFERENCE]->(sr)
 
 // handle different kinds of state objects
 FOREACH (_ IN
@@ -70,6 +68,7 @@ END |
   MERGE (allele)-[:HAS_STATE]->(rle)
 )
 
+// ----- Declare base CV node + nodes related to constraint -----
 WITH cv
 UNWIND $cv.has_members AS m
 MERGE (member_allele:Variation:MolecularVariation:Allele {id: m.id})
@@ -88,6 +87,10 @@ MERGE (member_sl:Location:SequenceLocation {id: m.has_location.id})
         sequence: m.has_location.sequence
       }
 MERGE (member_allele)-[:HAS_LOCATION]->(member_sl)
+MERGE
+  (member_sr:SequenceReference
+    {refget_accession: m.has_location.has_sequence_reference.refget_accession})
+MERGE (member_sl)-[:HAS_SEQUENCE_REFERENCE]->(member_sr)
 
 // handle different kinds of state objects
 FOREACH (_ IN

--- a/server/src/metakb/repository/queries/load_definingalleleconstraint_catvar.cypher
+++ b/server/src/metakb/repository/queries/load_definingalleleconstraint_catvar.cypher
@@ -23,6 +23,7 @@ MERGE
         expressions: $cv.has_constraint.has_defining_allele.expressions
       }
 MERGE (constr)-[:HAS_DEFINING_ALLELE]->(allele)
+// bind `loc` for readability
 WITH
   cv,
   constr,

--- a/server/src/metakb/repository/queries/search_statements.cypher
+++ b/server/src/metakb/repository/queries/search_statements.cypher
@@ -78,6 +78,9 @@ MATCH
   (constraint:DefiningAlleleConstraint)-[:HAS_DEFINING_ALLELE]->
   (defining_allele:Allele)
 MATCH (defining_allele)-[:HAS_LOCATION]->(defining_allele_sl:SequenceLocation)
+MATCH
+  (defining_allele_sl)-[:HAS_SEQUENCE_REFERENCE]->
+  (defining_allele_sr:SequenceReference)
 MATCH (defining_allele)-[:HAS_STATE]->(defining_allele_se:SequenceExpression)
 CALL (cv) {
   WITH cv
@@ -106,7 +109,8 @@ CALL (s) {
       CASE
         WHEN line IS NULL THEN null
         ELSE line {.*, evidence_item_ids: item_ids}
-      END) AS tmp
+      END
+    ) AS tmp
   RETURN [x IN tmp WHERE x IS NOT NULL] AS evidence_lines
 }
 
@@ -128,6 +132,5 @@ RETURN DISTINCT
   drug,
   documents,
   evidence_lines
-ORDER BY s.id
-SKIP $start
+ORDER BY s.id SKIP $start
 LIMIT $limit;

--- a/server/src/metakb/repository/queries/search_statements.cypher
+++ b/server/src/metakb/repository/queries/search_statements.cypher
@@ -86,10 +86,15 @@ CALL (cv) {
   WITH cv
   OPTIONAL MATCH (cv)-[:HAS_MEMBER]->(m:Allele)
   OPTIONAL MATCH (m)-[:HAS_LOCATION]->(sl:SequenceLocation)
+  OPTIONAL MATCH (sl)-[:HAS_SEQUENCE_REFERENCE]->(sr:SequenceReference)
   OPTIONAL MATCH (m)-[:HAS_STATE]->(se:SequenceExpression)
-  WITH m, sl, se
-  WHERE m IS NOT NULL AND sl IS NOT NULL AND se IS NOT NULL
-  RETURN collect(DISTINCT {allele: m, location: sl, state: se}) AS members
+  WITH m, sl, sr, se
+  WHERE m IS NOT NULL AND sl IS NOT NULL AND sr IS NOT NULL AND se IS NOT NULL
+  RETURN
+    collect(
+      DISTINCT
+      {allele: m, location: sl {.*, has_sequence_reference: sr}, state: se}
+    ) AS members
 }
 
 // get documents
@@ -123,7 +128,7 @@ RETURN DISTINCT
   cv,
   constraint,
   defining_allele,
-  defining_allele_sl,
+  defining_allele_sl {.*, has_sequence_reference: defining_allele_sr} AS defining_allele_sl,
   defining_allele_se,
   members,
   c,


### PR DESCRIPTION
tldr: now there is a node representing a sequence reference (e.g. to chromosome 9, or `NM_12345.1`) that you can walk to from alleles on that sequence

<img width="710" height="349" alt="Screenshot 2025-12-09 at 9 30 35 PM" src="https://github.com/user-attachments/assets/a2ad561c-9854-40bb-90ca-222390dc3e25" />

* Previously, the sequence ID part of alleles was just a property on Location nodes. I think I was hoping that we could just let aliases/etc live in SeqRepo, but I started to realize that it might be more complicated (esp for Firefly support).
* Also cleaned up some particularly long property chaining in the defining allele catvar load query

