### PR TITLE
fix: deps issue causing deploy fail - downgrade react to 18 

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -21,8 +21,8 @@
     "@visx/heatmap": "^3.12.0",
     "@visx/scale": "^3.12.0",
     "@visx/tooltip": "^3.12.0",
-    "react": "^19.0.0",
-    "react-dom": "^19.0.0",
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
     "react-router-dom": "^7.5.1"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -29,40 +29,40 @@ importers:
     dependencies:
       '@emotion/react':
         specifier: ^11.14.0
-        version: 11.14.0(@types/react@19.1.2)(react@19.1.0)
+        version: 11.14.0(@types/react@19.1.2)(react@18.2.0)
       '@emotion/styled':
         specifier: ^11.14.1
-        version: 11.14.1(@emotion/react@11.14.0(@types/react@19.1.2)(react@19.1.0))(@types/react@19.1.2)(react@19.1.0)
+        version: 11.14.1(@emotion/react@11.14.0(@types/react@19.1.2)(react@18.2.0))(@types/react@19.1.2)(react@18.2.0)
       '@mui/icons-material':
         specifier: ^7.3.1
-        version: 7.3.1(@mui/material@7.3.1(@emotion/react@11.14.0(@types/react@19.1.2)(react@19.1.0))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.1.2)(react@19.1.0))(@types/react@19.1.2)(react@19.1.0))(@types/react@19.1.2)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(@types/react@19.1.2)(react@19.1.0)
+        version: 7.3.1(@mui/material@7.3.1(@emotion/react@11.14.0(@types/react@19.1.2)(react@18.2.0))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.1.2)(react@18.2.0))(@types/react@19.1.2)(react@18.2.0))(@types/react@19.1.2)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(@types/react@19.1.2)(react@18.2.0)
       '@mui/material':
         specifier: ^7.3.1
-        version: 7.3.1(@emotion/react@11.14.0(@types/react@19.1.2)(react@19.1.0))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.1.2)(react@19.1.0))(@types/react@19.1.2)(react@19.1.0))(@types/react@19.1.2)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+        version: 7.3.1(@emotion/react@11.14.0(@types/react@19.1.2)(react@18.2.0))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.1.2)(react@18.2.0))(@types/react@19.1.2)(react@18.2.0))(@types/react@19.1.2)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       '@visx/axis':
         specifier: ^3.12.0
-        version: 3.12.0(react@19.1.0)
+        version: 3.12.0(react@18.2.0)
       '@visx/group':
         specifier: ^3.12.0
-        version: 3.12.0(react@19.1.0)
+        version: 3.12.0(react@18.2.0)
       '@visx/heatmap':
         specifier: ^3.12.0
-        version: 3.12.0(react@19.1.0)
+        version: 3.12.0(react@18.2.0)
       '@visx/scale':
         specifier: ^3.12.0
         version: 3.12.0
       '@visx/tooltip':
         specifier: ^3.12.0
-        version: 3.12.0(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+        version: 3.12.0(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       react:
-        specifier: ^19.0.0
-        version: 19.1.0
+        specifier: ^18.2.0
+        version: 18.2.0
       react-dom:
-        specifier: ^19.0.0
-        version: 19.1.0(react@19.1.0)
+        specifier: ^18.2.0
+        version: 18.2.0(react@18.2.0)
       react-router-dom:
         specifier: ^7.5.1
-        version: 7.8.0(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+        version: 7.8.0(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
     devDependencies:
       '@eslint/js':
         specifier: ^9.21.0
@@ -111,7 +111,7 @@ importers:
         version: 3.5.3
       recharts:
         specifier: ^3.3.0
-        version: 3.4.1(@types/react@19.1.2)(react-dom@19.1.0(react@19.1.0))(react-is@19.2.1)(react@19.1.0)(redux@5.0.1)
+        version: 3.4.1(@types/react@19.1.2)(react-dom@18.2.0(react@18.2.0))(react-is@19.2.1)(react@18.2.0)(redux@5.0.1)
       typescript:
         specifier: ~5.7.3
         version: 5.7.3
@@ -2156,6 +2156,11 @@ packages:
   queue-microtask@1.2.3:
     resolution: {integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==}
 
+  react-dom@18.2.0:
+    resolution: {integrity: sha512-6IMTriUmvsjHUjNtEDudZfuDQUoWXVxKHhlEGSk81n4YFS+r/Kl99wXiwlVXtPBtJenozv2P+hxDsw9eA7Xo6g==}
+    peerDependencies:
+      react: ^18.2.0
+
   react-dom@19.1.0:
     resolution: {integrity: sha512-Xs1hdnE+DyKgeHJeJznQmYMIBG3TKIHJJT95Q58nHLSrElKlGQqDTR2HQ9fx5CN/Gk6Vh/kupBTDLU11/nDk/g==}
     peerDependencies:
@@ -2217,6 +2222,10 @@ packages:
     peerDependenciesMeta:
       react-dom:
         optional: true
+
+  react@18.2.0:
+    resolution: {integrity: sha512-/3IjMdb2L9QbBdWiW5e3P2/npwMBaU9mHCSCUzNln0ZCYbcfTsGbTJrU/kGemdH2IWmB2ioZ+zkxtmq6g09fGQ==}
+    engines: {node: '>=0.10.0'}
 
   react@19.1.0:
     resolution: {integrity: sha512-FS+XFBNvn3GTAWq26joslQgWNoFu08F4kl0J4CgdNKADkdSGXQyTCnKteIAJy96Br6YbpEU1LSzV5dYtjMkMDg==}
@@ -2301,6 +2310,9 @@ packages:
   safe-regex-test@1.1.0:
     resolution: {integrity: sha512-x/+Cz4YrimQxQccJf5mKEbIa1NzeCRNI5Ecl/ekmlYaampdNLPalVyIcCZNNH3MvmqBugV5TMYZXv0ljslUlaw==}
     engines: {node: '>= 0.4'}
+
+  scheduler@0.23.2:
+    resolution: {integrity: sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==}
 
   scheduler@0.26.0:
     resolution: {integrity: sha512-NlHwttCI/l5gCPR3D1nNXtWABUmBwvZpEQiD4IXSbIDq8BzLIK/7Ir5gTFSGZDUu37K5cMNp0hFtzO38sC7gWA==}
@@ -2861,6 +2873,22 @@ snapshots:
 
   '@emotion/memoize@0.9.0': {}
 
+  '@emotion/react@11.14.0(@types/react@19.1.2)(react@18.2.0)':
+    dependencies:
+      '@babel/runtime': 7.28.3
+      '@emotion/babel-plugin': 11.13.5
+      '@emotion/cache': 11.14.0
+      '@emotion/serialize': 1.3.3
+      '@emotion/use-insertion-effect-with-fallbacks': 1.2.0(react@18.2.0)
+      '@emotion/utils': 1.4.2
+      '@emotion/weak-memoize': 0.4.0
+      hoist-non-react-statics: 3.3.2
+      react: 18.2.0
+    optionalDependencies:
+      '@types/react': 19.1.2
+    transitivePeerDependencies:
+      - supports-color
+
   '@emotion/react@11.14.0(@types/react@19.1.2)(react@19.1.0)':
     dependencies:
       '@babel/runtime': 7.28.3
@@ -2876,6 +2904,7 @@ snapshots:
       '@types/react': 19.1.2
     transitivePeerDependencies:
       - supports-color
+    optional: true
 
   '@emotion/serialize@1.3.3':
     dependencies:
@@ -2886,6 +2915,21 @@ snapshots:
       csstype: 3.1.3
 
   '@emotion/sheet@1.4.0': {}
+
+  '@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.1.2)(react@18.2.0))(@types/react@19.1.2)(react@18.2.0)':
+    dependencies:
+      '@babel/runtime': 7.28.3
+      '@emotion/babel-plugin': 11.13.5
+      '@emotion/is-prop-valid': 1.3.1
+      '@emotion/react': 11.14.0(@types/react@19.1.2)(react@18.2.0)
+      '@emotion/serialize': 1.3.3
+      '@emotion/use-insertion-effect-with-fallbacks': 1.2.0(react@18.2.0)
+      '@emotion/utils': 1.4.2
+      react: 18.2.0
+    optionalDependencies:
+      '@types/react': 19.1.2
+    transitivePeerDependencies:
+      - supports-color
 
   '@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.1.2)(react@19.1.0))(@types/react@19.1.2)(react@19.1.0)':
     dependencies:
@@ -2901,12 +2945,18 @@ snapshots:
       '@types/react': 19.1.2
     transitivePeerDependencies:
       - supports-color
+    optional: true
 
   '@emotion/unitless@0.10.0': {}
+
+  '@emotion/use-insertion-effect-with-fallbacks@1.2.0(react@18.2.0)':
+    dependencies:
+      react: 18.2.0
 
   '@emotion/use-insertion-effect-with-fallbacks@1.2.0(react@19.1.0)':
     dependencies:
       react: 19.1.0
+    optional: true
 
   '@emotion/utils@1.4.2': {}
 
@@ -3089,12 +3139,33 @@ snapshots:
 
   '@mui/core-downloads-tracker@7.3.1': {}
 
-  '@mui/icons-material@7.3.1(@mui/material@7.3.1(@emotion/react@11.14.0(@types/react@19.1.2)(react@19.1.0))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.1.2)(react@19.1.0))(@types/react@19.1.2)(react@19.1.0))(@types/react@19.1.2)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(@types/react@19.1.2)(react@19.1.0)':
+  '@mui/icons-material@7.3.1(@mui/material@7.3.1(@emotion/react@11.14.0(@types/react@19.1.2)(react@18.2.0))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.1.2)(react@18.2.0))(@types/react@19.1.2)(react@18.2.0))(@types/react@19.1.2)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(@types/react@19.1.2)(react@18.2.0)':
     dependencies:
       '@babel/runtime': 7.28.3
-      '@mui/material': 7.3.1(@emotion/react@11.14.0(@types/react@19.1.2)(react@19.1.0))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.1.2)(react@19.1.0))(@types/react@19.1.2)(react@19.1.0))(@types/react@19.1.2)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
-      react: 19.1.0
+      '@mui/material': 7.3.1(@emotion/react@11.14.0(@types/react@19.1.2)(react@18.2.0))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.1.2)(react@18.2.0))(@types/react@19.1.2)(react@18.2.0))(@types/react@19.1.2)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      react: 18.2.0
     optionalDependencies:
+      '@types/react': 19.1.2
+
+  '@mui/material@7.3.1(@emotion/react@11.14.0(@types/react@19.1.2)(react@18.2.0))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.1.2)(react@18.2.0))(@types/react@19.1.2)(react@18.2.0))(@types/react@19.1.2)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)':
+    dependencies:
+      '@babel/runtime': 7.28.3
+      '@mui/core-downloads-tracker': 7.3.1
+      '@mui/system': 7.3.1(@emotion/react@11.14.0(@types/react@19.1.2)(react@18.2.0))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.1.2)(react@18.2.0))(@types/react@19.1.2)(react@18.2.0))(@types/react@19.1.2)(react@18.2.0)
+      '@mui/types': 7.4.5(@types/react@19.1.2)
+      '@mui/utils': 7.3.1(@types/react@19.1.2)(react@18.2.0)
+      '@popperjs/core': 2.11.8
+      '@types/react-transition-group': 4.4.12(@types/react@19.1.2)
+      clsx: 2.1.1
+      csstype: 3.1.3
+      prop-types: 15.8.1
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
+      react-is: 19.1.1
+      react-transition-group: 4.4.5(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+    optionalDependencies:
+      '@emotion/react': 11.14.0(@types/react@19.1.2)(react@18.2.0)
+      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.1.2)(react@18.2.0))(@types/react@19.1.2)(react@18.2.0)
       '@types/react': 19.1.2
 
   '@mui/material@7.3.1(@emotion/react@11.14.0(@types/react@19.1.2)(react@19.1.0))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.1.2)(react@19.1.0))(@types/react@19.1.2)(react@19.1.0))(@types/react@19.1.2)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
@@ -3118,6 +3189,15 @@ snapshots:
       '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.1.2)(react@19.1.0))(@types/react@19.1.2)(react@19.1.0)
       '@types/react': 19.1.2
 
+  '@mui/private-theming@7.3.1(@types/react@19.1.2)(react@18.2.0)':
+    dependencies:
+      '@babel/runtime': 7.28.3
+      '@mui/utils': 7.3.1(@types/react@19.1.2)(react@18.2.0)
+      prop-types: 15.8.1
+      react: 18.2.0
+    optionalDependencies:
+      '@types/react': 19.1.2
+
   '@mui/private-theming@7.3.1(@types/react@19.1.2)(react@19.1.0)':
     dependencies:
       '@babel/runtime': 7.28.3
@@ -3126,6 +3206,19 @@ snapshots:
       react: 19.1.0
     optionalDependencies:
       '@types/react': 19.1.2
+
+  '@mui/styled-engine@7.3.1(@emotion/react@11.14.0(@types/react@19.1.2)(react@18.2.0))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.1.2)(react@18.2.0))(@types/react@19.1.2)(react@18.2.0))(react@18.2.0)':
+    dependencies:
+      '@babel/runtime': 7.28.3
+      '@emotion/cache': 11.14.0
+      '@emotion/serialize': 1.3.3
+      '@emotion/sheet': 1.4.0
+      csstype: 3.1.3
+      prop-types: 15.8.1
+      react: 18.2.0
+    optionalDependencies:
+      '@emotion/react': 11.14.0(@types/react@19.1.2)(react@18.2.0)
+      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.1.2)(react@18.2.0))(@types/react@19.1.2)(react@18.2.0)
 
   '@mui/styled-engine@7.3.1(@emotion/react@11.14.0(@types/react@19.1.2)(react@19.1.0))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.1.2)(react@19.1.0))(@types/react@19.1.2)(react@19.1.0))(react@19.1.0)':
     dependencies:
@@ -3139,6 +3232,22 @@ snapshots:
     optionalDependencies:
       '@emotion/react': 11.14.0(@types/react@19.1.2)(react@19.1.0)
       '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.1.2)(react@19.1.0))(@types/react@19.1.2)(react@19.1.0)
+
+  '@mui/system@7.3.1(@emotion/react@11.14.0(@types/react@19.1.2)(react@18.2.0))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.1.2)(react@18.2.0))(@types/react@19.1.2)(react@18.2.0))(@types/react@19.1.2)(react@18.2.0)':
+    dependencies:
+      '@babel/runtime': 7.28.3
+      '@mui/private-theming': 7.3.1(@types/react@19.1.2)(react@18.2.0)
+      '@mui/styled-engine': 7.3.1(@emotion/react@11.14.0(@types/react@19.1.2)(react@18.2.0))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.1.2)(react@18.2.0))(@types/react@19.1.2)(react@18.2.0))(react@18.2.0)
+      '@mui/types': 7.4.5(@types/react@19.1.2)
+      '@mui/utils': 7.3.1(@types/react@19.1.2)(react@18.2.0)
+      clsx: 2.1.1
+      csstype: 3.1.3
+      prop-types: 15.8.1
+      react: 18.2.0
+    optionalDependencies:
+      '@emotion/react': 11.14.0(@types/react@19.1.2)(react@18.2.0)
+      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.1.2)(react@18.2.0))(@types/react@19.1.2)(react@18.2.0)
+      '@types/react': 19.1.2
 
   '@mui/system@7.3.1(@emotion/react@11.14.0(@types/react@19.1.2)(react@19.1.0))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.1.2)(react@19.1.0))(@types/react@19.1.2)(react@19.1.0))(@types/react@19.1.2)(react@19.1.0)':
     dependencies:
@@ -3165,6 +3274,18 @@ snapshots:
   '@mui/types@7.4.9(@types/react@19.1.2)':
     dependencies:
       '@babel/runtime': 7.28.4
+    optionalDependencies:
+      '@types/react': 19.1.2
+
+  '@mui/utils@7.3.1(@types/react@19.1.2)(react@18.2.0)':
+    dependencies:
+      '@babel/runtime': 7.28.3
+      '@mui/types': 7.4.5(@types/react@19.1.2)
+      '@types/prop-types': 15.7.15
+      clsx: 2.1.1
+      prop-types: 15.8.1
+      react: 18.2.0
+      react-is: 19.1.1
     optionalDependencies:
       '@types/react': 19.1.2
 
@@ -3247,7 +3368,7 @@ snapshots:
 
   '@popperjs/core@2.11.8': {}
 
-  '@reduxjs/toolkit@2.10.1(react-redux@9.2.0(@types/react@19.1.2)(react@19.1.0)(redux@5.0.1))(react@19.1.0)':
+  '@reduxjs/toolkit@2.10.1(react-redux@9.2.0(@types/react@19.1.2)(react@18.2.0)(redux@5.0.1))(react@18.2.0)':
     dependencies:
       '@standard-schema/spec': 1.0.0
       '@standard-schema/utils': 0.3.0
@@ -3256,8 +3377,8 @@ snapshots:
       redux-thunk: 3.1.0(redux@5.0.1)
       reselect: 5.1.1
     optionalDependencies:
-      react: 19.1.0
-      react-redux: 9.2.0(@types/react@19.1.2)(react@19.1.0)(redux@5.0.1)
+      react: 18.2.0
+      react-redux: 9.2.0(@types/react@19.1.2)(react@18.2.0)(redux@5.0.1)
 
   '@rolldown/pluginutils@1.0.0-beta.47': {}
 
@@ -3511,45 +3632,45 @@ snapshots:
       '@typescript-eslint/types': 8.30.0
       eslint-visitor-keys: 4.2.0
 
-  '@visx/axis@3.12.0(react@19.1.0)':
+  '@visx/axis@3.12.0(react@18.2.0)':
     dependencies:
       '@types/react': 19.1.2
-      '@visx/group': 3.12.0(react@19.1.0)
+      '@visx/group': 3.12.0(react@18.2.0)
       '@visx/point': 3.12.0
       '@visx/scale': 3.12.0
-      '@visx/shape': 3.12.0(react@19.1.0)
-      '@visx/text': 3.12.0(react@19.1.0)
+      '@visx/shape': 3.12.0(react@18.2.0)
+      '@visx/text': 3.12.0(react@18.2.0)
       classnames: 2.5.1
       prop-types: 15.8.1
-      react: 19.1.0
+      react: 18.2.0
 
-  '@visx/bounds@3.12.0(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
+  '@visx/bounds@3.12.0(react-dom@18.2.0(react@18.2.0))(react@18.2.0)':
     dependencies:
       '@types/react': 19.1.2
       '@types/react-dom': 19.1.2(@types/react@19.1.2)
       prop-types: 15.8.1
-      react: 19.1.0
-      react-dom: 19.1.0(react@19.1.0)
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
 
   '@visx/curve@3.12.0':
     dependencies:
       '@types/d3-shape': 1.3.12
       d3-shape: 1.3.7
 
-  '@visx/group@3.12.0(react@19.1.0)':
+  '@visx/group@3.12.0(react@18.2.0)':
     dependencies:
       '@types/react': 19.1.2
       classnames: 2.5.1
       prop-types: 15.8.1
-      react: 19.1.0
+      react: 18.2.0
 
-  '@visx/heatmap@3.12.0(react@19.1.0)':
+  '@visx/heatmap@3.12.0(react@18.2.0)':
     dependencies:
       '@types/react': 19.1.2
-      '@visx/group': 3.12.0(react@19.1.0)
+      '@visx/group': 3.12.0(react@18.2.0)
       classnames: 2.5.1
       prop-types: 15.8.1
-      react: 19.1.0
+      react: 18.2.0
 
   '@visx/point@3.12.0': {}
 
@@ -3557,41 +3678,41 @@ snapshots:
     dependencies:
       '@visx/vendor': 3.12.0
 
-  '@visx/shape@3.12.0(react@19.1.0)':
+  '@visx/shape@3.12.0(react@18.2.0)':
     dependencies:
       '@types/d3-path': 1.0.11
       '@types/d3-shape': 1.3.12
       '@types/lodash': 4.17.21
       '@types/react': 19.1.2
       '@visx/curve': 3.12.0
-      '@visx/group': 3.12.0(react@19.1.0)
+      '@visx/group': 3.12.0(react@18.2.0)
       '@visx/scale': 3.12.0
       classnames: 2.5.1
       d3-path: 1.0.9
       d3-shape: 1.3.7
       lodash: 4.17.21
       prop-types: 15.8.1
-      react: 19.1.0
+      react: 18.2.0
 
-  '@visx/text@3.12.0(react@19.1.0)':
+  '@visx/text@3.12.0(react@18.2.0)':
     dependencies:
       '@types/lodash': 4.17.21
       '@types/react': 19.1.2
       classnames: 2.5.1
       lodash: 4.17.21
       prop-types: 15.8.1
-      react: 19.1.0
+      react: 18.2.0
       reduce-css-calc: 1.3.0
 
-  '@visx/tooltip@3.12.0(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
+  '@visx/tooltip@3.12.0(react-dom@18.2.0(react@18.2.0))(react@18.2.0)':
     dependencies:
       '@types/react': 19.1.2
-      '@visx/bounds': 3.12.0(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@visx/bounds': 3.12.0(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       classnames: 2.5.1
       prop-types: 15.8.1
-      react: 19.1.0
-      react-dom: 19.1.0(react@19.1.0)
-      react-use-measure: 2.1.7(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
+      react-use-measure: 2.1.7(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
 
   '@visx/vendor@3.12.0':
     dependencies:
@@ -4860,6 +4981,12 @@ snapshots:
 
   queue-microtask@1.2.3: {}
 
+  react-dom@18.2.0(react@18.2.0):
+    dependencies:
+      loose-envify: 1.4.0
+      react: 18.2.0
+      scheduler: 0.23.2
+
   react-dom@19.1.0(react@19.1.0):
     dependencies:
       react: 19.1.0
@@ -4871,30 +4998,39 @@ snapshots:
 
   react-is@19.2.1: {}
 
-  react-redux@9.2.0(@types/react@19.1.2)(react@19.1.0)(redux@5.0.1):
+  react-redux@9.2.0(@types/react@19.1.2)(react@18.2.0)(redux@5.0.1):
     dependencies:
       '@types/use-sync-external-store': 0.0.6
-      react: 19.1.0
-      use-sync-external-store: 1.5.0(react@19.1.0)
+      react: 18.2.0
+      use-sync-external-store: 1.5.0(react@18.2.0)
     optionalDependencies:
       '@types/react': 19.1.2
       redux: 5.0.1
 
   react-refresh@0.18.0: {}
 
-  react-router-dom@7.8.0(react-dom@19.1.0(react@19.1.0))(react@19.1.0):
+  react-router-dom@7.8.0(react-dom@18.2.0(react@18.2.0))(react@18.2.0):
     dependencies:
-      react: 19.1.0
-      react-dom: 19.1.0(react@19.1.0)
-      react-router: 7.8.0(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
+      react-router: 7.8.0(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
 
-  react-router@7.8.0(react-dom@19.1.0(react@19.1.0))(react@19.1.0):
+  react-router@7.8.0(react-dom@18.2.0(react@18.2.0))(react@18.2.0):
     dependencies:
       cookie: 1.0.2
-      react: 19.1.0
+      react: 18.2.0
       set-cookie-parser: 2.7.1
     optionalDependencies:
-      react-dom: 19.1.0(react@19.1.0)
+      react-dom: 18.2.0(react@18.2.0)
+
+  react-transition-group@4.4.5(react-dom@18.2.0(react@18.2.0))(react@18.2.0):
+    dependencies:
+      '@babel/runtime': 7.28.3
+      dom-helpers: 5.2.1
+      loose-envify: 1.4.0
+      prop-types: 15.8.1
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
 
   react-transition-group@4.4.5(react-dom@19.1.0(react@19.1.0))(react@19.1.0):
     dependencies:
@@ -4905,29 +5041,33 @@ snapshots:
       react: 19.1.0
       react-dom: 19.1.0(react@19.1.0)
 
-  react-use-measure@2.1.7(react-dom@19.1.0(react@19.1.0))(react@19.1.0):
+  react-use-measure@2.1.7(react-dom@18.2.0(react@18.2.0))(react@18.2.0):
     dependencies:
-      react: 19.1.0
+      react: 18.2.0
     optionalDependencies:
-      react-dom: 19.1.0(react@19.1.0)
+      react-dom: 18.2.0(react@18.2.0)
+
+  react@18.2.0:
+    dependencies:
+      loose-envify: 1.4.0
 
   react@19.1.0: {}
 
-  recharts@3.4.1(@types/react@19.1.2)(react-dom@19.1.0(react@19.1.0))(react-is@19.2.1)(react@19.1.0)(redux@5.0.1):
+  recharts@3.4.1(@types/react@19.1.2)(react-dom@18.2.0(react@18.2.0))(react-is@19.2.1)(react@18.2.0)(redux@5.0.1):
     dependencies:
-      '@reduxjs/toolkit': 2.10.1(react-redux@9.2.0(@types/react@19.1.2)(react@19.1.0)(redux@5.0.1))(react@19.1.0)
+      '@reduxjs/toolkit': 2.10.1(react-redux@9.2.0(@types/react@19.1.2)(react@18.2.0)(redux@5.0.1))(react@18.2.0)
       clsx: 2.1.1
       decimal.js-light: 2.5.1
       es-toolkit: 1.41.0
       eventemitter3: 5.0.1
       immer: 10.2.0
-      react: 19.1.0
-      react-dom: 19.1.0(react@19.1.0)
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
       react-is: 19.2.1
-      react-redux: 9.2.0(@types/react@19.1.2)(react@19.1.0)(redux@5.0.1)
+      react-redux: 9.2.0(@types/react@19.1.2)(react@18.2.0)(redux@5.0.1)
       reselect: 5.1.1
       tiny-invariant: 1.3.3
-      use-sync-external-store: 1.5.0(react@19.1.0)
+      use-sync-external-store: 1.5.0(react@18.2.0)
       victory-vendor: 37.3.6
     transitivePeerDependencies:
       - '@types/react'
@@ -5046,6 +5186,10 @@ snapshots:
       call-bound: 1.0.4
       es-errors: 1.3.0
       is-regex: 1.2.1
+
+  scheduler@0.23.2:
+    dependencies:
+      loose-envify: 1.4.0
 
   scheduler@0.26.0: {}
 
@@ -5325,9 +5469,9 @@ snapshots:
     dependencies:
       punycode: 2.3.1
 
-  use-sync-external-store@1.5.0(react@19.1.0):
+  use-sync-external-store@1.5.0(react@18.2.0):
     dependencies:
-      react: 19.1.0
+      react: 18.2.0
 
   use-sync-external-store@1.6.0(react@19.1.0):
     dependencies:


### PR DESCRIPTION
React 19 is not widely supported and conflicts with VisX. This dependency conflict causes deploy to fail in EB. This PR downgrades React to 18 to fix the deploys. We can upgrade later once 19 is more widely supported