### PR TITLE
cicd: prevent test from trying to set up normalizers

### DIFF
--- a/server/tests/unit/transformers/test_moa.py
+++ b/server/tests/unit/transformers/test_moa.py
@@ -19,7 +19,10 @@ from metakb.transformers.moa import MoaTransformer
 
 @pytest.fixture
 def transformer() -> MoaTransformer:
-    return MoaTransformer()
+    return MoaTransformer(
+        # need to avoid triggering the normalizer factory method
+        normalizers="dummy value"
+    )
 
 
 @pytest.fixture(scope="session")


### PR DESCRIPTION
tests weren't passing