### PR TITLE
feat: add get_all_ids and update_assertion_strength methods

### DIFF
--- a/server/src/metakb/repository/base.py
+++ b/server/src/metakb/repository/base.py
@@ -2,6 +2,7 @@
 
 import abc
 
+from ga4gh.core.models import MappableConcept
 from ga4gh.va_spec.aac_2017 import (
     VariantDiagnosticStudyStatement,
     VariantPrognosticStudyStatement,
@@ -106,3 +107,17 @@ class AbstractRepository(abc.ABC):
     @abc.abstractmethod
     def teardown_db(self) -> None:
         """Reset repository storage."""
+
+    @abc.abstractmethod
+    def get_all_assertion_ids(self) -> list[str]:
+        """Return all assertion IDs"""
+
+    @abc.abstractmethod
+    def update_assertion_strength(
+        self, assertion_id: str, strength: MappableConcept
+    ) -> None:
+        """Update strength associated with an assertion
+
+        :param assertion_id:
+        :param strength:
+        """

--- a/server/src/metakb/repository/base.py
+++ b/server/src/metakb/repository/base.py
@@ -118,6 +118,6 @@ class AbstractRepository(abc.ABC):
     ) -> None:
         """Update strength associated with an assertion
 
-        :param assertion_id:
-        :param strength:
+        :param assertion_id: ID of statement to update
+        :param strength: new strength concept
         """

--- a/server/src/metakb/repository/neo4j_repository.py
+++ b/server/src/metakb/repository/neo4j_repository.py
@@ -811,8 +811,8 @@ class Neo4jRepository(AbstractRepository):
     ) -> None:
         """Update strength associated with an assertion
 
-        :param assertion_id:
-        :param strength:
+        :param assertion_id: ID of statement to update
+        :param strength: new strength concept
         """
         strength_node = StrengthNode.from_gks(strength)
         with self.session.begin_transaction() as tx:

--- a/server/src/metakb/repository/neo4j_repository.py
+++ b/server/src/metakb/repository/neo4j_repository.py
@@ -798,3 +798,26 @@ class Neo4jRepository(AbstractRepository):
         with self.session.begin_transaction() as tx:
             for query in queries_catalog.teardown():
                 tx.run(query)
+
+    def get_all_assertion_ids(self) -> list[str]:
+        """Return all assertion IDs"""
+        result = self.session.execute_read(
+            lambda tx: list(tx.run(queries_catalog.get_all_assertion_ids()))
+        )
+        return [r["s.id"] for r in result]
+
+    def update_assertion_strength(
+        self, assertion_id: str, strength: MappableConcept
+    ) -> None:
+        """Update strength associated with an assertion
+
+        :param assertion_id:
+        :param strength:
+        """
+        strength_node = StrengthNode.from_gks(strength)
+        with self.session.begin_transaction() as tx:
+            tx.run(
+                queries_catalog.update_assertion_strength(),
+                statement_id=assertion_id,
+                strength=strength_node.model_dump(mode="json"),
+            )

--- a/server/src/metakb/repository/queries/catalog.py
+++ b/server/src/metakb/repository/queries/catalog.py
@@ -118,3 +118,13 @@ def search_statements() -> str:
 @cache
 def get_counts() -> str:
     return _load("get_counts.cypher")
+
+
+@cache
+def get_all_assertion_ids() -> str:
+    return _load("get_all_assertion_ids.cypher")
+
+
+@cache
+def update_assertion_strength() -> str:
+    return _load("update_assertion_strength.cypher")

--- a/server/src/metakb/repository/queries/get_all_assertion_ids.cypher
+++ b/server/src/metakb/repository/queries/get_all_assertion_ids.cypher
@@ -1,0 +1,3 @@
+MATCH (s:Statement)
+WHERE s.id STARTS WITH "metakb.assertion:"
+RETURN s.id

--- a/server/src/metakb/repository/queries/update_assertion_strength.cypher
+++ b/server/src/metakb/repository/queries/update_assertion_strength.cypher
@@ -1,0 +1,24 @@
+MATCH (s:Statement {id: $statement_id})
+
+// grab the old strength association to delete the edge later
+OPTIONAL MATCH (s)-[old_rel:HAS_STRENGTH]->(old_strength:Strength)
+
+// match against the new strength node and create it if it doesn't exist
+MERGE (strength:Strength {id: $strength.id})
+  ON CREATE SET
+    strength +=
+      {
+        name: $strength.name,
+        mappings: $strength.mappings,
+        primary_coding: $strength.primary_coding
+      }
+
+// delete edge to previous and merge into an edge to the new strength value
+WITH s, strength, old_rel, old_strength
+DELETE old_rel
+MERGE (s)-[:HAS_STRENGTH]->(strength)
+
+// "garbage collect" -- if the old strength value is no longer used anywhere, then remove it
+WITH old_strength
+WHERE old_strength IS NOT NULL AND NOT (old_strength)--()
+DELETE old_strength

--- a/server/tests/unit/repository/test_neo4j_repository.py
+++ b/server/tests/unit/repository/test_neo4j_repository.py
@@ -4,6 +4,7 @@ import json
 from pathlib import Path
 
 import pytest
+from ga4gh.core.models import Coding, MappableConcept, code
 from ga4gh.va_spec.base import Statement
 
 from metakb.repository.neo4j_repository import Neo4jRepository, get_driver
@@ -151,3 +152,36 @@ def test_get_stats(repository: Neo4jRepository):
     stats = repository.get_stats()
     for k, v in stats.model_dump().items():
         assert v, f"Count of {k} is {v}"
+
+
+@pytest.mark.ci_only
+def test_get_all_assertion_ids(repository: Neo4jRepository):
+    all_ids = repository.get_all_assertion_ids()
+    assert set(all_ids) == {
+        "metakb.assertion:WRdtjMzgdMFsPX2i4MgN-BTFz_C3ITZQ",
+        "metakb.assertion:zk-WDclkxtcOEnxIH6VClRKRqbPXEURy",
+    }
+
+
+@pytest.mark.ci_only
+def test_update_assertion(repository: Neo4jRepository, cdm: dict):
+    assertion_id = "metakb.assertion:WRdtjMzgdMFsPX2i4MgN-BTFz_C3ITZQ"
+    new_strength = MappableConcept(
+        primaryCoding=Coding(
+            code=code("fake_code"), system="AMP/ASCO/CAP (AAC) Guidelines, 2017"
+        )
+    )
+    repository.update_assertion_strength(assertion_id, new_strength)
+
+    new_assertion_copy = repository.search_statements(statement_ids=[assertion_id])[0]
+    assert new_assertion_copy.strength.model_dump(
+        exclude_none=True
+    ) == new_strength.model_dump(exclude_none=True)
+
+    old_strength = cdm["statements"][0].strength
+    repository.update_assertion_strength(assertion_id, old_strength)
+
+    new_assertion_copy = repository.search_statements(statement_ids=[assertion_id])[0]
+    assert new_assertion_copy.strength.model_dump(
+        exclude_none=True
+    ) == old_strength.model_dump(exclude_none=True)


### PR DESCRIPTION
close #757 

Today on the drive home i was thinking about how I might need something like this to update aggregate strength values, so I sat down to see how it would work, and then that ended up being mostly enough. This adds methods to

* get all metakb assertion IDs (so you have a list of everything you need to check for updating)
* update strength (other values like a star rating should be even simpler than this)

