### PR TITLE
docs: make them build pls

### DIFF
--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -143,7 +143,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v6
         with:
-          python-version: 3.12
+          python-version: 3.14
 
       - name: Install uv
         uses: astral-sh/setup-uv@v7

--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -143,7 +143,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v6
         with:
-          python-version: 3.13
+          python-version: 3.12
 
       - name: Install uv
         uses: astral-sh/setup-uv@v7

--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -143,7 +143,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v6
         with:
-          python-version: 3.14
+          python-version: 3.13
 
       - name: Install uv
         uses: astral-sh/setup-uv@v7

--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -143,6 +143,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v6
         with:
+          # use 3.12 for docs. currently, build fails on newer Python releases
           python-version: 3.12
 
       - name: Install uv

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -3,7 +3,7 @@ version: 2
 build:
   os: "ubuntu-20.04"
   tools:
-    python: "3.14"
+    python: "3.13"
 
 python:
   install:

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -3,7 +3,7 @@ version: 2
 build:
   os: "ubuntu-20.04"
   tools:
-    python: "3.13"
+    python: "3.12"
 
 python:
   install:

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -3,12 +3,12 @@ version: 2
 build:
   os: "ubuntu-20.04"
   tools:
-    python: "3.11"
+    python: "3.14"
 
 python:
   install:
     - method: pip
-      path: .
+      path: ./server
       extra_requirements:
         - docs
 

--- a/server/pyproject.toml
+++ b/server/pyproject.toml
@@ -85,7 +85,7 @@ docs = [
     "furo==2023.3.27",
     "sphinx-github-changelog==1.2.1",
     "sphinx-click==5.0.1",
-    "sphinxcontrib-images==0.9.4",
+    "sphinxcontrib-images==1.0.1",
 ]
 
 [project.urls]


### PR DESCRIPTION
Enable readthedocs deployment to the `latest` path, as well as pull requests. It looks like it's not entirely error-free right now but it builds: https://vicc-metakb--700.org.readthedocs.build/en/700/