### PR TITLE
docs: update RTD build image

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,7 +1,7 @@
 version: 2
 
 build:
-  os: "ubuntu-20.04"
+  os: "ubuntu-24.04"
   tools:
     python: "3.12"
 


### PR DESCRIPTION
readthedocs just sent out a notice that `ubuntu-20.04` is deprecated