### PR TITLE
feat: constrain page width

### DIFF
--- a/client/src/components/Footer.tsx
+++ b/client/src/components/Footer.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from 'react'
 import { Box, IconButton, Toolbar, Typography } from '@mui/material'
 import GitHubIcon from '@mui/icons-material/GitHub'
 import theme from '../theme'
+import ContentContainer from './common/ContentContainer'
 
 const Footer = () => {
   const [version, setVersion] = useState('')
@@ -31,36 +32,38 @@ const Footer = () => {
         bgcolor: theme.palette.footer.main,
       }}
     >
-      <Toolbar sx={{ display: 'flex', justifyContent: 'space-between' }}>
-        <Box display="flex" alignItems="center" gap={2}>
-          {version && (
-            <Typography variant="body2" color="white" sx={{ opacity: 0.8 }}>
-              {version ? `version ${version}` : 'version ?'}
-              {environment && environment != 'prod' ? ` [${environment}]` : ''}
-            </Typography>
-          )}
-        </Box>
-
-        <IconButton
-          component="a"
-          href="https://github.com/cancervariants/metakb"
-          target="_blank"
-          rel="noopener noreferrer"
-          color="secondary"
-          disableRipple
-          sx={{
-            '&:hover': {
-              color: 'white',
-            },
-          }}
-        >
-          {' '}
-          <Box display="flex" alignItems="center" gap={1}>
-            <GitHubIcon fontSize="large" />
-            <Typography fontWeight="bold">Visit us on GitHub!</Typography>
+      <ContentContainer>
+        <Toolbar sx={{ display: 'flex', justifyContent: 'space-between' }}>
+          <Box display="flex" alignItems="center" gap={2}>
+            {version && (
+              <Typography variant="body2" color="white" sx={{ opacity: 0.8 }}>
+                {version ? `MetaKB version ${version}` : 'version ?'}
+                {environment && environment != 'prod' ? ` [${environment}]` : ''}
+              </Typography>
+            )}
           </Box>
-        </IconButton>
-      </Toolbar>
+
+          <IconButton
+            component="a"
+            href="https://github.com/cancervariants/metakb"
+            target="_blank"
+            rel="noopener noreferrer"
+            color="secondary"
+            disableRipple
+            sx={{
+              '&:hover': {
+                color: 'white',
+              },
+            }}
+          >
+            {' '}
+            <Box display="flex" alignItems="center" gap={1}>
+              <GitHubIcon fontSize="large" />
+              <Typography fontWeight="bold">GitHub</Typography>
+            </Box>
+          </IconButton>
+        </Toolbar>
+      </ContentContainer>
     </Box>
   )
 }

--- a/client/src/components/Header.tsx
+++ b/client/src/components/Header.tsx
@@ -1,22 +1,25 @@
 import { AppBar, Box, Toolbar } from '@mui/material'
 import { Link } from 'react-router-dom'
 import metakbJrLogo from '../assets/metakbjr-logo.png'
+import ContentContainer from './common/ContentContainer'
 
 const Header = () => {
   return (
     <AppBar position="static" color="header">
-      <Toolbar sx={{ display: 'flex', justifyContent: 'space-between' }}>
-        <Box display="flex" alignItems="center" gap={2}>
-          <Link to="/" style={{ textDecoration: 'none', color: 'inherit' }}>
-            <Box
-              component="img"
-              src={metakbJrLogo}
-              alt="MetaKB Jr."
-              sx={{ height: 75, width: 'auto', display: 'block', padding: 1 }}
-            />
-          </Link>
-        </Box>
-      </Toolbar>
+      <ContentContainer>
+        <Toolbar sx={{ display: 'flex', justifyContent: 'space-between' }}>
+          <Box display="flex" alignItems="center" gap={2}>
+            <Link to="/" style={{ textDecoration: 'none', color: 'inherit' }}>
+              <Box
+                component="img"
+                src={metakbJrLogo}
+                alt="MetaKB Jr."
+                sx={{ height: 75, width: 'auto', display: 'block', padding: 1 }}
+              />
+            </Link>
+          </Box>
+        </Toolbar>
+      </ContentContainer>
     </AppBar>
   )
 }

--- a/client/src/components/common/ContentContainer.tsx
+++ b/client/src/components/common/ContentContainer.tsx
@@ -1,0 +1,25 @@
+/**
+ * Shared layout container that constrains content width,
+ * centers content horizontally, and applies consistent
+ * horizontal padding across the application.
+ *
+ * Used to keep top/bottom bar (header/footer) + main content
+ * aligned to the same visual grid while allowing outer
+ * page backgrounds to remain full-width.
+ */
+import { Box, BoxProps } from '@mui/material'
+
+export default function ContentContainer(props: BoxProps) {
+  return (
+    <Box
+      {...props}
+      sx={{
+        width: '100%',
+        maxWidth: 1350,
+        mx: 'auto',
+        px: 3,
+        ...props.sx,
+      }}
+    />
+  )
+}

--- a/client/src/pages/Home.tsx
+++ b/client/src/pages/Home.tsx
@@ -5,6 +5,7 @@ import SearchIcon from '@mui/icons-material/Search'
 import { useNavigate } from 'react-router-dom'
 import { useEffect, useState } from 'react'
 import AutoStoriesIcon from '@mui/icons-material/AutoStories'
+import ContentContainer from '../components/common/ContentContainer'
 
 const HomePage = () => {
   const navigate = useNavigate()
@@ -51,11 +52,11 @@ const HomePage = () => {
   }, [])
 
   return (
-    <>
+    <ContentContainer>
       <Box component="main">
         <Box
           id="main-page-container"
-          m={5}
+          my={5}
           sx={{
             display: 'flex',
             flexDirection: 'column',
@@ -196,7 +197,7 @@ const HomePage = () => {
           </Box>
         </Box>
       </Box>
-    </>
+    </ContentContainer>
   )
 }
 

--- a/client/src/pages/Results/ResultPage.tsx
+++ b/client/src/pages/Results/ResultPage.tsx
@@ -28,6 +28,7 @@ import { StarRatingHistogram } from '../../components/StarRatingHistogram/StarRa
 import GeneInfo from '../../components/EntityInfo/GeneInfo'
 import VariationInfo from '../../components/EntityInfo/VariationInfo'
 import { CategoricalVariant, MappableConcept } from '../../models/domain'
+import ContentContainer from '../../components/common/ContentContainer'
 
 type SearchType = 'gene' | 'variation'
 const API_BASE = '/api/search/statements'
@@ -288,8 +289,8 @@ const ResultPage = () => {
   const hasFilteredResults = filteredResults.length > 0
 
   return (
-    <>
-      <Box id="result-page-container" m={5}>
+    <ContentContainer>
+      <Box id="result-page-container" my={5}>
         {loading && <CircularProgress />}
         {error && <Alert severity="error">{error}</Alert>}
         {!loading && !error && (
@@ -435,7 +436,7 @@ const ResultPage = () => {
           </Box>
         )}
       </Box>
-    </>
+    </ContentContainer>
   )
 }
 


### PR DESCRIPTION
Constrain all elements to a standard width of about 1400px. This is on the larger side, but anything less starts to mess with existing page elements, so this just makes it so it doesn't get totlaly crazy.

this is particularly helpful for text-heavy pages (eg about section) because the human brain does not like having to relocate its position after a new line.

before:

<img width="2056" height="1329" alt="Screenshot 2026-05-08 at 11 26 59 AM" src="https://github.com/user-attachments/assets/5f32871b-3796-4792-98e7-5e3d7bc6c30b" />

after:

<img width="2056" height="1329" alt="Screenshot 2026-05-08 at 11 24 36 AM" src="https://github.com/user-attachments/assets/2292aada-6e85-489c-b9a4-938bd58ec543" />