### PR TITLE
feat: add preflight checks for transform

### DIFF
--- a/server/src/metakb/cli.py
+++ b/server/src/metakb/cli.py
@@ -3,7 +3,9 @@ to graph datastore.
 """
 
 import datetime
+import importlib.metadata as importlib_metadata
 import logging
+import os
 import re
 import tempfile
 from collections.abc import Generator
@@ -17,6 +19,7 @@ import boto3
 from boto3.exceptions import ResourceLoadException
 from botocore import UNSIGNED
 from botocore.config import Config
+from botocore.exceptions import ClientError, EndpointConnectionError
 
 from metakb import DATE_FMT, __version__
 from metakb.config import get_config
@@ -67,6 +70,165 @@ def _help_msg(msg: str = "") -> None:
     click.echo(msg) if msg else click.echo(ctx.get_help())
 
     ctx.exit()
+
+
+def _get_transform_env_diagnostics(normalizer_db_url: str | None) -> list[str]:
+    """Collect baseline environment diagnostics for transform preflight.
+    This is a helper function for ensuring environment variables are properly set prior to running transform.
+
+    :param normalizer_db_url: optional explicit normalizer database URL
+    :return: list of issues found
+    """
+    diagnostics: list[str] = []
+
+    if not normalizer_db_url:
+        normalizer_env = {
+            "GENE_NORM_DB_URL": os.environ.get("GENE_NORM_DB_URL"),
+            "DISEASE_NORM_DB_URL": os.environ.get("DISEASE_NORM_DB_URL"),
+            "THERAPY_NORM_DB_URL": os.environ.get("THERAPY_NORM_DB_URL"),
+        }
+        for env_name, value in normalizer_env.items():
+            if not value:
+                diagnostics.append(
+                    f"{env_name} is not set (required when running CLI from host)."
+                )
+
+    seqrepo_root = os.environ.get("SEQREPO_ROOT_DIR")
+    if not seqrepo_root:
+        diagnostics.append("SEQREPO_ROOT_DIR is not set.")
+    elif not Path(seqrepo_root).exists():
+        diagnostics.append(
+            f"SEQREPO_ROOT_DIR points to a path that does not exist: {seqrepo_root}"
+        )
+
+    if not os.environ.get("UTA_DB_URL"):
+        diagnostics.append("UTA_DB_URL is not set.")
+
+    return diagnostics
+
+
+async def _get_preflighted_normalizers(
+    normalizer_db_url: str | None,
+) -> ViccNormalizers:
+    """Initialize normalizer dependencies for transform workflows and verify that they are online.
+
+    :param normalizer_db_url: optional explicit normalizer database URL
+    :raises click.ClickException: If required dependencies are unavailable
+    :return: initialized normalizer container
+    """
+    diagnostics = _get_transform_env_diagnostics(normalizer_db_url)
+    if diagnostics:
+        msg = "\n".join(
+            [
+                "Transform preflight failed due to missing local configuration:",
+                *[f"- {d}" for d in diagnostics],
+                "Tip: when running from host with compose-dev services, set "
+                "GENE_NORM_DB_URL=http://localhost:8011, "
+                "DISEASE_NORM_DB_URL=http://localhost:8012, "
+                "THERAPY_NORM_DB_URL=http://localhost:8013, plus UTA_DB_URL and "
+                "SEQREPO_ROOT_DIR.",
+            ]
+        )
+        raise click.ClickException(msg)
+
+    try:
+        normalizer_handler = ViccNormalizers(normalizer_db_url)
+    except EndpointConnectionError as e:
+        msg = (
+            "Unable to connect to one or more normalizer databases. "
+            "Check GENE_NORM_DB_URL/DISEASE_NORM_DB_URL/THERAPY_NORM_DB_URL.\n"
+            f"Original error: {e}"
+        )
+        raise click.ClickException(msg) from e
+    except ClientError as e:
+        msg = (
+            "Normalizer endpoint responded with an unexpected API error. "
+            "This often means the URL points at a non-normalizer service "
+            "(for example, MetaKB API on :8000 instead of DynamoDB local).\n"
+            f"Original error: {e}"
+        )
+        raise click.ClickException(msg) from e
+    except Exception as e:
+        msg = (
+            "Failed to initialize normalizers. Verify normalizer endpoints, UTA DB "
+            "connectivity, and SeqRepo configuration.\n"
+            f"Original error: {e}"
+        )
+        raise click.ClickException(msg) from e
+
+    # Probe concept normalizers to fail fast if services are misconfigured.
+    concept_probes = (
+        ("gene", lambda: normalizer_handler.normalize_gene("BRAF")),
+        (
+            "disease",
+            lambda: normalizer_handler.normalize_disease("melanoma"),
+        ),
+        ("therapy", lambda: normalizer_handler.normalize_therapy("aspirin")),
+    )
+    for concept_name, probe in concept_probes:
+        try:
+            probe()
+        except Exception as e:
+            msg = (
+                f"{concept_name.capitalize()} normalizer probe failed. "
+                "Confirm endpoint accessibility and loaded tables.\n"
+                f"Original error: {e}"
+            )
+            raise click.ClickException(msg) from e
+
+    # Probe variation normalizer for UTA/SeqRepo readiness.
+    # Use raw normalize handler rather than wrapper so exceptions are not suppressed.
+    try:
+        variation_norm_resp = (
+            await normalizer_handler.variation_normalizer.normalize_handler.normalize(
+                "BRAF V600E"
+            )
+        )
+    except Exception as e:
+        if (
+            isinstance(e, AttributeError)
+            and "ValidationInfo" in str(e)
+            and "warnings" in str(e)
+        ):
+            pydantic_version = importlib_metadata.version("pydantic")
+            variation_norm_version = importlib_metadata.version("variation-normalizer")
+            msg = (
+                "Variation normalizer failed due to a dependency compatibility issue.\n"
+                f"Detected pydantic=={pydantic_version}, variation-normalizer=={variation_norm_version}.\n"
+                "Known symptom: AttributeError involving `ValidationInfo` and "
+                "`warnings`.\n"
+                "Try pinning pydantic below 2.12 in this environment, e.g.:\n"
+                '  pip install "pydantic<2.12"'
+            )
+            raise click.ClickException(msg) from e
+        msg = (
+            "Variation normalizer probe failed. This typically indicates UTA or "
+            "SeqRepo is unavailable/misconfigured (check UTA_DB_URL and "
+            "SEQREPO_ROOT_DIR).\n"
+            f"Original error: {e}"
+        )
+        raise click.ClickException(msg) from e
+    variation_probe = (
+        variation_norm_resp.variation
+        if hasattr(variation_norm_resp, "variation")
+        else None
+    )
+    if variation_probe is None:
+        warnings = (
+            variation_norm_resp.warnings
+            if hasattr(variation_norm_resp, "warnings")
+            else None
+        )
+        msg = (
+            "Variation normalizer probe returned no result for 'BRAF V600E'. "
+            "This indicates variation normalization is not operational in this "
+            "environment (commonly UTA/SeqRepo misconfiguration or inaccessible "
+            "normalizer dependencies).\n"
+            f"Variation normalizer warnings: {warnings}"
+        )
+        raise click.ClickException(msg)
+
+    return normalizer_handler
 
 
 @click.group()
@@ -333,7 +495,7 @@ async def transform_file(
     :param harvest_file: path to harvest output file
     :param source_name: name of source that harvested file comes from
     """  # noqa: D301
-    normalizer_handler = ViccNormalizers(normalizer_db_url)
+    normalizer_handler = await _get_preflighted_normalizers(normalizer_db_url)
     await _transform_source(
         source_name, normalizer_handler, harvest_file, output_directory
     )
@@ -610,8 +772,13 @@ async def _transform_source(
     transformer: CivicTransformer | MoaTransformer = transformer_sources[source](
         normalizers=normalizer_handler, harvester_path=harvest_file
     )
-    harvested_data = transformer.extract_harvested_data()
-    await transformer.transform(harvested_data)
+    if source == SourceName.CIVIC:
+        # CIViC transform uses civicpy cache directly and does not require a harvested
+        # JSON payload.
+        await transformer.transform()
+    else:
+        harvested_data = transformer.extract_harvested_data()
+        await transformer.transform(harvested_data)
     end = timer()
     _echo_info(
         f"{source.as_print_case()} transformation finished in {(end - start):.2f} s."
@@ -641,7 +808,7 @@ async def _transform_sources(
     _echo_info("Transforming harvested data to CDM...")
     if not sources:
         sources = tuple(SourceName)
-    normalizer_handler = ViccNormalizers(normalizer_db_url)
+    normalizer_handler = await _get_preflighted_normalizers(normalizer_db_url)
     total_start = timer()
     for source in sources:
         await _transform_source(

--- a/server/src/metakb/cli.py
+++ b/server/src/metakb/cli.py
@@ -34,6 +34,7 @@ from metakb.normalizers import (
     IllegalUpdateError,
     NormalizerName,
     ViccNormalizers,
+    probe_variation_normalizer_runtime,
     update_normalizer,
 )
 from metakb.normalizers import check_normalizers as check_normalizer_health
@@ -177,14 +178,9 @@ async def _get_preflighted_normalizers(
             raise click.ClickException(msg) from e
 
     # Probe variation normalizer for UTA/SeqRepo readiness.
-    # Use raw normalize handler rather than wrapper so exceptions are not suppressed.
-    try:
-        variation_norm_resp = (
-            await normalizer_handler.variation_normalizer.normalize_handler.normalize(
-                "BRAF V600E"
-            )
-        )
-    except Exception as e:
+    probe_result = await probe_variation_normalizer_runtime(normalizer_handler)
+    if probe_result.error:
+        e = probe_result.error
         if (
             isinstance(e, AttributeError)
             and "ValidationInfo" in str(e)
@@ -208,23 +204,13 @@ async def _get_preflighted_normalizers(
             f"Original error: {e}"
         )
         raise click.ClickException(msg) from e
-    variation_probe = (
-        variation_norm_resp.variation
-        if hasattr(variation_norm_resp, "variation")
-        else None
-    )
-    if variation_probe is None:
-        warnings = (
-            variation_norm_resp.warnings
-            if hasattr(variation_norm_resp, "warnings")
-            else None
-        )
+    if not probe_result.variation_found:
         msg = (
             "Variation normalizer probe returned no result for 'BRAF V600E'. "
             "This indicates variation normalization is not operational in this "
             "environment (commonly UTA/SeqRepo misconfiguration or inaccessible "
             "normalizer dependencies).\n"
-            f"Variation normalizer warnings: {warnings}"
+            f"Variation normalizer warnings: {probe_result.warnings}"
         )
         raise click.ClickException(msg)
 

--- a/server/src/metakb/normalizers.py
+++ b/server/src/metakb/normalizers.py
@@ -2,6 +2,7 @@
 
 import logging
 from collections.abc import Iterable
+from dataclasses import dataclass
 from enum import Enum
 from os import environ
 
@@ -34,8 +35,10 @@ __all__ = [
     "NORMALIZER_AWS_ENV_VARS",
     "IllegalUpdateError",
     "NormalizerName",
+    "VariationRuntimeProbeResult",
     "ViccNormalizers",
     "check_normalizers",
+    "probe_variation_normalizer_runtime",
     "update_normalizer",
 ]
 
@@ -252,6 +255,51 @@ class ViccNormalizers:
                 )[-1]
 
         return normalizer_resp, normalized_id
+
+
+@dataclass
+class VariationRuntimeProbeResult:
+    """Define result model for variation-normalizer runtime probes."""
+
+    variation_found: bool
+    warnings: list[str] | None
+    error: Exception | None = None
+
+
+async def probe_variation_normalizer_runtime(
+    normalizers: ViccNormalizers, query: str = "BRAF V600E"
+) -> VariationRuntimeProbeResult:
+    """Probe variation-normalizer runtime readiness for a query.
+
+    This helper intentionally does not suppress exceptions so callers can present targeted diagnostics.
+
+    :param normalizers: initialized normalizer container
+    :param query: variation query to test
+    :return: probe result with variation/warnings data or captured exception
+    """
+    try:
+        variation_norm_resp = (
+            await normalizers.variation_normalizer.normalize_handler.normalize(query)
+        )
+    except Exception as e:
+        return VariationRuntimeProbeResult(
+            variation_found=False, warnings=None, error=e
+        )
+
+    variation = (
+        variation_norm_resp.variation
+        if hasattr(variation_norm_resp, "variation")
+        else None
+    )
+    warnings = (
+        variation_norm_resp.warnings
+        if hasattr(variation_norm_resp, "warnings")
+        else None
+    )
+    return VariationRuntimeProbeResult(
+        variation_found=variation is not None,
+        warnings=warnings,
+    )
 
 
 class NormalizerName(str, Enum):


### PR DESCRIPTION
I was having some issues yesterday when I was trying to run `transform` and lost more time than I'd like to admit because I didn't realize I had some environment variables misconfigured (or forgot to set them at all). The transform will fully run, taking a few minutes, leading a dev to believe it's working properly, just to arrive at the end with an empty db and silent failures.

This code was debug code for myself, but I decided to open this PR in case it might be helpful to add to the cli. Everything _should_ work the same as before (I think. I didn't verify with the OG way of having the normalizers stood up on a local ddb instance) but with initial checks and probes before moving on. 

One thing I'm not super sure on is the pydantic version issue. It seems super niche to be including in the code like this, so I might end up taking that out. I'll comment on it to bring attention. 

I'm also unsure about exposing the errors - it seems like there's existing patterns in place to silence/log errors. When I was trying this out yesterday, though, I didn't see any errors logged to metakb.log when I was running the transform. 