### PR TITLE
fix: resolve missing primaryCoding error

### DIFF
--- a/server/src/metakb/repository/neo4j_models.py
+++ b/server/src/metakb/repository/neo4j_models.py
@@ -364,12 +364,34 @@ class CategoricalVariantNode(BaseNode):
         )
 
 
-class GeneNode(BaseNode):
-    """Node model for Gene."""
+class _MappableConceptNode(BaseNode):
+    """Base class for mappable concept entity nodes.
+
+    Provide some basic shared properties/functions.
+    """
 
     id: str
     name: str
     mappings: str
+    primary_coding: str
+
+    @classmethod
+    def _dump_primary_coding(cls, concept: MappableConcept) -> str:
+        return (
+            concept.primaryCoding.model_dump_json(exclude_none=True)
+            if concept.primaryCoding
+            else ""
+        )
+
+    def _load_primary_coding(self) -> Coding | None:
+        return (
+            Coding(**json.loads(self.primary_coding)) if self.primary_coding else None
+        )
+
+
+class GeneNode(_MappableConceptNode):
+    """Node model for Gene."""
+
     extensions: str
     description: str
 
@@ -389,6 +411,7 @@ class GeneNode(BaseNode):
             extensions=_Extensions(gene.extensions or []).model_dump_json(
                 exclude_none=True
             ),
+            primary_coding=cls._dump_primary_coding(gene),
         )
 
     def to_gks(self) -> MappableConcept:
@@ -396,18 +419,15 @@ class GeneNode(BaseNode):
         return MappableConcept(
             id=self.id,
             conceptType="Gene",
-            name=self.name if self.name else None,
+            name=self.name or None,
             mappings=_Mappings(json.loads(self.mappings)).root or None,
             extensions=_Extensions(json.loads(self.extensions)).root or None,
+            primaryCoding=self._load_primary_coding(),
         )
 
 
-class DiseaseNode(BaseNode):
+class DiseaseNode(_MappableConceptNode):
     """Node model for an individual Disease."""
-
-    id: str
-    name: str
-    mappings: str
 
     @classmethod
     def from_gks(cls, disease: MappableConcept) -> Self:
@@ -418,6 +438,7 @@ class DiseaseNode(BaseNode):
             mappings=_Mappings(disease.mappings or []).model_dump_json(
                 exclude_none=True
             ),
+            primary_coding=cls._dump_primary_coding(disease),
         )
 
     def to_gks(self) -> MappableConcept:
@@ -427,6 +448,7 @@ class DiseaseNode(BaseNode):
             conceptType="Disease",
             name=self.name or None,
             mappings=_Mappings(json.loads(self.mappings)).root,
+            primaryCoding=self._load_primary_coding(),
         )
 
 
@@ -520,13 +542,10 @@ def _get_condition_node(
     return ConditionSetNode.from_gks(condition)
 
 
-class DrugNode(BaseNode):
+class DrugNode(_MappableConceptNode):
     """Node model for Drug."""
 
-    id: str
-    name: str
     extensions: str
-    mappings: str
 
     @classmethod
     def from_gks(cls, therapy: MappableConcept) -> Self:
@@ -540,6 +559,7 @@ class DrugNode(BaseNode):
             extensions=_Extensions(therapy.extensions or []).model_dump_json(
                 exclude_none=True
             ),
+            primary_coding=cls._dump_primary_coding(therapy),
         )
 
     def to_gks(self) -> MappableConcept:
@@ -550,6 +570,7 @@ class DrugNode(BaseNode):
             name=self.name or None,
             mappings=_Mappings(json.loads(self.mappings)).root,
             extensions=_Extensions(json.loads(self.extensions)).root,
+            primaryCoding=self._load_primary_coding(),
         )
 
 

--- a/server/src/metakb/repository/queries/load_disease.cypher
+++ b/server/src/metakb/repository/queries/load_disease.cypher
@@ -1,3 +1,9 @@
 MERGE (d:Condition {id: $disease.id})
-  ON CREATE SET d += {name: $disease.name, mappings: $disease.mappings}
+  ON CREATE SET
+    d +=
+      {
+        name: $disease.name,
+        mappings: $disease.mappings,
+        primary_coding: $disease.primary_coding
+      }
 SET d: Disease

--- a/server/src/metakb/repository/queries/load_drug.cypher
+++ b/server/src/metakb/repository/queries/load_drug.cypher
@@ -5,5 +5,6 @@ MERGE (drug:Therapeutic:Drug {id: $drug.id})
         name: $drug.name,
         mappings: $drug.mappings,
         aliases: $drug.aliases,
-        extensions: $drug.extensions
+        extensions: $drug.extensions,
+        primary_coding: $drug.primary_coding
       }

--- a/server/src/metakb/repository/queries/load_featurecontextconstraint_catvar.cypher
+++ b/server/src/metakb/repository/queries/load_featurecontextconstraint_catvar.cypher
@@ -18,6 +18,7 @@ MERGE (g:Gene {id: $cv.has_constraint.has_feature_context.id})
         name: $cv.has_constraint.has_feature_context.name,
         aliases: $cv.has_constraint.has_feature_context.aliases,
         mappings: $cv.has_constraint.has_feature_context.mappings,
-        extensions: $cv.has_constraint.has_feature_context.extensions
+        extensions: $cv.has_constraint.has_feature_context.extensions,
+        primary_coding: $cv.has_constraint.has_feature_context.primary_coding
       }
 MERGE (constr)-[:HAS_FEATURE_CONTEXT]->(g)

--- a/server/src/metakb/repository/queries/load_gene.cypher
+++ b/server/src/metakb/repository/queries/load_gene.cypher
@@ -6,5 +6,6 @@ MERGE (g:Gene {id: $gene.id})
         name: $gene.name,
         aliases: $gene.aliases,
         mappings: $gene.mappings,
-        extensions: $gene.extensions
+        extensions: $gene.extensions,
+        primary_coding: $gene.primary_coding
       }

--- a/server/src/metakb/repository/queries/load_therapy_group.cypher
+++ b/server/src/metakb/repository/queries/load_therapy_group.cypher
@@ -15,6 +15,7 @@ MERGE (member_drug:Therapeutic:Drug {id: m.id})
         name: m.name,
         mappings: m.mappings,
         aliases: m.aliases,
-        extensions: m.extensions
+        extensions: m.extensions,
+        primary_coding: m.primary_coding
       }
 MERGE (thg)-[:HAS_THERAPY]->(member_drug)

--- a/server/src/metakb/transformers/civic.py
+++ b/server/src/metakb/transformers/civic.py
@@ -226,6 +226,7 @@ class CivicTransformer(Transformer):
                 ev_line = clinsig_statement.hasEvidenceLines[0]
                 statement = Statement(
                     id=clinsig_statement.id,
+                    description=clinsig_statement.description,
                     strength=ev_line.strengthOfEvidenceProvided,
                     proposition=ev_line.targetProposition,
                     direction=clinsig_statement.direction,


### PR DESCRIPTION
Ensure that `primaryCoding` is preserved in the major entities (drug/gene/disease) that we get from the normalizers

this fixes an edge case introduced by the latest va-spec where obscure drugs that don't have a name will fail to validate without a primaryCoding, which we previously were dropping on ingest