### PR TITLE
feat: move evidence key to tooltip and adjust colors

### DIFF
--- a/client/src/components/ResultTable/EvidenceLegend.tsx
+++ b/client/src/components/ResultTable/EvidenceLegend.tsx
@@ -12,8 +12,9 @@ export const EvidenceLegend: React.FC = () => {
       component="ul"
       sx={{
         display: 'flex',
-        flexWrap: 'wrap',
-        gap: 2,
+        flexDirection: 'column',
+        alignItems: 'flex-start',
+        gap: 0.75,
         p: 0,
         m: 0,
         listStyle: 'none',

--- a/client/src/components/ResultTable/LegendSwatch.tsx
+++ b/client/src/components/ResultTable/LegendSwatch.tsx
@@ -36,7 +36,7 @@ export const LegendSwatch: React.FC<LegendSwatchProps> = ({ color, label, descri
       {label}
     </Typography>
     {description && (
-      <Typography variant="body2" color="text.secondary" sx={{ ml: 0.5 }} aria-label={description}>
+      <Typography variant="body2" color="inherit" sx={{ ml: 0.5 }} aria-label={description}>
         {description}
       </Typography>
     )}

--- a/client/src/components/ResultTable/ResultTable.tsx
+++ b/client/src/components/ResultTable/ResultTable.tsx
@@ -280,7 +280,7 @@ const ResultTable: FC<ResultTableProps> = ({ results, resultType }) => {
                     placement="top"
                     enterTouchDelay={0}
                     title={<EvidenceLegend />}
-                    slotProps={{'popper': popperProps}}
+                    slotProps={{ popper: popperProps }}
                   >
                     <IconButton
                       size="small"

--- a/client/src/components/ResultTable/ResultTable.tsx
+++ b/client/src/components/ResultTable/ResultTable.tsx
@@ -18,6 +18,7 @@ import KeyboardArrowRight from '@mui/icons-material/KeyboardArrowRight'
 import LastPageIcon from '@mui/icons-material/LastPage'
 import KeyboardArrowUpIcon from '@mui/icons-material/KeyboardArrowUp'
 import KeyboardArrowDownIcon from '@mui/icons-material/KeyboardArrowDown'
+import HelpOutlineIcon from '@mui/icons-material/HelpOutline'
 import ResultTableRow from './ResultTableRow'
 import { ResultColumn } from './types'
 import { NormalizedResult, TherapyInteractionType } from '../../utils'
@@ -25,6 +26,7 @@ import { normalizeEvidenceLevelFromStrength } from '../../utils/normalization'
 import { EvidenceLevel } from '../../models/codings'
 import { PieChart, Pie, Cell } from 'recharts'
 import theme from '../../theme'
+import { EvidenceLegend } from './EvidenceLegend'
 
 interface TablePaginationActionsProps {
   count: number
@@ -260,13 +262,38 @@ const ResultTable: FC<ResultTableProps> = ({ results, resultType }) => {
     ]
   }
 
+  const popperProps = {
+    modifiers: [{ name: 'offset', options: { offset: [0, 8] } }],
+  }
+
   return (
     <Table>
       <TableHead>
         <TableRow>
           {columns.map((column) => (
             <TableCell key={column.field} style={{ width: column.width }}>
-              {column.headerName}
+              {column.field === 'evidence_summary' ? (
+                <Box display="flex" alignItems="center" gap={0.75}>
+                  {column.headerName}
+                  <Tooltip
+                    arrow
+                    placement="top"
+                    enterTouchDelay={0}
+                    title={<EvidenceLegend />}
+                    slotProps={{'popper': popperProps}}
+                  >
+                    <IconButton
+                      size="small"
+                      aria-label="Show evidence level legend"
+                      sx={{ p: 0.25 }}
+                    >
+                      <HelpOutlineIcon fontSize="small" />
+                    </IconButton>
+                  </Tooltip>
+                </Box>
+              ) : (
+                column.headerName
+              )}
             </TableCell>
           ))}
         </TableRow>

--- a/client/src/pages/Results/ResultPage.tsx
+++ b/client/src/pages/Results/ResultPage.tsx
@@ -24,7 +24,6 @@ import {
   TAB_LABELS,
   getEntityMetadataFromProposition,
 } from '../../utils'
-import { EvidenceLegend } from '../../components/ResultTable/EvidenceLegend'
 import { VariantDiseaseHeatmap } from '../../components/VariantDiseaseHeatmap/VariantDiseaseHeatmap'
 
 type SearchType = 'gene' | 'variation'
@@ -300,7 +299,6 @@ const ResultPage = () => {
                 <Typography variant="h6" fontWeight="bold" mb={2}>
                   {TAB_LABELS[activeTab]} Search Results ({filteredResults?.length})
                 </Typography>
-                <EvidenceLegend />
               </Box>
               {hasInitialResults ? (
                 <Box display="flex">

--- a/client/src/theme.ts
+++ b/client/src/theme.ts
@@ -35,10 +35,10 @@ export const themeOptions: ThemeOptions = {
     },
     evidence: {
       A: '#1f77b4', // blue
-      B: '#ff7f0e', // orange
-      C: '#2ca02c', // green
-      D: '#d62728', // red
-      E: '#9467bd', // purple
+      B: '#2ca02c', // green
+      C: '#f1c40f', // yellow
+      D: '#ff7f0e', // orange
+      E: '#d62728', // red
     },
   },
 }


### PR DESCRIPTION
<img width="1636" height="835" alt="Screenshot 2026-02-20 at 1 07 58 PM" src="https://github.com/user-attachments/assets/c2d3e0d1-989f-496c-9488-de18c0ceb86d" />

This addresses #720 