### PR TITLE
feat!: move classification methods out of shared space

### DIFF
--- a/server/src/metakb/transformers/base.py
+++ b/server/src/metakb/transformers/base.py
@@ -96,13 +96,6 @@ class EcoLevel(str, Enum):
     CLINICAL_STUDY_EVIDENCE = "ECO:0000180"
 
 
-class MethodId(str, Enum):
-    """Create method id constants"""
-
-    CIVIC_EID_SOP = "civic.method:2019"
-    MOA_ASSERTION_BIORXIV = "moa.method:2021"
-
-
 class CivicEvidenceLevel(str, Enum):
     """Define constraints for CIViC evidence levels"""
 
@@ -168,19 +161,6 @@ class TransformedData(BaseModel):
 class Transformer(ABC):
     """A base class for transforming harvester data."""
 
-    _methods: ClassVar[list[Method]] = [
-        Method(
-            id=MethodId.MOA_ASSERTION_BIORXIV,
-            name="MOAlmanac (2021)",
-            reportedIn=Document(
-                name="Reardon, B., Moore, N.D., Moore, N.S. et al.",
-                title="Integrating molecular profiles into clinical frameworks through the Molecular Oncology Almanac to prospectively guide precision oncology",
-                doi="10.1038/s43018-021-00243-3",
-                pmid="35121878",
-            ),
-        ),
-    ]
-    methods_mapping: ClassVar[dict[MethodId, Method]] = {m.id: m for m in _methods}
     _vicc_concept_vocabs: ClassVar[list[ViccConceptVocab]] = [
         ViccConceptVocab(
             id="vicc:e000000",

--- a/server/src/metakb/transformers/moa.py
+++ b/server/src/metakb/transformers/moa.py
@@ -85,6 +85,10 @@ class MoaTransformer(Transformer):
         return _MoaTransformedCache()
 
     def _create_method(self) -> Method:
+        """Get MOA classification method object for use in study statements
+
+        :return: MOA method
+        """
         return Method(
             id="moa.method:2021",
             name="MOAlmanac (2021)",

--- a/server/src/metakb/transformers/moa.py
+++ b/server/src/metakb/transformers/moa.py
@@ -22,6 +22,7 @@ from ga4gh.va_spec.base import (
     Direction,
     Document,
     MembershipOperator,
+    Method,
     PrognosticPredicate,
     Statement,
     TherapeuticResponsePredicate,
@@ -38,7 +39,6 @@ from metakb.normalizers import (
 )
 from metakb.schemas.app import SourceName
 from metakb.transformers.base import (
-    MethodId,
     MoaEvidenceLevel,
     Transformer,
     _sanitize_name,
@@ -78,15 +78,23 @@ class MoaTransformer(Transformer):
             data_dir=data_dir, harvester_path=harvester_path, normalizers=normalizers
         )
 
-        # Method will always be the same
-        self.processed_data.methods = [
-            self.methods_mapping[MethodId.MOA_ASSERTION_BIORXIV.value]
-        ]
         self._cache = self._create_cache()
 
     def _create_cache(self) -> _MoaTransformedCache:
         """Create cache for transformed records"""
         return _MoaTransformedCache()
+
+    def _create_method(self) -> Method:
+        return Method(
+            id="moa.method:2021",
+            name="MOAlmanac (2021)",
+            reportedIn=Document(
+                name="Reardon, B., Moore, N.D., Moore, N.S. et al.",
+                title="Integrating molecular profiles into clinical frameworks through the Molecular Oncology Almanac to prospectively guide precision oncology",
+                doi="10.1038/s43018-021-00243-3",
+                pmid="35121878",
+            ),
+        )
 
     async def transform(self, harvested_data: MoaHarvestedData) -> None:
         """Transform MOA harvested JSON to common data model. Will store transformed
@@ -163,7 +171,7 @@ class MoaTransformer(Transformer):
             "id": assertion_id,
             "description": assertion["description"],
             "strength": strength,
-            "specifiedBy": self.processed_data.methods[0],
+            "specifiedBy": self._create_method(),
             "reportedIn": [document],
         }
         prop_params = {


### PR DESCRIPTION
* technically a "feat!" but really just a refactor

Move Method (capital M) construction out of a shared base class space and into individual source classes. The CIViC transformer already does this since civicpy provides the method now, and the constructor function pattern used in the MOA class here will match up with how other parts of the GKS statement get built.