### PR TITLE
build: freeze vaspec release

### DIFF
--- a/server/pyproject.toml
+++ b/server/pyproject.toml
@@ -28,7 +28,7 @@ license-files = ["LICENSE"]
 dependencies = [
     "ga4gh.vrs~=2.4.0-a1",
     "ga4gh.cat_vrs~=0.8.0-a2",
-    "ga4gh.va_spec~=0.5.0-a0",
+    "ga4gh.va_spec==0.5.0-a0",
     "cool-seq-tool ~= 0.16.0",
     "gene-normalizer[etl]~=0.11.5",
     "variation-normalizer~=0.15.4",


### PR DESCRIPTION
need to pin an exact dependency because

a) va-spec 0.5.0-a2 introduces a breaking change, which we can easily upgrade to, but
b) kori is still awaiting final review on a civicpy review that would also catch up to that change

so we need to freeze ourselves in place for a minute