### PR TITLE
 feat: refactor filters, add special star rating filter 

### DIFF
--- a/client/src/components/ResultTable/ResultTableRow.tsx
+++ b/client/src/components/ResultTable/ResultTableRow.tsx
@@ -128,10 +128,10 @@ const ResultTableRow: FC<{ row: AssertionResult; columns: ResultColumn[] }> = ({
                       <div>
                         <strong>References:</strong>{' '}
                         {documentRefLinks.map((document, i) => (
-                          <>
+                          <Box key={i}>
                             {i > 0 && ', '}
                             <DocumentLink reference={document} index={i} />
-                          </>
+                          </Box>
                         ))}
                       </div>
                     )}

--- a/client/src/components/SearchFilters/ChecklistFilter.tsx
+++ b/client/src/components/SearchFilters/ChecklistFilter.tsx
@@ -12,15 +12,9 @@ import {
   Typography,
 } from '@mui/material'
 import ExpandMoreIcon from '@mui/icons-material/ExpandMore'
+import { FilterProps } from './types'
 
-interface FilterSectionProps {
-  title: string
-  options: string[]
-  selected: string[]
-  setSelected: (values: string[]) => void
-}
-
-const FilterSection = ({ title, options, selected, setSelected }: FilterSectionProps) => {
+const ChecklistFilter = ({ title, options, selected, setSelected }: FilterProps) => {
   // expand/collapse value for accordion for filter section
   const [expanded, setExpanded] = useState(true)
   // we only show the top 5 filters at a time, so this tracks if the user clicked a button to show all or not
@@ -116,4 +110,4 @@ const FilterSection = ({ title, options, selected, setSelected }: FilterSectionP
   )
 }
 
-export default FilterSection
+export default ChecklistFilter

--- a/client/src/components/SearchFilters/StarRatingFilter.tsx
+++ b/client/src/components/SearchFilters/StarRatingFilter.tsx
@@ -1,0 +1,106 @@
+import { useState } from 'react'
+import {
+  Accordion,
+  AccordionDetails,
+  AccordionSummary,
+  Box,
+  Button,
+  IconButton,
+  Tooltip,
+  Typography,
+} from '@mui/material'
+import ExpandMoreIcon from '@mui/icons-material/ExpandMore'
+import StarIcon from '@mui/icons-material/Star'
+import StarBorderIcon from '@mui/icons-material/StarBorder'
+import type { FilterProps } from './types'
+
+const RATINGS = ['1', '2', '3', '4']
+
+const getRatingLabel = (rating: string) => (rating === '4' ? '4 stars' : `${rating}+ stars`)
+
+const StarRatingFilter = ({ title, selected, setSelected }: FilterProps) => {
+  const [hoveredRating, setHoveredRating] = useState<string | null>(null)
+
+  const selectedThreshold = selected.length > 0 ? Math.min(...selected.map(Number)) : null
+
+  const displayedThreshold = hoveredRating !== null ? Number(hoveredRating) : selectedThreshold
+
+  const selectMinimumRating = (minimumRating: string) => {
+    setSelected(RATINGS.filter((rating) => Number(rating) >= Number(minimumRating)))
+  }
+
+  return (
+    <Accordion
+      defaultExpanded
+      sx={{
+        boxShadow: 'none',
+        '&:before': { display: 'none' },
+        backgroundColor: 'transparent',
+      }}
+    >
+      <AccordionSummary
+        expandIcon={<ExpandMoreIcon />}
+        sx={{
+          minHeight: 'unset !important',
+          px: 0,
+          '& .MuiAccordionSummary-content': {
+            margin: 0,
+          },
+        }}
+      >
+        <Box display="flex" justifyContent="space-between" alignItems="center" width="100%">
+          <Typography fontWeight="bold">{title}</Typography>
+
+          {selected.length > 0 && (
+            <Button
+              size="small"
+              color="success"
+              onClick={(event) => {
+                event.stopPropagation()
+                setSelected([])
+              }}
+            >
+              Clear
+            </Button>
+          )}
+        </Box>
+      </AccordionSummary>
+
+      <AccordionDetails sx={{ px: 0 }}>
+        <Box display="flex" alignItems="center" onMouseLeave={() => setHoveredRating(null)}>
+          {RATINGS.map((rating) => {
+            const numericRating = Number(rating)
+
+            const isActive = displayedThreshold !== null && numericRating <= displayedThreshold
+
+            const isHoverPreview = hoveredRating !== null && isActive
+
+            return (
+              <Tooltip key={rating} title={getRatingLabel(rating)} arrow>
+                <IconButton
+                  size="small"
+                  aria-label={`Filter by ${getRatingLabel(rating)}`}
+                  onMouseEnter={() => setHoveredRating(rating)}
+                  onFocus={() => setHoveredRating(rating)}
+                  onBlur={() => setHoveredRating(null)}
+                  onClick={() => selectMinimumRating(rating)}
+                  sx={{
+                    color: isHoverPreview
+                      ? 'text.secondary'
+                      : isActive
+                        ? 'warning.main'
+                        : 'action.disabled',
+                  }}
+                >
+                  {isActive ? <StarIcon /> : <StarBorderIcon />}
+                </IconButton>
+              </Tooltip>
+            )
+          })}
+        </Box>
+      </AccordionDetails>
+    </Accordion>
+  )
+}
+
+export default StarRatingFilter

--- a/client/src/components/SearchFilters/types.ts
+++ b/client/src/components/SearchFilters/types.ts
@@ -1,0 +1,10 @@
+export interface FilterProps {
+  // title of filter section
+  title: string
+  // literal options to select from (eg disease names, star ratings, etc)
+  options: string[]
+  // subset of options indicating what's selected by the user
+  selected: string[]
+  // setter to set selections
+  setSelected: (values: string[]) => void
+}

--- a/client/src/components/StarRatingHistogram/StarRatingHistogram.tsx
+++ b/client/src/components/StarRatingHistogram/StarRatingHistogram.tsx
@@ -61,7 +61,7 @@ export function StarRatingHistogram({ data }: Props) {
       >
         Assertions by Star Rating
       </Typography>
-      <ResponsiveContainer width="100%" height="100%">
+      <ResponsiveContainer width="100%" height="100%" initialDimension={{ width: 100, height: 50 }}>
         <BarChart data={chartData} margin={{ top: 8, right: 16, left: 24, bottom: 24 }}>
           <XAxis
             dataKey="stars"

--- a/client/src/pages/Results/ResultPage.tsx
+++ b/client/src/pages/Results/ResultPage.tsx
@@ -13,7 +13,6 @@ import {
 } from '@mui/material'
 import { useSearchParams } from 'react-router-dom'
 import ResultTable from '../../components/ResultTable/ResultTable'
-import FilterSection from '../../components/FilterSection/FilterSection'
 import {
   AssertionResult,
   buildCountMap,
@@ -29,6 +28,8 @@ import GeneInfo from '../../components/EntityInfo/GeneInfo'
 import VariationInfo from '../../components/EntityInfo/VariationInfo'
 import { CategoricalVariant, MappableConcept } from '../../models/domain'
 import ContentContainer from '../../components/common/ContentContainer'
+import ChecklistFilter from '../../components/SearchFilters/ChecklistFilter'
+import StarRatingFilter from '../../components/SearchFilters/StarRatingFilter'
 
 type SearchType = 'gene' | 'variation'
 const API_BASE = '/api/search/statements'
@@ -346,25 +347,25 @@ const ResultPage = () => {
                           </Stack>
                         )}
                       </Box>
-                      <hr></hr>
-                      <FilterSection
+                      <hr />
+                      <ChecklistFilter
                         title="Variant"
                         options={variantOptions}
                         selected={selectedVariants}
                         setSelected={setSelectedVariants}
                       />
-                      <hr></hr>
-                      <FilterSection
+                      <hr />
+                      <ChecklistFilter
                         title="Disease"
                         options={diseaseOptions}
                         selected={selectedDiseases}
                         setSelected={setSelectedDiseases}
                       />
-                      <hr></hr>
+                      <hr />
                       <>
                         {activeTab === 'therapeutic' && (
                           <>
-                            <FilterSection
+                            <ChecklistFilter
                               title="Therapy"
                               options={therapyOptions}
                               selected={selectedTherapies}
@@ -375,28 +376,29 @@ const ResultPage = () => {
                         )}
                       </>
 
-                      <FilterSection
+                      <ChecklistFilter
                         title="Evidence Level"
                         options={evidenceLevelOptions}
                         selected={selectedEvidenceLevels}
                         setSelected={setSelectedEvidenceLevels}
                       />
-                      <hr></hr>
-                      <FilterSection
+                      <hr />
+                      <StarRatingFilter
                         title="Star Rating"
                         options={starRatingOptions}
                         selected={selectedStarRatings}
                         setSelected={setSelectedStarRatings}
                       />
-                      <hr></hr>
-                      <FilterSection
+
+                      <hr />
+                      <ChecklistFilter
                         title="Significance"
                         options={significanceOptions}
                         selected={selectedSignificance}
                         setSelected={setSelectedSignificance}
                       />
                       <hr />
-                      <FilterSection
+                      <ChecklistFilter
                         title="Source"
                         options={sourceOptions}
                         selected={selectedSources}


### PR DESCRIPTION
Two things here

1. generalize filters interface so that non-checklist-style filter sections can be used
2. make a new one for star rating that matches its semantics -- ie, select "2 stars or better" rather than selecting "2 stars", "3 stars", and "4 stars"

<img width="306" height="156" alt="Screenshot 2026-07-23 at 4 28 28 PM" src="https://github.com/user-attachments/assets/591bf4e3-375b-4c3a-8389-60dd06b9b799" />
<img width="343" height="199" alt="Screenshot 2026-07-23 at 4 28 32 PM" src="https://github.com/user-attachments/assets/35a84a25-f31b-473a-80ed-7b72de385c82" />
