### PR TITLE
feat: add basic frontend display of age of onset

### DIFF
--- a/client/src/components/ResultTable/ResultTable.tsx
+++ b/client/src/components/ResultTable/ResultTable.tsx
@@ -243,6 +243,22 @@ const ResultTable: FC<ResultTableProps> = ({ results, resultType }) => {
       render: (value: AssertionResult) => value?.disease,
     },
     {
+      field: 'hasPediatricOnset',
+      headerName: 'Pediatric Onset',
+      width: 60,
+      render: (value: AssertionResult) =>
+        value?.hasPediatricOnset ? (
+          <Tooltip
+            title="This assertion pertains to a condition associated with pediatric onset phenotypes."
+            arrow
+          >
+            <span>🍎</span>
+          </Tooltip>
+        ) : (
+          ''
+        ),
+    },
+    {
       field: 'significance',
       headerName: 'Significance',
       width: 100,

--- a/client/src/utils/propositions.ts
+++ b/client/src/utils/propositions.ts
@@ -113,19 +113,37 @@ const getTherapyNames = (objectTherapeutic: Therapeutic): string[] | null => {
   return []
 }
 
-type ConditionNameBuckets = {
+type ConditionInfo = {
   diseases: string[]
-  phenotypes: string[]
+  hasPediatricOnset: boolean
 }
 
-const emptyBuckets = (): ConditionNameBuckets => ({
+const PEDIATRIC_ONSET_TERMS = new Set<string>([
+  'HP:0410280',
+  'HP:0003623',
+  'HP:0011463',
+  'HP:0003593',
+  'HP:0003621',
+  'HP:0025708',
+  'HP:0011462',
+])
+
+const emptyConditionInfo = (): ConditionInfo => ({
   diseases: [],
-  phenotypes: [],
+  hasPediatricOnset: false,
 })
 
 const getNamedValue = (value: unknown): string | undefined => {
   if (value && typeof value === 'object' && 'name' in value && typeof value.name === 'string') {
     return value.name
+  }
+
+  return undefined
+}
+
+const getIdValue = (value: unknown): string | undefined => {
+  if (value && typeof value === 'object' && 'id' in value && typeof value.id === 'string') {
+    return value.id
   }
 
   return undefined
@@ -137,14 +155,14 @@ const isPhenotype = (condition: unknown): boolean =>
   'conceptType' in condition &&
   condition.conceptType === 'Phenotype'
 
-function getConditionNameBuckets(condition: string | Condition | undefined): ConditionNameBuckets {
-  const buckets = emptyBuckets()
+function getConditionInfo(condition: string | Condition | undefined): ConditionInfo {
+  const result = emptyConditionInfo()
 
   const visit = (value: string | Condition | undefined) => {
     if (!value) return
 
     if (typeof value === 'string') {
-      buckets.diseases.push(value)
+      result.diseases.push(value)
       return
     }
 
@@ -153,20 +171,40 @@ function getConditionNameBuckets(condition: string | Condition | undefined): Con
       return
     }
 
-    const name = getNamedValue(value)
-    if (!name) return
-
     if (isPhenotype(value)) {
-      buckets.phenotypes.push(name)
-    } else {
-      buckets.diseases.push(name)
+      const phenotypeId = getIdValue(value)
+      if (phenotypeId && PEDIATRIC_ONSET_TERMS.has(phenotypeId)) {
+        result.hasPediatricOnset = true
+      }
+
+      return
+    }
+
+    const diseaseName = getNamedValue(value)
+    if (diseaseName) {
+      result.diseases.push(diseaseName)
     }
   }
 
   visit(condition)
-  return buckets
+  console.log(result)
+  return result
 }
 
+/**
+ * Extracts disease names and pediatric-onset phenotype status from a proposition.
+ *
+ * Traverses nested Condition / ConditionSet structures associated with the
+ * proposition and:
+ * - collects all non-phenotype condition names into `diseases`
+ * - sets `hasPediatricOnset` to true if any phenotype term ID matches one of
+ *   the configured pediatric-onset HPO IDs
+ *
+ * Phenotype terms themselves are not returned.
+ *
+ * @param prop - A supported proposition type containing condition information
+ * @returns Object containing flattened disease names and pediatric-onset status
+ */
 export function getConditionsFromProposition(
   prop:
     | VariantTherapeuticResponseProposition
@@ -175,24 +213,24 @@ export function getConditionsFromProposition(
     | VariantOncogenicityProposition
     | VariantPathogenicityProposition
     | ExperimentalVariantFunctionalImpactProposition,
-): ConditionNameBuckets {
-  if (!prop) return emptyBuckets()
+): ConditionInfo {
+  if (!prop) return emptyConditionInfo()
 
   switch (prop.type) {
     case 'VariantTherapeuticResponseProposition':
-      return getConditionNameBuckets(prop.conditionQualifier)
+      return getConditionInfo(prop.conditionQualifier)
 
     case 'VariantDiagnosticProposition':
     case 'VariantPrognosticProposition':
     case 'VariantPathogenicityProposition':
-      return getConditionNameBuckets(prop.objectCondition)
+      return getConditionInfo(prop.objectCondition)
 
     case 'VariantOncogenicityProposition':
-      return getConditionNameBuckets(prop.objectTumorType)
+      return getConditionInfo(prop.objectTumorType)
 
     case 'ExperimentalVariantFunctionalImpactProposition':
     default:
-      return emptyBuckets()
+      return emptyConditionInfo()
   }
 }
 

--- a/client/src/utils/propositions.ts
+++ b/client/src/utils/propositions.ts
@@ -113,40 +113,61 @@ const getTherapyNames = (objectTherapeutic: Therapeutic): string[] | null => {
   return []
 }
 
-const getNamedValue = (value: unknown): string => {
+type ConditionNameBuckets = {
+  diseases: string[]
+  phenotypes: string[]
+}
+
+const emptyBuckets = (): ConditionNameBuckets => ({
+  diseases: [],
+  phenotypes: [],
+})
+
+const getNamedValue = (value: unknown): string | undefined => {
   if (value && typeof value === 'object' && 'name' in value && typeof value.name === 'string') {
     return value.name
   }
-  return 'N/A'
+
+  return undefined
 }
 
-/**
- * Extracts human-readable condition names from a Condition object.
- *
- * @param condition - A string, MappableConcept, ConditionSet, or undefined
- * @returns Array of condition names (may be multiple for ConditionSet)
- */
-function getConditionNames(condition: string | Condition | undefined): string[] {
-  if (!condition) return ['N/A']
+const isPhenotype = (condition: unknown): boolean =>
+  !!condition &&
+  typeof condition === 'object' &&
+  'conceptType' in condition &&
+  condition.conceptType === 'Phenotype'
 
-  if (typeof condition === 'string') {
-    return [condition]
+function getConditionNameBuckets(condition: string | Condition | undefined): ConditionNameBuckets {
+  const buckets = emptyBuckets()
+
+  const visit = (value: string | Condition | undefined) => {
+    if (!value) return
+
+    if (typeof value === 'string') {
+      buckets.diseases.push(value)
+      return
+    }
+
+    if ('conditions' in value) {
+      value.conditions.forEach(visit)
+      return
+    }
+
+    const name = getNamedValue(value)
+    if (!name) return
+
+    if (isPhenotype(value)) {
+      buckets.phenotypes.push(name)
+    } else {
+      buckets.diseases.push(name)
+    }
   }
 
-  if ('conditions' in condition) {
-    return condition.conditions.map(getNamedValue)
-  }
-
-  return [getNamedValue(condition)]
+  visit(condition)
+  return buckets
 }
 
-/**
- * Extracts associated disease names from a proposition, based on its type.
- *
- * @param prop - A variant proposition of various supported types
- * @returns Array of disease/condition names, or ["N/A"] if not available
- */
-export function getDiseaseFromProposition(
+export function getConditionsFromProposition(
   prop:
     | VariantTherapeuticResponseProposition
     | VariantDiagnosticProposition
@@ -154,27 +175,24 @@ export function getDiseaseFromProposition(
     | VariantOncogenicityProposition
     | VariantPathogenicityProposition
     | ExperimentalVariantFunctionalImpactProposition,
-): string[] {
-  if (!prop) return ['N/A']
+): ConditionNameBuckets {
+  if (!prop) return emptyBuckets()
 
   switch (prop.type) {
     case 'VariantTherapeuticResponseProposition':
-      return getConditionNames(prop.conditionQualifier)
+      return getConditionNameBuckets(prop.conditionQualifier)
 
     case 'VariantDiagnosticProposition':
     case 'VariantPrognosticProposition':
-      return getConditionNames(prop.objectCondition)
+    case 'VariantPathogenicityProposition':
+      return getConditionNameBuckets(prop.objectCondition)
 
     case 'VariantOncogenicityProposition':
-      return getConditionNames(prop.objectTumorType)
-    case 'VariantPathogenicityProposition':
-      return getConditionNames(prop.objectCondition)
+      return getConditionNameBuckets(prop.objectTumorType)
 
     case 'ExperimentalVariantFunctionalImpactProposition':
-      return ['N/A']
-
     default:
-      return ['N/A']
+      return emptyBuckets()
   }
 }
 

--- a/client/src/utils/results.ts
+++ b/client/src/utils/results.ts
@@ -22,7 +22,7 @@ import {
   VariantTherapeuticResponseProposition,
 } from '../models/domain'
 import {
-  getDiseaseFromProposition,
+  getConditionsFromProposition,
   getTherapyFromProposition,
   getVariantNameFromProposition,
 } from './propositions'
@@ -85,6 +85,8 @@ export interface AssertionResult {
   evidence_level: string
   /** Associated diseases, may include multiple names */
   disease: string[]
+  /** Associated phenotype options */
+  phenotype: string[]
   /** Therapy or combination therapy (if applicable) */
   therapy: NormalizedTherapy
   /** Clinical significance string */
@@ -252,12 +254,14 @@ export const normalizeResults = (data: Record<string, Statement>): AssertionResu
         ratingReason: typeof reasonExt === 'string' ? reasonExt : starRating.ratingReason,
       }
     }
+    const conditions = getConditionsFromProposition(assertion.proposition)
     return [
       {
         proposition: assertion.proposition,
         variant_name: getVariantNameFromProposition(assertion.proposition),
         evidence_level: getEvidenceGrade(assertion.strength),
-        disease: getDiseaseFromProposition(assertion.proposition),
+        disease: conditions.diseases,
+        phenotype: conditions.phenotypes,
         therapy: getTherapyFromProposition(assertion.proposition),
         significance: assertion.proposition?.predicate
           ? formatSignificance(assertion.proposition.predicate)

--- a/client/src/utils/results.ts
+++ b/client/src/utils/results.ts
@@ -86,7 +86,7 @@ export interface AssertionResult {
   /** Associated diseases, may include multiple names */
   disease: string[]
   /** Associated phenotype options */
-  phenotype: string[]
+  hasPediatricOnset: boolean
   /** Therapy or combination therapy (if applicable) */
   therapy: NormalizedTherapy
   /** Clinical significance string */
@@ -261,7 +261,7 @@ export const normalizeResults = (data: Record<string, Statement>): AssertionResu
         variant_name: getVariantNameFromProposition(assertion.proposition),
         evidence_level: getEvidenceGrade(assertion.strength),
         disease: conditions.diseases,
-        phenotype: conditions.phenotypes,
+        hasPediatricOnset: conditions.hasPediatricOnset,
         therapy: getTherapyFromProposition(assertion.proposition),
         significance: assertion.proposition?.predicate
           ? formatSignificance(assertion.proposition.predicate)

--- a/server/src/metakb/transformers/civic.py
+++ b/server/src/metakb/transformers/civic.py
@@ -12,7 +12,7 @@ from civicpy.exports.civic_gks_record import (
     create_gks_record_from_assertion,
 )
 from ga4gh.cat_vrs.models import CategoricalVariant
-from ga4gh.core.models import ConceptMapping, Extension, iriReference
+from ga4gh.core.models import ConceptMapping, Extension, MappableConcept, iriReference
 from ga4gh.va_spec.base import (
     ConditionSet,
     Document,
@@ -26,6 +26,7 @@ from pydantic.dataclasses import dataclass
 from tqdm import tqdm
 
 from metakb.schemas.data import TransformedData
+from metakb.transformers import phenotypes
 from metakb.transformers.base import Transformer
 from metakb.transformers.catvars import (
     build_copynumberchange_catvar,
@@ -286,6 +287,17 @@ class CivicTransformer(Transformer):
 
             statement.reportedIn = reported_in
         return statement
+
+    def _normalize_phenotype(
+        self, phenotype: MappableConcept
+    ) -> MappableConcept | ConditionSet | None:
+        """Retrieve normalized phenotype concept
+
+        :param phenotype: phenotype concept from source
+        :return: normalized equivalent, if available
+        """
+        xref = phenotype.mappings[0].coding.code.root
+        return phenotypes.ONSET_LOOKUP.get(xref)
 
     def _add_ids_to_variant_mappings(
         self, mappings: list[ConceptMapping]

--- a/server/src/metakb/transformers/phenotypes.py
+++ b/server/src/metakb/transformers/phenotypes.py
@@ -89,6 +89,7 @@ EARLY_YOUNG_ADULT_ONSET = MappableConcept(
             value="Onset of disease at an age of greater than or equal to 16 to under 19 years.",
         )
     ],
+    conceptType="Phenotype",
 )
 YOUNG_ADULT_ONSET = MappableConcept(
     id="HP:0011462",
@@ -103,6 +104,7 @@ YOUNG_ADULT_ONSET = MappableConcept(
             value="Onset of disease at the age of between 16 and 40 years.",
         )
     ],
+    conceptType="Phenotype",
 )
 INTERMEDIATE_YOUNG_ADULT_ONSET = MappableConcept(
     id="HP:0025709",

--- a/server/src/metakb/transformers/phenotypes.py
+++ b/server/src/metakb/transformers/phenotypes.py
@@ -76,6 +76,49 @@ JUVENILE_ONSET = MappableConcept(
     ],
     conceptType="Phenotype",
 )
+EARLY_YOUNG_ADULT_ONSET = MappableConcept(
+    id="HP:0025708",
+    name="Early young adult onset",
+    primaryCoding=Coding(
+        system="https://hpo.jax.org/app/browse/term/",
+        code=code("HP:0025708"),
+    ),
+    extensions=[
+        Extension(
+            name="definition",
+            value="Onset of disease at an age of greater than or equal to 16 to under 19 years.",
+        )
+    ],
+)
+YOUNG_ADULT_ONSET = MappableConcept(
+    id="HP:0011462",
+    name="Young adult onset",
+    primaryCoding=Coding(
+        system="https://hpo.jax.org/app/browse/term/",
+        code=code("HP:0011462"),
+    ),
+    extensions=[
+        Extension(
+            name="definition",
+            value="Onset of disease at the age of between 16 and 40 years.",
+        )
+    ],
+)
+INTERMEDIATE_YOUNG_ADULT_ONSET = MappableConcept(
+    id="HP:0025709",
+    name="Intermediate young adult onset",
+    primaryCoding=Coding(
+        system="https://hpo.jax.org/app/browse/term/",
+        code=code("HP:0025709"),
+    ),
+    extensions=[
+        Extension(
+            name="definition",
+            value="Onset of disease at an age of greater than or equal to 19 to under 25 years.",
+        )
+    ],
+    conceptType="Phenotype",
+)
 ADULT_ONSET = MappableConcept(
     id="HP:0003581",
     name="Adult onset",
@@ -91,3 +134,47 @@ ADULT_ONSET = MappableConcept(
     ],
     conceptType="Phenotype",
 )
+MIDDLE_AGE_ONSET = MappableConcept(
+    id="HP:0003596",
+    name="Middle age onset",
+    primaryCoding=Coding(
+        system="https://hpo.jax.org/app/browse/term/",
+        code=code("HP:0003596"),
+    ),
+    extensions=[
+        Extension(
+            name="definition",
+            value="A type of adult onset with onset of symptoms at the age of 40 to 60 years.",
+        )
+    ],
+    conceptType="Phenotype",
+)
+LATE_ONSET = MappableConcept(
+    id="HP:0003584",
+    name="Late onset",
+    primaryCoding=Coding(
+        system="https://hpo.jax.org/app/browse/term/",
+        code=code("HP:0003584"),
+    ),
+    extensions=[
+        Extension(
+            name="definition",
+            value="A type of adult onset with onset of symptoms after the age of 60 years.",
+        )
+    ],
+    conceptType="Phenotype",
+)
+
+ONSET_LOOKUP = {
+    PEDIATRIC_ONSET.id: PEDIATRIC_ONSET,
+    NEONATAL_ONSET.id: NEONATAL_ONSET,
+    CHILDHOOD_ONSET.id: CHILDHOOD_ONSET,
+    INFANTILE_ONSET.id: INFANTILE_ONSET,
+    JUVENILE_ONSET.id: JUVENILE_ONSET,
+    EARLY_YOUNG_ADULT_ONSET.id: EARLY_YOUNG_ADULT_ONSET,
+    YOUNG_ADULT_ONSET.id: YOUNG_ADULT_ONSET,
+    INTERMEDIATE_YOUNG_ADULT_ONSET.id: INTERMEDIATE_YOUNG_ADULT_ONSET,
+    ADULT_ONSET.id: ADULT_ONSET,
+    MIDDLE_AGE_ONSET.id: MIDDLE_AGE_ONSET,
+    LATE_ONSET.id: LATE_ONSET,
+}


### PR DESCRIPTION
close #806 

Also kinda close the "phenotype normalizer" issue

* Implement phenotype normalization for CIViC, it wasn't as bad as I thought
* Fix the thing where "N/A" was showing up in the diseases column -- phenotypes are now excluded from there
* Add a "pediatric onset" column on search result table indicating whether an assertion is associated with pediatric onset phenotype terms (if the associated condition has ANY pediatric phenotype terms -> "has pediatric onset")
* Add an apple emoji icon + brief description for the pediatric onset column

<img width="1220" height="571" alt="Screenshot 2026-05-07 at 9 02 05 PM" src="https://github.com/user-attachments/assets/5c8ec1fa-343f-4b7f-9a2f-13c162758063" />
