### PR TITLE
fix: default to first non-empty tab

### DIFF
--- a/client/src/pages/Results/ResultPage.tsx
+++ b/client/src/pages/Results/ResultPage.tsx
@@ -173,6 +173,15 @@ const ResultPage = () => {
           diagnostic: norm_diag_data,
           therapeutic: norm_ther_data,
         })
+
+        // Pick the first non-empty tab in preferred order
+        if (norm_ther_data.length > 0) {
+          setActiveTab('therapeutic')
+        } else if (norm_diag_data.length > 0) {
+          setActiveTab('diagnostic')
+        } else if (norm_prog_data.length > 0) {
+          setActiveTab('prognostic')
+        }
       } catch (e: unknown) {
         if (e instanceof Error) {
           if (e.name !== 'AbortError') {


### PR DESCRIPTION
If you load search results that have some non-therapeutic response assertions, the page still defaults to showing you the (empty) therapeutic response tab, instead of a non-empty tab. this PR fixes that

(see here for an example of the problem: https://staging.pediatric.metakb.org/search?gene=MYOD1)