### PR TITLE
feat!: streamline caching

### DIFF
--- a/server/pyproject.toml
+++ b/server/pyproject.toml
@@ -46,7 +46,7 @@ dependencies = [
     "asyncclick",
     "jinja2",
     "pandas>=2.3.3, <3.0",
-    "tqdm",
+    "async-lru",
 ]
 
 [project.optional-dependencies]

--- a/server/pyproject.toml
+++ b/server/pyproject.toml
@@ -46,6 +46,7 @@ dependencies = [
     "asyncclick",
     "jinja2",
     "pandas>=2.3.3, <3.0",
+    "tqdm",
 ]
 
 [project.optional-dependencies]

--- a/server/src/metakb/normalizers.py
+++ b/server/src/metakb/normalizers.py
@@ -67,11 +67,11 @@ class ViccNormalizers:
         """Initialize normalizers. Construct a normalizer instance for each service
         (gene, variation, disease, therapy) and retain them as instance properties.
 
-        >>> from metakb.normalizers import ViccNormalizers
-        >>> norm = ViccNormalizers()
-
-        Note that gene concept lookups within the Variation Normalizer are resolved
-        using the Gene Normalizer instance, rather than creating a second sub-instance.
+        * Gene concept lookups within the Variation Normalizer are resolved using the
+          Gene Normalizer instance, rather than creating a second sub-instance.
+        * The normalizers are exposed interally as callback functions wrapped in an
+          ``lru_cache`` at initialization, so that a configurable cache size variable
+          can be passed to the caching wrapper
 
         :param db_url: optional definition of shared normalizer database. Because the
             same parameter is passed to each concept normalizer, this only works for

--- a/server/src/metakb/normalizers.py
+++ b/server/src/metakb/normalizers.py
@@ -1,10 +1,12 @@
 """Handle construction of and relay requests to VICC normalizer services."""
 
 import logging
-from collections.abc import Iterable
-from enum import Enum
+from collections.abc import Callable, Iterable
+from enum import StrEnum
+from functools import lru_cache
 from os import environ
 
+from async_lru import alru_cache
 from botocore.exceptions import TokenRetrievalError
 from disease.cli import update as update_disease_db
 from disease.database import create_db as create_disease_db
@@ -42,6 +44,9 @@ __all__ = [
 _logger = logging.getLogger(__name__)
 
 
+DEFAULT_CACHE_SIZE = 1024
+
+
 class ViccNormalizers:
     """Manage VICC concept normalization services.
 
@@ -56,7 +61,9 @@ class ViccNormalizers:
     more.
     """
 
-    def __init__(self, db_url: str | None = None) -> None:
+    def __init__(
+        self, db_url: str | None = None, cache_size: int | None = DEFAULT_CACHE_SIZE
+    ) -> None:
         """Initialize normalizers. Construct a normalizer instance for each service
         (gene, variation, disease, therapy) and retain them as instance properties.
 
@@ -66,23 +73,26 @@ class ViccNormalizers:
         Note that gene concept lookups within the Variation Normalizer are resolved
         using the Gene Normalizer instance, rather than creating a second sub-instance.
 
-        >>> id(norm.gene_query_handler) == id(
-        ...     norm.variation_normalizer.gnomad_vcf_to_protein_handler.gene_normalizer
-        ... )
-        True
-
         :param db_url: optional definition of shared normalizer database. Because the
             same parameter is passed to each concept normalizer, this only works for
             connecting a DynamoDB backend. If not given, each normalizer falls back
             on default behavior for connecting to a database, which includes checking
             their corresponding environment variables.
+        :param cache_size: size of LRU cache used for each normalizer. Use ``None`` to
+            use an unbounded cache (ie no max size).
         """
-        self.gene_query_handler = GeneQueryHandler(create_gene_db(db_url))
-        self.variation_normalizer = VariationQueryHandler(
-            gene_query_handler=self.gene_query_handler
+        gene_query_handler = GeneQueryHandler(create_gene_db(db_url))
+        self._normalize_gene = lru_cache(cache_size)(gene_query_handler.normalize)
+        disease_query_handler = DiseaseQueryHandler(create_disease_db(db_url))
+        self._normalize_disease = lru_cache(cache_size)(disease_query_handler.normalize)
+        therapy_query_handler = TherapyQueryHandler(create_therapy_db(db_url))
+        self._normalize_therapy = lru_cache(cache_size)(therapy_query_handler.normalize)
+        variation_query_handler = VariationQueryHandler(
+            gene_query_handler=gene_query_handler
         )
-        self.disease_query_handler = DiseaseQueryHandler(create_disease_db(db_url))
-        self.therapy_query_handler = TherapyQueryHandler(create_therapy_db(db_url))
+        self._normalize_variation = alru_cache(cache_size)(
+            variation_query_handler.normalize_handler.normalize
+        )
 
     async def normalize_variation(
         self, query: str
@@ -94,9 +104,7 @@ class ViccNormalizers:
         :return: A normalized variation, if available.
         """
         try:
-            variation_norm_resp = (
-                await self.variation_normalizer.normalize_handler.normalize(query)
-            )
+            variation_norm_resp = await self._normalize_variation(query)
             if variation_norm_resp and variation_norm_resp.variation:
                 return variation_norm_resp.variation
         except TokenRetrievalError:
@@ -120,13 +128,10 @@ class ViccNormalizers:
         :raises TokenRetrievalError: If AWS credentials are expired
         :return: Gene normalization response and normalized gene ID, if available.
         """
-        return self._normalize_concept(query, self.gene_query_handler, "gene")
+        return self._normalize_concept(query, self._normalize_gene, "gene")
 
     def normalize_disease(self, query: str) -> tuple[NormalizedDisease, str | None]:
         """Attempt to normalize a disease query
-
-        Given a collection of terms, return the normalized concept with the highest
-        match.
 
         >>> from metakb.normalizers import ViccNormalizers
         >>> v = ViccNormalizers()
@@ -137,7 +142,7 @@ class ViccNormalizers:
         :raises TokenRetrievalError: If AWS credentials are expired
         :return: Disease normalization response and normalized disease ID, if available.
         """
-        return self._normalize_concept(query, self.disease_query_handler, "disease")
+        return self._normalize_concept(query, self._normalize_disease, "disease")
 
     def normalize_therapy(self, query: str) -> tuple[NormalizedTherapy, str | None]:
         """Attempt to normalize a therapy query
@@ -151,7 +156,7 @@ class ViccNormalizers:
         :raises TokenRetrievalError: If AWS credentials are expired
         :return: Therapy normalization response and normalized therapy ID, if available.
         """
-        return self._normalize_concept(query, self.therapy_query_handler, "therapy")
+        return self._normalize_concept(query, self._normalize_therapy, "therapy")
 
     @staticmethod
     def get_regulatory_approval_extension(
@@ -221,7 +226,7 @@ class ViccNormalizers:
     @staticmethod
     def _normalize_concept(
         query: str,
-        query_handler: GeneQueryHandler | DiseaseQueryHandler | TherapyQueryHandler,
+        normalizer_callback: Callable,
         concept_name: str,
     ) -> tuple[NormalizedGene | NormalizedDisease | NormalizedTherapy, str | None]:
         """Attempt to normalize a concept
@@ -236,7 +241,7 @@ class ViccNormalizers:
         normalized_id = None
 
         try:
-            normalizer_resp = query_handler.normalize(query)
+            normalizer_resp = normalizer_callback(query)
         except TokenRetrievalError:
             raise
         except Exception:
@@ -254,7 +259,7 @@ class ViccNormalizers:
         return normalizer_resp, normalized_id
 
 
-class NormalizerName(str, Enum):
+class NormalizerName(StrEnum):
     """Constrain normalizer CLI options."""
 
     GENE = "gene"

--- a/server/src/metakb/transformers/base.py
+++ b/server/src/metakb/transformers/base.py
@@ -7,7 +7,7 @@ import re
 from abc import ABC, abstractmethod
 from enum import Enum
 from pathlib import Path
-from typing import ClassVar, TypeVar
+from typing import ClassVar
 
 from disease.schemas import NamespacePrefix as DiseaseNamespacePrefix
 from disease.schemas import NormalizationService as NormalizedDisease

--- a/server/src/metakb/transformers/base.py
+++ b/server/src/metakb/transformers/base.py
@@ -9,12 +9,8 @@ from enum import Enum
 from pathlib import Path
 from typing import ClassVar, TypeVar
 
-from disease.schemas import (
-    NamespacePrefix as DiseaseNamespacePrefix,
-)
-from disease.schemas import (
-    NormalizationService as NormalizedDisease,
-)
+from disease.schemas import NamespacePrefix as DiseaseNamespacePrefix
+from disease.schemas import NormalizationService as NormalizedDisease
 from ga4gh.cat_vrs.models import CategoricalVariant
 from ga4gh.cat_vrs.recipes import ProteinSequenceConsequence
 from ga4gh.core import sha512t24u
@@ -39,26 +35,16 @@ from ga4gh.va_spec.base import (
     TherapyGroup,
 )
 from ga4gh.vrs.models import Allele
-from gene.schemas import (
-    NamespacePrefix as GeneNamespacePrefix,
-)
-from gene.schemas import (
-    NormalizeService as NormalizedGene,
-)
+from gene.schemas import NamespacePrefix as GeneNamespacePrefix
+from gene.schemas import NormalizeService as NormalizedGene
 from pydantic import BaseModel, Field, StrictStr
-from therapy.schemas import (
-    NamespacePrefix as TherapyNamespacePrefix,
-)
-from therapy.schemas import (
-    NormalizationService as NormalizedTherapy,
-)
+from therapy.schemas import NamespacePrefix as TherapyNamespacePrefix
+from therapy.schemas import NormalizationService as NormalizedTherapy
 
 from metakb import DATE_FMT
 from metakb.config import get_config
 from metakb.harvesters.base import _HarvestedData
-from metakb.normalizers import (
-    ViccNormalizers,
-)
+from metakb.normalizers import ViccNormalizers
 
 logger = logging.getLogger(__name__)
 
@@ -68,8 +54,6 @@ NORMALIZER_INSTANCE_TO_ATTR = {
     NormalizedTherapy: "therapy",
     NormalizedGene: "gene",
 }
-
-_CacheType = TypeVar("_CacheType", bound="_TransformedRecordsCache")
 
 
 def _sanitize_name(name: str) -> str:
@@ -133,14 +117,6 @@ class ViccConceptVocab(BaseModel):
     parents: list[StrictStr] = []
     exact_mappings: set[CivicEvidenceLevel | MoaEvidenceLevel | EcoLevel] = set()
     definition: StrictStr
-
-
-class _TransformedRecordsCache(BaseModel):
-    """Define model for caching transformed records"""
-
-    therapies: ClassVar[dict[str, MappableConcept]] = {}
-    conditions: ClassVar[dict[str, MappableConcept]] = {}
-    genes: ClassVar[dict[str, MappableConcept]] = {}
 
 
 class TransformedData(BaseModel):
@@ -285,7 +261,6 @@ class Transformer(ABC):
         :param harvester_path: Path to previously harvested data
         :param normalizers: normalizer collection instance
         """
-        self._cache = self._create_cache()
         self.name = self.__class__.__name__.lower().split("transformer")[0]
         if data_dir:
             self.data_dir = data_dir
@@ -306,10 +281,6 @@ class Transformer(ABC):
 
         :param harvested_data: Source harvested data
         """
-
-    @abstractmethod
-    def _create_cache() -> _CacheType:
-        """Create cache for transformed records"""
 
     def extract_harvested_data(self) -> _HarvestedData:
         """Get harvested data from file.

--- a/server/src/metakb/transformers/civic.py
+++ b/server/src/metakb/transformers/civic.py
@@ -19,16 +19,9 @@ from civicpy.exports.civic_gks_record import (
     CivicGksTherapyGroup,
     create_gks_record_from_assertion,
 )
-from ga4gh.cat_vrs.models import (
-    CategoricalVariant,
-    Constraint,
-    Relation,
-)
+from ga4gh.cat_vrs.models import CategoricalVariant, Constraint, Relation
 from ga4gh.cat_vrs.recipes import ProteinSequenceConsequence, SystemUri
-from ga4gh.core.models import (
-    Coding,
-    MappableConcept,
-)
+from ga4gh.core.models import Coding, MappableConcept
 from ga4gh.va_spec.base import (
     Condition,
     ConditionSet,
@@ -43,13 +36,8 @@ from ga4gh.vrs.models import Allele, Expression, Syntax, Variation
 from pydantic.dataclasses import dataclass
 from tqdm import tqdm
 
-from metakb.normalizers import (
-    ViccNormalizers,
-)
-from metakb.transformers.base import (
-    Transformer,
-    _TransformedRecordsCache,
-)
+from metakb.normalizers import ViccNormalizers
+from metakb.transformers.base import Transformer
 
 _logger = logging.getLogger(__name__)
 
@@ -141,20 +129,6 @@ class MolecularProfileNameComponents:
     c_change: str | None
 
 
-class _CivicTransformedCache(_TransformedRecordsCache):
-    """Create model for caching CIViC data"""
-
-    categorical_variants: ClassVar[
-        dict[str, CategoricalVariant | ProteinSequenceConsequence]
-    ] = {}
-    evidence: ClassVar[
-        dict[
-            str,
-            Statement,
-        ]
-    ] = {}
-
-
 class CivicTransformer(Transformer):
     """A class for transforming CIViC to the common data model."""
 
@@ -174,7 +148,6 @@ class CivicTransformer(Transformer):
             data_dir=data_dir, harvester_path=harvester_path, normalizers=normalizers
         )
 
-        self._cache = self._create_cache()
         self._concept_norm_method = MappingProxyType(
             {
                 ConceptType.DISEASE: self.vicc_normalizers.normalize_disease,
@@ -186,8 +159,7 @@ class CivicTransformer(Transformer):
     async def transform(self) -> None:
         """Normalize CIViC evidence items and assertions and add annotations
 
-        Updated records will store results in ``processed_data`` and ``_cache`` instance
-        variables.
+        Updated records will store results in ``processed_data`` variables.
         """
         accepted_evidence_items = civicpy.get_all_evidence(include_status=["accepted"])
         accepted_assertions = civicpy.get_all_assertions(include_status=["accepted"])
@@ -203,17 +175,12 @@ class CivicTransformer(Transformer):
 
         pbar.close()
 
-    def _create_cache(self) -> _CivicTransformedCache:
-        """Create cache for transformed records"""
-        return _CivicTransformedCache()
-
     async def _annotate_evidence(
         self, evidence_item: civicpy.Evidence | CivicGksEvidence
     ) -> Statement | None:
         """Annotate evidence with additional information, such as normalizer info
 
-        Annotated evidence will be added to the ``processed_data.statements_evidence``
-        and ``_cache.evidence`` instance variables.
+        Annotated evidence will be added to ``processed_data.statements_evidence``
 
         :param evidence_item: CIViC evidence item
         :return: Statement for CIViC evidence item, if able to annotate
@@ -245,7 +212,6 @@ class CivicTransformer(Transformer):
             **gks_evidence_item.model_dump(exclude_none=True, exclude={"proposition"}),
             proposition=updated_proposition,
         )
-        self._cache.evidence[gks_evidence_item.id] = annotated_gks_evidence_item
         self.processed_data.statements_evidence.append(annotated_gks_evidence_item)
         return annotated_gks_evidence_item
 
@@ -262,17 +228,12 @@ class CivicTransformer(Transformer):
         async def _resolve_evidence(
             ev: CivicGksEvidence, assertion_id: str
         ) -> Statement | None:
-            """Get annotated evidence from cache or create annotated evidence
-            (and add to cache)
+            """Create annotated evidence
 
             :param ev: CIViC GKS evidence item
             :param assertion_id: ID of assertion that ``ev`` belongs to
             :return: Annotated evidence, if able to resolve
             """
-            cached_evidence = self._cache.evidence.get(ev.id)
-            if cached_evidence:
-                return cached_evidence
-
             annotated_evidence = await self._annotate_evidence(ev)
             if not annotated_evidence:
                 _logger.warning(
@@ -327,25 +288,21 @@ class CivicTransformer(Transformer):
         :param proposition: Proposition for a given statement
         :return: Annotated proposition
         """
-
-        async def _add_therapy(therapy: CivicGksTherapy) -> MappableConcept:
-            """Create or get therapy given CIViC therapy.
-            First looks in cache for existing therapy, if not found will attempt to
-            transform. Will add CIViC therapy ID to ``processed_data.therapies`` and
-            ``_cache.therapies``
-
-            :param therapy: CIViC Therapy object
-            :return: Therapy represented as mappable concept
-            """
-            return await self._resolve_entity(
-                therapy,
-                self._cache.therapies,
-                self.processed_data.therapies,
-            )
+        # async def _add_therapy(therapy: CivicGksTherapy) -> MappableConcept:
+        #     """Create or get therapy given CIViC therapy.
+        #
+        #     Will add CIViC therapy ID to ``processed_data.therapies``
+        #
+        #     :param therapy: CIViC Therapy object
+        #     :return: Therapy represented as mappable concept
+        #     """
+        #     return await self._resolve_entity(
+        #         therapy,
+        #         self.processed_data.therapies,
+        #     )
 
         updated_molecular_profile = await self._resolve_entity(
             proposition.subjectVariant,
-            self._cache.categorical_variants,
             self.processed_data.categorical_variants,
         )
 
@@ -360,14 +317,12 @@ class CivicTransformer(Transformer):
         else:
             updated_condition = await self._resolve_entity(
                 condition.root,
-                self._cache.conditions,
                 self.processed_data.conditions,
             )
         updated_condition = Condition(root=updated_condition)
 
         updated_gene = await self._resolve_entity(
             proposition.geneContextQualifier,
-            self._cache.genes,
             self.processed_data.genes,
         )
 
@@ -383,7 +338,11 @@ class CivicTransformer(Transformer):
                 therapies = []
                 for therapy_member in therapeutic.root.therapies:
                     therapy_member_ids.append(therapy_member.id)
-                    therapies.append(await _add_therapy(therapy_member))
+                    therapies.append(
+                        await self._resolve_entity(
+                            therapeutic, self.processed_data.therapies
+                        )
+                    )
 
                 updated_therapeutic = TherapyGroup(
                     **therapeutic.model_dump(exclude_none=True, exclude={"therapies"}),
@@ -394,7 +353,9 @@ class CivicTransformer(Transformer):
                     self.processed_data.therapy_groups.append(updated_therapeutic)
 
             else:
-                updated_therapeutic = await _add_therapy(therapeutic.root)
+                updated_therapeutic = await self._resolve_entity(
+                    therapeutic, self.processed_data.therapies
+                )
 
             updated_mappings["objectTherapeutic"] = updated_therapeutic
 
@@ -426,24 +387,17 @@ class CivicTransformer(Transformer):
         | CivicGksPhenotype
         | CivicGksGene
         | CivicGksMolecularProfile,
-        cache: dict,
         processed_list: list,
     ) -> CategoricalVariant | ProteinSequenceConsequence | MappableConcept:
-        """Get annotated entity from cache or create annotated entity
+        """Create annotated entity
 
-        Annotated entity will be added to the ``processed_list`` and ``cache``
+        Annotated entity will be added to the ``processed_list``
 
-        :param entity: The entity to annotate with the VICC normalizers
-            If entity is CivicGksPhenotype, will not attempt to annotate
-        :param cache: Concept cache
+        :param entity: The entity to annotate with the VICC normalizers. If entity is
+            CivicGksPhenotype, will not attempt to annotate
         :param processed_list: List of processed data
         :return: Annotated entity
         """
-        entityt_id = entity.id
-        entity_obj = cache.get(entityt_id)
-        if entity_obj:
-            return entity_obj
-
         if isinstance(entity, CivicGksMolecularProfile):
             annotated_entity = await self._get_annotated_mp(entity)
         elif isinstance(entity, CivicGksDisease | CivicGksGene | CivicGksTherapy):
@@ -454,15 +408,13 @@ class CivicTransformer(Transformer):
         if inspect.isawaitable(annotated_entity):
             annotated_entity = await annotated_entity
 
-        cache[entityt_id] = annotated_entity
         processed_list.append(annotated_entity)
         return annotated_entity
 
     async def _resolve_condition_set(self, condition_set: ConditionSet) -> ConditionSet:
         """Get annotated condition set
 
-        Conditions will be added to the ``processed_data.conditions`` and
-        ``_cache.conditions``
+        Conditions will be added to ``processed_data.conditions``
 
         :param condition_set: Condition set
         :return: Annotated condition set
@@ -475,7 +427,6 @@ class CivicTransformer(Transformer):
                 updated_conditions.append(
                     await self._resolve_entity(
                         condition,
-                        self._cache.conditions,
                         self.processed_data.conditions,
                     )
                 )

--- a/server/src/metakb/transformers/civic.py
+++ b/server/src/metakb/transformers/civic.py
@@ -326,7 +326,7 @@ class CivicTransformer(Transformer):
                     therapy_member_ids.append(therapy_member.id)
                     therapies.append(
                         await self._resolve_entity(
-                            therapeutic, self.processed_data.therapies
+                            therapy_member, self.processed_data.therapies
                         )
                     )
 

--- a/server/src/metakb/transformers/civic.py
+++ b/server/src/metakb/transformers/civic.py
@@ -6,7 +6,6 @@ import re
 from enum import Enum, StrEnum
 from pathlib import Path
 from types import MappingProxyType
-from typing import ClassVar
 
 from civicpy import civic as civicpy
 from civicpy.exports.civic_gks_record import (
@@ -288,19 +287,6 @@ class CivicTransformer(Transformer):
         :param proposition: Proposition for a given statement
         :return: Annotated proposition
         """
-        # async def _add_therapy(therapy: CivicGksTherapy) -> MappableConcept:
-        #     """Create or get therapy given CIViC therapy.
-        #
-        #     Will add CIViC therapy ID to ``processed_data.therapies``
-        #
-        #     :param therapy: CIViC Therapy object
-        #     :return: Therapy represented as mappable concept
-        #     """
-        #     return await self._resolve_entity(
-        #         therapy,
-        #         self.processed_data.therapies,
-        #     )
-
         updated_molecular_profile = await self._resolve_entity(
             proposition.subjectVariant,
             self.processed_data.categorical_variants,

--- a/server/src/metakb/transformers/civic.py
+++ b/server/src/metakb/transformers/civic.py
@@ -41,6 +41,7 @@ from ga4gh.va_spec.base import (
 )
 from ga4gh.vrs.models import Allele, Expression, Syntax, Variation
 from pydantic.dataclasses import dataclass
+from tqdm import tqdm
 
 from metakb.normalizers import (
     ViccNormalizers,
@@ -189,12 +190,18 @@ class CivicTransformer(Transformer):
         variables.
         """
         accepted_evidence_items = civicpy.get_all_evidence(include_status=["accepted"])
-        for evidence_item in accepted_evidence_items:
-            await self._annotate_evidence(evidence_item)
-
         accepted_assertions = civicpy.get_all_assertions(include_status=["accepted"])
-        for assertion in accepted_assertions:
-            await self._annotate_assertion(assertion)
+        pbar = tqdm(
+            total=len(accepted_evidence_items) + len(accepted_assertions),
+        )
+        for item in accepted_evidence_items:
+            await self._annotate_evidence(item)
+            pbar.update(1)
+        for item in accepted_assertions:
+            await self._annotate_assertion(item)
+            pbar.update(1)
+
+        pbar.close()
 
     def _create_cache(self) -> _CivicTransformedCache:
         """Create cache for transformed records"""

--- a/server/src/metakb/transformers/moa.py
+++ b/server/src/metakb/transformers/moa.py
@@ -1,6 +1,5 @@
 """A module to convert MOA resources to common data model"""
 
-import json
 import logging
 from pathlib import Path
 
@@ -9,7 +8,6 @@ from ga4gh.cat_vrs.models import (
     DefiningAlleleConstraint,
     FeatureContextConstraint,
 )
-from ga4gh.core import sha512t24u
 from ga4gh.core.models import (
     Coding,
     ConceptMapping,
@@ -44,17 +42,6 @@ from metakb.transformers.base import (
 )
 
 _logger = logging.getLogger(__name__)
-
-
-# class _MoaTransformedCache(_TransformedRecordsCache):
-#     """Create model for caching MOA data"""
-#
-#     variations: ClassVar[dict[str, dict]] = {}
-#     documents: ClassVar[dict[str, Document]] = {}
-#     normalized_therapies: ClassVar[
-#         dict[str, MappableConcept]
-#     ] = {}  # normalized_id: therapy
-#     therapy_groups: ClassVar[dict[str, TherapyGroup]] = {}
 
 
 class MoaTransformer(Transformer):
@@ -93,7 +80,7 @@ class MoaTransformer(Transformer):
         docs_map = {}
         for source in harvested_data.sources:
             source_doc = self._create_document(source)
-            docs_map[source_doc.id] = source_doc
+            docs_map[source["id"]] = source_doc
             pbar.update(1)
 
         # Add variant therapeutic response study statement data. Will update `statements`
@@ -113,7 +100,6 @@ class MoaTransformer(Transformer):
         :param docs_map:
         """
         assertion_id = f"moa.assertion:{assertion['id']}"
-        variant = await self._create_categorical_variant(assertion["variant"])
 
         # Get strength
         predictive_implication = (
@@ -132,8 +118,13 @@ class MoaTransformer(Transformer):
             mappings=self.evidence_level_to_vicc_concept_mapping[evidence_level],
         )
 
+        # Add variant
+        variant = await self._create_categorical_variant(assertion["variant"])
+        if not variant:
+            return
+
         # Add disease
-        moa_disease = self._add_disease(assertion["disease"])
+        moa_disease = self._create_disease(assertion["disease"])
         if not moa_disease:
             _logger.debug(
                 "%s has no disease for disease %s", assertion_id, assertion["disease"]
@@ -172,7 +163,7 @@ class MoaTransformer(Transformer):
         }
 
         if assertion["favorable_prognosis"] == "":  # can be either 0, 1, or ""
-            prop_params["objectTherapeutic"] = self._get_therapy_or_group(assertion)
+            prop_params["objectTherapeutic"] = self._create_therapeutic(assertion)
 
             if not prop_params["objectTherapeutic"]:
                 _logger.debug(
@@ -216,16 +207,19 @@ class MoaTransformer(Transformer):
             stmt_params["proposition"] = VariantPrognosticProposition(**prop_params)
         self.processed_data.statements_evidence.append(Statement(**stmt_params))
 
-    async def _create_categorical_variant(self, variant: dict) -> None:
+    async def _create_categorical_variant(
+        self, variant: dict
+    ) -> CategoricalVariant | None:
         """Create Categorical Variant object for MOA variant record
 
         Mutates instance variable ``processed_data.variations``
 
         :param variant: variants in MOAlmanac
+        :return:
         """
         if variant.get("gene2"):
             # Do not support gene fusions for now
-            return
+            return None
 
         variant_id = variant["id"]
         moa_variant_id = f"moa.variant:{variant_id}"
@@ -366,6 +360,7 @@ class MoaTransformer(Transformer):
         )
 
         self.processed_data.categorical_variants.append(cv)
+        return cv
 
     async def _get_variation_members(
         self, moa_rep_coord: dict
@@ -414,7 +409,7 @@ class MoaTransformer(Transformer):
     def _create_gene(self, gene: str) -> MappableConcept:
         """Create gene object for MOA gene record
 
-        Mutates instance variables ``_cache['genes']`` and ``processed_data.genes``
+        Mutates instance variable ``processed_data.genes``
 
         :param gene: gene from MOAlmanac
         :return:
@@ -460,7 +455,7 @@ class MoaTransformer(Transformer):
         self.processed_data.documents.append(document)
         return document
 
-    def _get_therapy_or_group(
+    def _create_therapeutic(
         self, assertion: dict
     ) -> MappableConcept | TherapyGroup | None:
         """Get therapy mappable concept (single) or therapy group (multiple)
@@ -506,65 +501,6 @@ class MoaTransformer(Transformer):
             therapy_type,
         )
 
-    def _resolve_concept_discrepancy(
-        self,
-        cached_id: str,
-        cached_obj: MappableConcept,
-        cached_label: str,
-        moa_concept_label: str,
-        is_disease: bool = False,
-    ) -> None:
-        """Resolve conflict where MOA disease or therapy resolve to same normalized
-        concept
-
-        The min name will be used as the primary name for the mappable concept, and
-        the other name will be added as an alias in extensions.
-        The cache will be updated with updated object.
-        The cached object will be removed from ``self.processed_data``
-
-        :param cached_id: ID found in cache
-        :param cached_obj: Mappable concept found in cache for ``cached_id``. This will
-            be mutated
-        :param cached_label: Label for ``cached_obj``
-        :param moa_concept_label: MOA concept name
-        :param is_disease: ``True`` if ``cached_obj`` is a disease. ``False`` if
-            ``cached_obj`` is a therapy
-        """
-        _logger.debug(
-            "MOA %s and %s resolve to same concept %s",
-            moa_concept_label,
-            cached_label,
-            cached_id,
-        )
-        alias = max(moa_concept_label, cached_label)
-        cached_obj.name = min(moa_concept_label, cached_label)
-        extensions = cached_obj.extensions or []
-
-        aliases_ext = next(
-            (ext for ext in extensions if ext.name == "aliases"),
-            None,
-        )
-        if aliases_ext:
-            if cached_obj.name in aliases_ext.value:
-                aliases_ext.value.remove(cached_obj.name)
-            aliases_ext.value.append(alias)
-        else:
-            extensions.append(Extension(name="aliases", value=[alias]))
-            cached_obj.extensions = extensions
-
-        if is_disease:
-            self.processed_data.conditions = [
-                c for c in self.processed_data.conditions if c.id != cached_obj.id
-            ]
-            cache = self._cache.conditions
-        else:
-            self.processed_data.therapies = [
-                t for t in self.processed_data.therapies if t.id != cached_id
-            ]
-            cache = self._cache.normalized_therapies
-
-        cache[cached_id] = cached_obj
-
     def _add_therapy(
         self,
         therapy_id: str,
@@ -572,9 +508,9 @@ class MoaTransformer(Transformer):
         membership_operator: MembershipOperator | None,
         therapy_type: str | None = None,
     ) -> MappableConcept | None:
-        """Create or get therapy mappable concept given therapies
-        First look in ``_cache`` for existing therapy, if not found will attempt to
-        transform. Will add ``therapy_id`` to ``therapies`` and ``_cache.therapies``
+        """Create therapy mappable concept given therapies
+
+        Will add ``therapy_id`` to ``therapies``
 
         :param therapy_id: ID for therapy
         :param therapies: List of therapy objects. If `membership_operator` is `None`,
@@ -583,21 +519,13 @@ class MoaTransformer(Transformer):
         :param therapy_type: Therapy type
         :return: Therapy mappable concept, if ``therapy_type`` is supported
         """
-        therapy = self._cache.therapies.get(
-            therapy_id
-        ) or self._cache.therapy_groups.get(therapy_id)
-        if therapy:
-            return therapy
-
         if membership_operator is None:
             therapy = self._get_therapy(therapy_id, therapies[0])
-            self._cache.therapies[therapy_id] = therapy
             self.processed_data.therapies.append(therapy)
         elif membership_operator == MembershipOperator.AND:
             therapy = self._get_combination_therapy(
                 therapy_id, therapies, therapy_type=therapy_type
             )
-            self._cache.therapy_groups[therapy_id] = therapy
             self.processed_data.therapy_groups.append(therapy)
         else:
             _logger.debug(
@@ -664,34 +592,6 @@ class MoaTransformer(Transformer):
         :param therapy: MOA therapy name
         :return: Therapy represented as a mappable concept
         """
-
-        def _resolve_therapy_discrepancy(
-            cached_id: str, moa_concept_label: str
-        ) -> MappableConcept:
-            """Resolve conflict where MOA therapy labels resolve to the same normalized
-            concept
-
-            If conflict occurs, the min name will be used as the primary name for the
-            mappable concept, and the other name will be added as an alias in
-            extensions. The cache will be updated.
-
-            :param cached_id: Cached ID for therapy concept that is in
-                ``self._cache.normalized_therapies``
-            :param moa_concept_label: MOA provided name for therapy concept
-            :return: Therapy represented as a mappable concept
-            """
-            therapy_norm_obj = self._cache.normalized_therapies[cached_id]
-            og_therapy_norm_label = therapy_norm_obj.name
-            if moa_concept_label != og_therapy_norm_label:
-                self._resolve_concept_discrepancy(
-                    cached_id,
-                    therapy_norm_obj,
-                    og_therapy_norm_label,
-                    moa_concept_label,
-                    is_disease=False,
-                )
-            return therapy_norm_obj
-
         mappings = []
         extensions = []
         name = therapy["name"]
@@ -708,9 +608,6 @@ class MoaTransformer(Transformer):
         else:
             id_ = f"moa.{therapy_norm_resp.therapy.id}"
 
-            if id_ in self._cache.normalized_therapies:
-                return _resolve_therapy_discrepancy(id_, name)
-
             regulatory_approval_extension = (
                 self.vicc_normalizers.get_regulatory_approval_extension(
                     therapy_norm_resp
@@ -726,68 +623,22 @@ class MoaTransformer(Transformer):
                 )
             )
 
-        therapy_concept = MappableConcept(
+        return MappableConcept(
             id=id_,
             conceptType="Therapy",
             name=name,
             mappings=mappings or None,
             extensions=extensions or None,
         )
-        self._cache.normalized_therapies[id_] = therapy_concept
-        return therapy_concept
 
-    def _add_disease(self, disease: dict) -> MappableConcept | None:
+    def _create_disease(self, disease: dict) -> MappableConcept | None:
         """Create or get disease given MOA disease.
-
-        First looks in cache for existing disease, if not found will attempt to
-        transform. Will generate a digest from the original MOA disease object oncotree
-        fields. This will be used as the key in the caches. Will add the generated
-        digest to ``processed_data.conditions`` and ``_cache['conditions']``.
 
         Since there may be duplicate Oncotree code/terms with different names, the first
         name will be used as the Disease name. Others will be added to the extensions
         aliases field.
 
         :param disease: MOA disease object
-        :return: Disease represented as a mappable concept
-        """
-        if not all(value for value in disease.values()):
-            return None
-
-        # Since MOA disease objects do not have an ID, we will create a digest from
-        # the original MOA disease object.
-        # The `name` is as written in the source text. In an upcoming MOA release, these
-        # will have leading underscore to differentiate "raw" values
-        oncotree_code = disease["oncotree_code"]
-        oncotree_key = "oncotree_code" if oncotree_code else "oncotree_term"
-        oncotree_value = oncotree_code or disease[oncotree_key]
-        oncotree_kv = [f"{oncotree_key}:{oncotree_value}"]
-        blob = json.dumps(oncotree_kv, separators=(",", ":")).encode("ascii")
-        disease_id = sha512t24u(blob)
-        moa_disease = self._cache.conditions.get(disease_id)
-        if moa_disease:
-            source_disease_name = disease["name"]
-            if source_disease_name != moa_disease.name:
-                self._resolve_concept_discrepancy(
-                    disease_id,
-                    moa_disease,
-                    moa_disease.name,
-                    source_disease_name,
-                    is_disease=True,
-                )
-                self.processed_data.conditions.append(moa_disease)
-            return moa_disease
-
-        moa_disease = None
-        moa_disease = self._get_disease(disease)
-        self._cache.conditions[disease_id] = moa_disease
-        self.processed_data.conditions.append(moa_disease)
-        return moa_disease
-
-    def _get_disease(self, disease: dict) -> MappableConcept:
-        """Get Disease object for a MOA disease
-
-        :param disease: MOA disease record
         :return: Disease represented as a mappable concept
         """
         queries = []
@@ -817,6 +668,7 @@ class MoaTransformer(Transformer):
         if disease_name:
             queries.append(disease_name)
 
+        normalized_disease_id = None
         for query in queries:  # Order matters (use highest match first)
             (
                 disease_norm_resp,
@@ -837,10 +689,13 @@ class MoaTransformer(Transformer):
                 )
             )
 
-        return MappableConcept(
+        moa_disease = MappableConcept(
             id=id_,
             conceptType="Disease",
             name=disease_name,
             mappings=mappings or None,
             extensions=extensions or None,
         )
+
+        self.processed_data.conditions.append(moa_disease)
+        return moa_disease

--- a/server/src/metakb/transformers/moa.py
+++ b/server/src/metakb/transformers/moa.py
@@ -43,21 +43,20 @@ from metakb.transformers.base import (
     MoaEvidenceLevel,
     Transformer,
     _sanitize_name,
-    _TransformedRecordsCache,
 )
 
 _logger = logging.getLogger(__name__)
 
 
-class _MoaTransformedCache(_TransformedRecordsCache):
-    """Create model for caching MOA data"""
-
-    variations: ClassVar[dict[str, dict]] = {}
-    documents: ClassVar[dict[str, Document]] = {}
-    normalized_therapies: ClassVar[
-        dict[str, MappableConcept]
-    ] = {}  # normalized_id: therapy
-    therapy_groups: ClassVar[dict[str, TherapyGroup]] = {}
+# class _MoaTransformedCache(_TransformedRecordsCache):
+#     """Create model for caching MOA data"""
+#
+#     variations: ClassVar[dict[str, dict]] = {}
+#     documents: ClassVar[dict[str, Document]] = {}
+#     normalized_therapies: ClassVar[
+#         dict[str, MappableConcept]
+#     ] = {}  # normalized_id: therapy
+#     therapy_groups: ClassVar[dict[str, TherapyGroup]] = {}
 
 
 class MoaTransformer(Transformer):
@@ -83,11 +82,6 @@ class MoaTransformer(Transformer):
         self.processed_data.methods = [
             self.methods_mapping[MethodId.MOA_ASSERTION_BIORXIV.value]
         ]
-        self._cache = self._create_cache()
-
-    def _create_cache(self) -> _MoaTransformedCache:
-        """Create cache for transformed records"""
-        return _MoaTransformedCache()
 
     async def transform(self, harvested_data: MoaHarvestedData) -> None:
         """Transform MOA harvested JSON to common data model. Will store transformed
@@ -97,7 +91,6 @@ class MoaTransformer(Transformer):
         """
         total = (
             len(harvested_data.genes)
-            + len(harvested_data.variants)
             + len(harvested_data.sources)
             + len(harvested_data.assertions)
         )
@@ -108,9 +101,7 @@ class MoaTransformer(Transformer):
         for gene in harvested_data.genes:
             self._create_gene(gene)
             pbar.update(1)
-        for variant in harvested_data.variants:
-            await self._add_categorical_variant(variant)
-            pbar.update(1)
+        variants_map = {}
         for source in harvested_data.sources:
             self._add_document(source)
             pbar.update(1)
@@ -124,20 +115,11 @@ class MoaTransformer(Transformer):
         """Create Variant Study Statements from MOA assertions.
         Will add associated values to ``processed_data`` instance variable
         (``therapies``, ``conditions``, and ``statements``).
-        ``_cache`` will also be mutated for associated therapies and conditions.
 
         :param assertions: MOA assertion record
         """
         assertion_id = f"moa.assertion:{assertion['id']}"
-        variant_id = assertion["variant"]["id"]
-
-        # Check cache for variation record (which contains gene information)
-        variation_gene_map = self._cache.variations.get(variant_id)
-        if not variation_gene_map:
-            _logger.debug(
-                "%s has no variation for variant_id %s", assertion_id, variant_id
-            )
-            return
+        variant = await self._create_categorical_variant(assertion["variant"])
 
         # Get strength
         predictive_implication = (
@@ -185,7 +167,7 @@ class MoaTransformer(Transformer):
         prop_params = {
             "alleleOriginQualifier": allele_origin_qualifier,
             "geneContextQualifier": variation_gene_map["moa_gene"],
-            "subjectVariant": variation_gene_map["cv"],
+            "subjectVariant": variant,
         }
 
         if assertion["favorable_prognosis"] == "":  # can be either 0, 1, or ""
@@ -233,7 +215,7 @@ class MoaTransformer(Transformer):
             stmt_params["proposition"] = VariantPrognosticProposition(**prop_params)
         self.processed_data.statements_evidence.append(Statement(**stmt_params))
 
-    async def _add_categorical_variant(self, variant: dict) -> None:
+    async def _create_categorical_variant(self, variant: dict) -> None:
         """Create Categorical Variant object for MOA variant record
 
         Mutates instance variables ``_cache['variations']`` and

--- a/server/src/metakb/transformers/moa.py
+++ b/server/src/metakb/transformers/moa.py
@@ -98,7 +98,7 @@ class MoaTransformer(Transformer):
         (``therapies``, ``conditions``, and ``statements``).
 
         :param assertions: MOA assertion record
-        :param docs_map:
+        :param docs_map: map from moa source ID to corresponding GKS Document object
         """
         assertion_id = f"moa.assertion:{assertion['id']}"
 
@@ -216,7 +216,7 @@ class MoaTransformer(Transformer):
         Mutates instance variable ``processed_data.variations``
 
         :param variant: variants in MOAlmanac
-        :return:
+        :return: constructed categorical variant object, if able to normalize
         """
         if variant.get("gene2"):
             # Do not support gene fusions for now

--- a/server/src/metakb/transformers/moa.py
+++ b/server/src/metakb/transformers/moa.py
@@ -31,6 +31,7 @@ from ga4gh.va_spec.base import (
 )
 from ga4gh.vrs.models import Variation
 from pydantic import ValidationError
+from tqdm import tqdm
 
 from metakb.harvesters.moa import MoaHarvestedData
 from metakb.normalizers import (
@@ -94,15 +95,30 @@ class MoaTransformer(Transformer):
 
         :param harvested_data: MOA harvested data
         """
+        total = (
+            len(harvested_data.genes)
+            + len(harvested_data.variants)
+            + len(harvested_data.sources)
+            + len(harvested_data.assertions)
+        )
+        pbar = tqdm(total=total)
+
         # Add gene, variant, and source data to ``processed_data`` instance variable
         # (``genes``, ``variations``, and ``documents``)
-        self._add_genes(harvested_data.genes)
-        await self._add_categorical_variants(harvested_data.variants)
-        self._add_documents(harvested_data.sources)
+        for gene in harvested_data.genes:
+            self._create_gene(gene)
+            pbar.update(1)
+        for variant in harvested_data.variants:
+            await self._add_categorical_variant(variant)
+            pbar.update(1)
+        for source in harvested_data.sources:
+            self._add_document(source)
+            pbar.update(1)
 
         # Add variant therapeutic response study statement data. Will update `statements`
         for assertion in harvested_data.assertions:
             await self._add_variant_study_stmt(assertion)
+            pbar.update(1)
 
     async def _add_variant_study_stmt(self, assertion: dict) -> None:
         """Create Variant Study Statements from MOA assertions.
@@ -217,158 +233,155 @@ class MoaTransformer(Transformer):
             stmt_params["proposition"] = VariantPrognosticProposition(**prop_params)
         self.processed_data.statements_evidence.append(Statement(**stmt_params))
 
-    async def _add_categorical_variants(self, variants: list[dict]) -> None:
-        """Create Categorical Variant objects for all MOA variant records.
+    async def _add_categorical_variant(self, variant: dict) -> None:
+        """Create Categorical Variant object for MOA variant record
 
         Mutates instance variables ``_cache['variations']`` and
         ``processed_data.variations``
 
-        :param variants: All variants in MOAlmanac
+        :param variant: variants in MOAlmanac
         """
-        for variant in variants:
-            if variant.get("gene2"):
-                # Do not support gene fusions for now
-                continue
+        if variant.get("gene2"):
+            # Do not support gene fusions for now
+            return
 
-            variant_id = variant["id"]
-            moa_variant_id = f"moa.variant:{variant_id}"
-            feature = variant["feature"]
-            moa_variation = None
-            gene = variant.get("gene") or variant.get("gene1")
-            moa_gene = self._cache.genes[_sanitize_name(gene)] if gene else None
-            protein_change = variant.get("protein_change")
-            constraints = None
-            extensions = []
+        variant_id = variant["id"]
+        moa_variant_id = f"moa.variant:{variant_id}"
+        feature = variant["feature"]
+        moa_variation = None
+        gene = variant.get("gene") or variant.get("gene1")
+        moa_gene = self._cache.genes[_sanitize_name(gene)] if gene else None
+        protein_change = variant.get("protein_change")
+        constraints = None
+        extensions = []
 
-            if (
-                variant["feature_type"] == "somatic_variant"
-                and variant["alternate_allele"] is None
-                and feature == gene
-                and protein_change is None
-                # no slam-dunk catvar solution exists for defining specific exons as features --
-                # see https://github.com/ga4gh/cat-vrs/discussions/161
-                and variant["exon"] is None
-            ):
-                gene_norm_resp, normalized_gene_id = (
-                    self.vicc_normalizers.normalize_gene(feature)
-                )
-                feature = f"{feature} Mutation"
-                if not normalized_gene_id:
-                    _logger.debug("Unable to normalize feature term: %s", feature)
-                    extensions.append(self._get_vicc_normalizer_failure_ext())
-                else:
-                    mappings = []
-                    extensions = []
-                    if normalized_gene_id:
-                        mappings.extend(
-                            self._get_vicc_normalizer_mappings(
-                                normalized_gene_id, gene_norm_resp
-                            )
+        if (
+            variant["feature_type"] == "somatic_variant"
+            and variant["alternate_allele"] is None
+            and feature == gene
+            and protein_change is None
+            # no slam-dunk catvar solution exists for defining specific exons as features --
+            # see https://github.com/ga4gh/cat-vrs/discussions/161
+            and variant["exon"] is None
+        ):
+            gene_norm_resp, normalized_gene_id = self.vicc_normalizers.normalize_gene(
+                feature
+            )
+            feature = f"{feature} Mutation"
+            if not normalized_gene_id:
+                _logger.debug("Unable to normalize feature term: %s", feature)
+                extensions.append(self._get_vicc_normalizer_failure_ext())
+            else:
+                mappings = []
+                extensions = []
+                if normalized_gene_id:
+                    mappings.extend(
+                        self._get_vicc_normalizer_mappings(
+                            normalized_gene_id, gene_norm_resp
                         )
-                        id_ = f"moa.{gene_norm_resp.gene.id}"
-                    else:
-                        id_ = f"moa.gene:{_sanitize_name(feature)}"
-                        extensions.append(self._get_vicc_normalizer_failure_ext())
-
-                    gene_concept = MappableConcept(
-                        id=id_,
-                        conceptType="Gene",
-                        name=gene,
-                        mappings=mappings or None,
-                        extensions=extensions or None,
                     )
-                    constraints = [
-                        FeatureContextConstraint(featureContext=gene_concept)
-                    ]
-            elif "rearrangement_type" in variant or not protein_change or not gene:
+                    id_ = f"moa.{gene_norm_resp.gene.id}"
+                else:
+                    id_ = f"moa.gene:{_sanitize_name(feature)}"
+                    extensions.append(self._get_vicc_normalizer_failure_ext())
+
+                gene_concept = MappableConcept(
+                    id=id_,
+                    conceptType="Gene",
+                    name=gene,
+                    mappings=mappings or None,
+                    extensions=extensions or None,
+                )
+                constraints = [FeatureContextConstraint(featureContext=gene_concept)]
+        elif "rearrangement_type" in variant or not protein_change or not gene:
+            _logger.debug(
+                "Variation Normalizer does not support %s: %s",
+                moa_variant_id,
+                feature,
+            )
+            extensions.append(self._get_vicc_normalizer_failure_ext())
+        else:
+            # Form query and run through variation-normalizer
+            # For now, the normalizer only support amino acid substitution
+            vrs_variation = None
+            gene = moa_gene.name
+            query = f"{gene} {protein_change[2:]}"
+            vrs_variation = await self.vicc_normalizers.normalize_variation(query)
+
+            if not vrs_variation:
                 _logger.debug(
-                    "Variation Normalizer does not support %s: %s",
-                    moa_variant_id,
-                    feature,
+                    "Variation Normalizer unable to normalize: moa.variant: %s using query: %s",
+                    variant_id,
+                    query,
                 )
                 extensions.append(self._get_vicc_normalizer_failure_ext())
             else:
-                # Form query and run through variation-normalizer
-                # For now, the normalizer only support amino acid substitution
-                vrs_variation = None
-                gene = moa_gene.name
-                query = f"{gene} {protein_change[2:]}"
-                vrs_variation = await self.vicc_normalizers.normalize_variation(query)
+                # Create VRS Variation object
+                params = vrs_variation.model_dump(exclude_none=True)
+                moa_variant_id = f"moa.variant:{variant_id}"
+                params["id"] = vrs_variation.id
+                moa_variation = Variation(**params)
+                constraints = [DefiningAlleleConstraint(allele=moa_variation.root)]
 
-                if not vrs_variation:
-                    _logger.debug(
-                        "Variation Normalizer unable to normalize: moa.variant: %s using query: %s",
-                        variant_id,
-                        query,
-                    )
-                    extensions.append(self._get_vicc_normalizer_failure_ext())
-                else:
-                    # Create VRS Variation object
-                    params = vrs_variation.model_dump(exclude_none=True)
-                    moa_variant_id = f"moa.variant:{variant_id}"
-                    params["id"] = vrs_variation.id
-                    moa_variation = Variation(**params)
-                    constraints = [DefiningAlleleConstraint(allele=moa_variation.root)]
-
-            # Add MOA representative coordinate data to extensions
-            coordinates_keys = [
-                "chromosome",
-                "start_position",
-                "end_position",
-                "reference_allele",
-                "alternate_allele",
-                "cdna_change",
-                "protein_change",
-                "exon",
-            ]
-            moa_rep_coord = {k: variant.get(k) for k in coordinates_keys}
-            if any(moa_rep_coord.values()):
-                extensions.append(
-                    Extension(name="MOA representative coordinate", value=moa_rep_coord)
-                )
-
-            if variant.get("locus"):
-                extensions.append(Extension(name="MOA locus", value=variant["locus"]))
-
-            members = await self._get_variation_members(moa_rep_coord)
-
-            # Add mappings data
-            mappings = [
-                ConceptMapping(
-                    coding=Coding(
-                        id=moa_variant_id,
-                        code=str(variant_id),
-                        system="https://moalmanac.org",
-                    ),
-                    relation=Relation.EXACT_MATCH,
-                )
-            ]
-
-            if variant.get("rsid"):
-                mappings.append(
-                    ConceptMapping(
-                        coding=Coding(
-                            code=variant["rsid"],
-                            system="https://www.ncbi.nlm.nih.gov/snp/",
-                        ),
-                        relation=Relation.RELATED_MATCH,
-                    )
-                )
-
-            cv = CategoricalVariant(
-                id=moa_variant_id,
-                name=feature,
-                constraints=constraints,
-                mappings=mappings or None,
-                extensions=extensions,
-                members=members,
+        # Add MOA representative coordinate data to extensions
+        coordinates_keys = [
+            "chromosome",
+            "start_position",
+            "end_position",
+            "reference_allele",
+            "alternate_allele",
+            "cdna_change",
+            "protein_change",
+            "exon",
+        ]
+        moa_rep_coord = {k: variant.get(k) for k in coordinates_keys}
+        if any(moa_rep_coord.values()):
+            extensions.append(
+                Extension(name="MOA representative coordinate", value=moa_rep_coord)
             )
 
-            self._cache.variations[variant_id] = {
-                "cv": cv,
-                "moa_gene": moa_gene,
-            }
-            self.processed_data.categorical_variants.append(cv)
+        if variant.get("locus"):
+            extensions.append(Extension(name="MOA locus", value=variant["locus"]))
+
+        members = await self._get_variation_members(moa_rep_coord)
+
+        # Add mappings data
+        mappings = [
+            ConceptMapping(
+                coding=Coding(
+                    id=moa_variant_id,
+                    code=str(variant_id),
+                    system="https://moalmanac.org",
+                ),
+                relation=Relation.EXACT_MATCH,
+            )
+        ]
+
+        if variant.get("rsid"):
+            mappings.append(
+                ConceptMapping(
+                    coding=Coding(
+                        code=variant["rsid"],
+                        system="https://www.ncbi.nlm.nih.gov/snp/",
+                    ),
+                    relation=Relation.RELATED_MATCH,
+                )
+            )
+
+        cv = CategoricalVariant(
+            id=moa_variant_id,
+            name=feature,
+            constraints=constraints,
+            mappings=mappings or None,
+            extensions=extensions,
+            members=members,
+        )
+
+        self._cache.variations[variant_id] = {
+            "cv": cv,
+            "moa_gene": moa_gene,
+        }
+        self.processed_data.categorical_variants.append(cv)
 
     async def _get_variation_members(
         self, moa_rep_coord: dict
@@ -414,59 +427,53 @@ class MoaTransformer(Transformer):
 
         return members
 
-    def _add_genes(self, genes: list[str]) -> None:
-        """Create gene objects for all MOA gene records.
+    def _create_gene(self, gene: str) -> None:
+        """Create gene object for MOA gene record
 
         Mutates instance variables ``_cache['genes']`` and ``processed_data.genes``
 
-        :param genes: All genes in MOAlmanac
+        :param gene: gene from MOAlmanac
         """
-        for gene in genes:
-            gene_norm_resp, normalized_gene_id = self.vicc_normalizers.normalize_gene(
-                gene
+        gene_norm_resp, normalized_gene_id = self.vicc_normalizers.normalize_gene(gene)
+        mappings = []
+        extensions = []
+        if normalized_gene_id:
+            mappings.extend(
+                self._get_vicc_normalizer_mappings(normalized_gene_id, gene_norm_resp)
             )
-            mappings = []
-            extensions = []
-            if normalized_gene_id:
-                mappings.extend(
-                    self._get_vicc_normalizer_mappings(
-                        normalized_gene_id, gene_norm_resp
-                    )
-                )
-                id_ = f"moa.{gene_norm_resp.gene.id}"
-            else:
-                id_ = f"moa.gene:{_sanitize_name(gene)}"
-                extensions.append(self._get_vicc_normalizer_failure_ext())
+            id_ = f"moa.{gene_norm_resp.gene.id}"
+        else:
+            id_ = f"moa.gene:{_sanitize_name(gene)}"
+            extensions.append(self._get_vicc_normalizer_failure_ext())
 
-            moa_gene = MappableConcept(
-                id=id_,
-                conceptType="Gene",
-                name=gene,
-                mappings=mappings or None,
-                extensions=extensions or None,
-            )
-            self._cache.genes[_sanitize_name(gene)] = moa_gene
-            self.processed_data.genes.append(moa_gene)
+        moa_gene = MappableConcept(
+            id=id_,
+            conceptType="Gene",
+            name=gene,
+            mappings=mappings or None,
+            extensions=extensions or None,
+        )
+        self._cache.genes[_sanitize_name(gene)] = moa_gene
+        self.processed_data.genes.append(moa_gene)
 
-    def _add_documents(self, sources: list) -> None:
-        """Create document objects for all MOA sources.
-        Mutates instance variables ``processed_data.documents`` and
-        ``self._cache.documents"]``
+    def _add_document(self, source: dict) -> None:
+        """Create document object for MOA source
+
+        Mutates instance variables ``processed_data.documents`` and ``self._cache.documents"]``
 
         :param sources: All sources in MOA
         """
-        for source in sources:
-            source_id = source["id"]
-            document = Document(
-                id=f"moa.source:{source_id}",
-                title=source["citation"],
-                urls=[source["url"]] if source["url"] else None,
-                pmid=str(source["pmid"]) if source["pmid"] else None,
-                doi=source["doi"] if source["doi"] else None,
-                extensions=[Extension(name="source_type", value=source["type"])],
-            )
-            self._cache.documents[source_id] = document
-            self.processed_data.documents.append(document)
+        source_id = source["id"]
+        document = Document(
+            id=f"moa.source:{source_id}",
+            title=source["citation"],
+            urls=[source["url"]] if source["url"] else None,
+            pmid=str(source["pmid"]) if source["pmid"] else None,
+            doi=source["doi"] or None,
+            extensions=[Extension(name="source_type", value=source["type"])],
+        )
+        self._cache.documents[source_id] = document
+        self.processed_data.documents.append(document)
 
     def _get_therapy_or_group(
         self, assertion: dict

--- a/server/src/metakb/transformers/moa.py
+++ b/server/src/metakb/transformers/moa.py
@@ -120,6 +120,8 @@ class MoaTransformer(Transformer):
             await self._add_variant_study_stmt(assertion)
             pbar.update(1)
 
+        pbar.close()
+
     async def _add_variant_study_stmt(self, assertion: dict) -> None:
         """Create Variant Study Statements from MOA assertions.
         Will add associated values to ``processed_data`` instance variable

--- a/server/src/metakb/transformers/moa.py
+++ b/server/src/metakb/transformers/moa.py
@@ -3,7 +3,6 @@
 import json
 import logging
 from pathlib import Path
-from typing import ClassVar
 
 from ga4gh.cat_vrs.models import (
     CategoricalVariant,
@@ -17,6 +16,7 @@ from ga4gh.core.models import (
     Extension,
     MappableConcept,
     Relation,
+    code,
 )
 from ga4gh.va_spec.base import (
     Direction,
@@ -34,9 +34,7 @@ from pydantic import ValidationError
 from tqdm import tqdm
 
 from metakb.harvesters.moa import MoaHarvestedData
-from metakb.normalizers import (
-    ViccNormalizers,
-)
+from metakb.normalizers import ViccNormalizers
 from metakb.schemas.app import SourceName
 from metakb.transformers.base import (
     MethodId,
@@ -89,34 +87,30 @@ class MoaTransformer(Transformer):
 
         :param harvested_data: MOA harvested data
         """
-        total = (
-            len(harvested_data.genes)
-            + len(harvested_data.sources)
-            + len(harvested_data.assertions)
-        )
+        total = len(harvested_data.sources) + len(harvested_data.assertions)
         pbar = tqdm(total=total)
 
-        # Add gene, variant, and source data to ``processed_data`` instance variable
-        # (``genes``, ``variations``, and ``documents``)
-        for gene in harvested_data.genes:
-            self._create_gene(gene)
-            pbar.update(1)
-        variants_map = {}
+        docs_map = {}
         for source in harvested_data.sources:
-            self._add_document(source)
+            source_doc = self._create_document(source)
+            docs_map[source_doc.id] = source_doc
             pbar.update(1)
 
         # Add variant therapeutic response study statement data. Will update `statements`
         for assertion in harvested_data.assertions:
-            await self._add_variant_study_stmt(assertion)
+            await self._add_variant_study_stmt(assertion, docs_map)
             pbar.update(1)
 
-    async def _add_variant_study_stmt(self, assertion: dict) -> None:
+    async def _add_variant_study_stmt(
+        self, assertion: dict, docs_map: dict[str, Document]
+    ) -> None:
         """Create Variant Study Statements from MOA assertions.
+
         Will add associated values to ``processed_data`` instance variable
         (``therapies``, ``conditions``, and ``statements``).
 
         :param assertions: MOA assertion record
+        :param docs_map:
         """
         assertion_id = f"moa.assertion:{assertion['id']}"
         variant = await self._create_categorical_variant(assertion["variant"])
@@ -133,7 +127,7 @@ class MoaTransformer(Transformer):
         strength = MappableConcept(
             primaryCoding=Coding(
                 system="https://moalmanac.org/about",
-                code=evidence_level.value,
+                code=code(evidence_level.value),
             ),
             mappings=self.evidence_level_to_vicc_concept_mapping[evidence_level],
         )
@@ -146,9 +140,16 @@ class MoaTransformer(Transformer):
             )
             return
 
-        # Add document
-        document = self._cache.documents.get(assertion["source_id"])
+        # Add gene
+        if gene_name := assertion["variant"].get("gene"):
+            moa_gene = self._create_gene(gene_name)
+        else:
+            return
 
+        # Add document
+        document = docs_map[assertion["source_id"]]
+
+        # Add allele origin
         feature_type = assertion["variant"]["feature_type"]
         if feature_type == "somatic_variant":
             allele_origin_qualifier = MappableConcept(name="somatic")
@@ -166,7 +167,7 @@ class MoaTransformer(Transformer):
         }
         prop_params = {
             "alleleOriginQualifier": allele_origin_qualifier,
-            "geneContextQualifier": variation_gene_map["moa_gene"],
+            "geneContextQualifier": moa_gene,
             "subjectVariant": variant,
         }
 
@@ -218,8 +219,7 @@ class MoaTransformer(Transformer):
     async def _create_categorical_variant(self, variant: dict) -> None:
         """Create Categorical Variant object for MOA variant record
 
-        Mutates instance variables ``_cache['variations']`` and
-        ``processed_data.variations``
+        Mutates instance variable ``processed_data.variations``
 
         :param variant: variants in MOAlmanac
         """
@@ -231,8 +231,7 @@ class MoaTransformer(Transformer):
         moa_variant_id = f"moa.variant:{variant_id}"
         feature = variant["feature"]
         moa_variation = None
-        gene = variant.get("gene") or variant.get("gene1")
-        moa_gene = self._cache.genes[_sanitize_name(gene)] if gene else None
+        moa_gene_value = variant.get("gene") or variant.get("gene1")
         protein_change = variant.get("protein_change")
         constraints = None
         extensions = []
@@ -240,7 +239,7 @@ class MoaTransformer(Transformer):
         if (
             variant["feature_type"] == "somatic_variant"
             and variant["alternate_allele"] is None
-            and feature == gene
+            and feature == moa_gene_value
             and protein_change is None
             # no slam-dunk catvar solution exists for defining specific exons as features --
             # see https://github.com/ga4gh/cat-vrs/discussions/161
@@ -270,12 +269,14 @@ class MoaTransformer(Transformer):
                 gene_concept = MappableConcept(
                     id=id_,
                     conceptType="Gene",
-                    name=gene,
+                    name=gene_norm_resp.gene.name if gene_norm_resp.gene else None,
                     mappings=mappings or None,
                     extensions=extensions or None,
                 )
                 constraints = [FeatureContextConstraint(featureContext=gene_concept)]
-        elif "rearrangement_type" in variant or not protein_change or not gene:
+        elif (
+            "rearrangement_type" in variant or not protein_change or not moa_gene_value
+        ):
             _logger.debug(
                 "Variation Normalizer does not support %s: %s",
                 moa_variant_id,
@@ -286,24 +287,29 @@ class MoaTransformer(Transformer):
             # Form query and run through variation-normalizer
             # For now, the normalizer only support amino acid substitution
             vrs_variation = None
-            gene = moa_gene.name
-            query = f"{gene} {protein_change[2:]}"
-            vrs_variation = await self.vicc_normalizers.normalize_variation(query)
-
-            if not vrs_variation:
-                _logger.debug(
-                    "Variation Normalizer unable to normalize: moa.variant: %s using query: %s",
-                    variant_id,
-                    query,
-                )
+            normalize_gene_response = self.vicc_normalizers.normalize_gene(
+                moa_gene_value
+            )
+            if not normalize_gene_response[0].gene:
                 extensions.append(self._get_vicc_normalizer_failure_ext())
             else:
-                # Create VRS Variation object
-                params = vrs_variation.model_dump(exclude_none=True)
-                moa_variant_id = f"moa.variant:{variant_id}"
-                params["id"] = vrs_variation.id
-                moa_variation = Variation(**params)
-                constraints = [DefiningAlleleConstraint(allele=moa_variation.root)]
+                query = f"{normalize_gene_response[0].gene.name} {protein_change[2:]}"
+                vrs_variation = await self.vicc_normalizers.normalize_variation(query)
+
+                if not vrs_variation:
+                    _logger.debug(
+                        "Variation Normalizer unable to normalize: moa.variant: %s using query: %s",
+                        variant_id,
+                        query,
+                    )
+                    extensions.append(self._get_vicc_normalizer_failure_ext())
+                else:
+                    # Create VRS Variation object
+                    params = vrs_variation.model_dump(exclude_none=True)
+                    moa_variant_id = f"moa.variant:{variant_id}"
+                    params["id"] = vrs_variation.id
+                    moa_variation = Variation(**params)
+                    constraints = [DefiningAlleleConstraint(allele=moa_variation.root)]
 
         # Add MOA representative coordinate data to extensions
         coordinates_keys = [
@@ -332,7 +338,7 @@ class MoaTransformer(Transformer):
             ConceptMapping(
                 coding=Coding(
                     id=moa_variant_id,
-                    code=str(variant_id),
+                    code=code(str(variant_id)),
                     system="https://moalmanac.org",
                 ),
                 relation=Relation.EXACT_MATCH,
@@ -359,10 +365,6 @@ class MoaTransformer(Transformer):
             members=members,
         )
 
-        self._cache.variations[variant_id] = {
-            "cv": cv,
-            "moa_gene": moa_gene,
-        }
         self.processed_data.categorical_variants.append(cv)
 
     async def _get_variation_members(
@@ -409,12 +411,13 @@ class MoaTransformer(Transformer):
 
         return members
 
-    def _create_gene(self, gene: str) -> None:
+    def _create_gene(self, gene: str) -> MappableConcept:
         """Create gene object for MOA gene record
 
         Mutates instance variables ``_cache['genes']`` and ``processed_data.genes``
 
         :param gene: gene from MOAlmanac
+        :return:
         """
         gene_norm_resp, normalized_gene_id = self.vicc_normalizers.normalize_gene(gene)
         mappings = []
@@ -435,13 +438,13 @@ class MoaTransformer(Transformer):
             mappings=mappings or None,
             extensions=extensions or None,
         )
-        self._cache.genes[_sanitize_name(gene)] = moa_gene
         self.processed_data.genes.append(moa_gene)
+        return moa_gene
 
-    def _add_document(self, source: dict) -> None:
+    def _create_document(self, source: dict) -> Document:
         """Create document object for MOA source
 
-        Mutates instance variables ``processed_data.documents`` and ``self._cache.documents"]``
+        Mutates instance variable ``processed_data.documents``
 
         :param sources: All sources in MOA
         """
@@ -454,8 +457,8 @@ class MoaTransformer(Transformer):
             doi=source["doi"] or None,
             extensions=[Extension(name="source_type", value=source["type"])],
         )
-        self._cache.documents[source_id] = document
         self.processed_data.documents.append(document)
+        return document
 
     def _get_therapy_or_group(
         self, assertion: dict


### PR DESCRIPTION
This PR changes how normalization/entity (i.e. gene/disease/therapy/variant) construction gets cached during source transformation. 

* Implement caching on the normalizer service class itself. This is done with the functools lru cache decorator. This would enable us to set up LRU caching during data retrieval, too.
* Drop the transformer cache stuff. I think this gets difficult to maintain because it's shared state that needs to be manually checked and updated while iterating through source data. If we instead put a cache in front of the normalizer request, then we 
   * Also cache the results of failed requests, instead of just successful ones
   * Have a lot less state to manage
   * Duplicate some work done to construct full GKS objects given the result of the normalizer, but that's not a huge deal (the normalization requests are what slow us down)
* Drop the discrepancy resolution biz in the MOA transformer. Since we won't be updating the source entity objects in-place anymore, we can just construct them as they're given to us, and then just map them to the same normalized object. No need to update a previously-constructed object to handle the discrepancy. (! This represents actual behavior change, although it's on purpose and a necessary part of the actual evidence aggregation stuff)

This is the important part

```python
    def __init__(
        self, db_url: str | None = None, cache_size: int | None = DEFAULT_CACHE_SIZE
    ) -> None:
        """Initialize normalizers. Construct a normalizer instance for each service
        (gene, variation, disease, therapy) and retain them as instance properties.

        * Gene concept lookups within the Variation Normalizer are resolved using the
          Gene Normalizer instance, rather than creating a second sub-instance.
        * The normalizers are exposed interally as callback functions wrapped in an
          ``lru_cache`` at initialization, so that a configurable cache size variable
          can be passed to the caching wrapper

        :param db_url: optional definition of shared normalizer database. Because the
            same parameter is passed to each concept normalizer, this only works for
            connecting a DynamoDB backend. If not given, each normalizer falls back
            on default behavior for connecting to a database, which includes checking
            their corresponding environment variables.
        :param cache_size: size of LRU cache used for each normalizer. Use ``None`` to
            use an unbounded cache (ie no max size).
        """
        gene_query_handler = GeneQueryHandler(create_gene_db(db_url))
        self._normalize_gene = lru_cache(cache_size)(gene_query_handler.normalize)
        disease_query_handler = DiseaseQueryHandler(create_disease_db(db_url))
        self._normalize_disease = lru_cache(cache_size)(disease_query_handler.normalize)
        therapy_query_handler = TherapyQueryHandler(create_therapy_db(db_url))
        self._normalize_therapy = lru_cache(cache_size)(therapy_query_handler.normalize)
        variation_query_handler = VariationQueryHandler(
            gene_query_handler=gene_query_handler
        )
        self._normalize_variation = alru_cache(cache_size)(
            variation_query_handler.normalize_handler.normalize
        )
```

### but why?

With the ev aggregation refactor, we now want to create associated normalized concepts associated with what sources give us, rather than updating those source entities in-place. This means we want to handle some parts of the normalization process differently, and rethink how we're saving prior work. Previously, we would manually maintain key-value mappings, but this made for a lot of complexity; sometimes we'd need to be tricky about what the "key" was for the purpose of the cache, and other times, we'd have to update a previously-constructed object because we'd want to mix it with a newly-encountered version of that object (this is the "discrepancy" handler code in the MOA transformer). This PR simplifies this.