### PR TITLE
fix: dont show therapy filter on diagnostic/prognostic tabs

### DIFF
--- a/client/src/pages/Results/ResultPage.tsx
+++ b/client/src/pages/Results/ResultPage.tsx
@@ -361,13 +361,20 @@ const ResultPage = () => {
                         setSelected={setSelectedDiseases}
                       />
                       <hr></hr>
-                      <FilterSection
-                        title="Therapy"
-                        options={therapyOptions}
-                        selected={selectedTherapies}
-                        setSelected={setSelectedTherapies}
-                      />
-                      <hr></hr>
+                      <>
+                        {activeTab === 'therapeutic' && (
+                          <>
+                            <FilterSection
+                              title="Therapy"
+                              options={therapyOptions}
+                              selected={selectedTherapies}
+                              setSelected={setSelectedTherapies}
+                            />
+                            <hr></hr>
+                          </>
+                        )}
+                      </>
+
                       <FilterSection
                         title="Evidence Level"
                         options={evidenceLevelOptions}


### PR DESCRIPTION
close #810