### PR TITLE
fix(ci): add unknown fallback_version

### DIFF
--- a/server/pyproject.toml
+++ b/server/pyproject.toml
@@ -102,6 +102,9 @@ metakb = "metakb.cli:cli"
 requires = ["setuptools>=77.0"]
 build-backend = "setuptools.build_meta"
 
+[tool.setuptools_scm]
+fallback_version = "0.0.0+unknown"
+
 [tool.setuptools.packages.find]
 where = ["src"]
 


### PR DESCRIPTION
In cases where setuptools-scm cannot determine a version due to missing git metadata, set a default unknown fallback version so builds don't fail.