### PR TITLE
fix: use temporary strength value

### DIFF
--- a/server/src/metakb/transformers/base.py
+++ b/server/src/metakb/transformers/base.py
@@ -547,6 +547,7 @@ class Transformer(ABC):
                         directionOfEvidenceProvided=Direction.SUPPORTS,
                     )
                 ],
+                strength=statement.strength,  # TODO this is a placeholder -- calculate accurately in #739
             )
             statement.id = compute_aggr_statement_id(statement)
             return statement
@@ -581,6 +582,7 @@ class Transformer(ABC):
                         directionOfEvidenceProvided=Direction.SUPPORTS,
                     )
                 ],
+                strength=statement.strength,  # TODO this is a placeholder -- calculate accurately in #739
             )
             statement.id = compute_aggr_statement_id(statement)
             return statement
@@ -624,6 +626,7 @@ class Transformer(ABC):
                         directionOfEvidenceProvided=Direction.SUPPORTS,
                     )
                 ],
+                strength=statement.strength,  # TODO this is a placeholder -- calculate accurately in #739
             )
             aggr_statement.id = compute_aggr_statement_id(aggr_statement)
             return aggr_statement


### PR DESCRIPTION
in #739 we should write a method that takes an assertion and calculates the proper strength value (then eg updates it in the DB if necessary) but we can't really get anything into the DB in the first place without a strength value, so we'll put a placeholder value here. 